### PR TITLE
Add OAuth configuration support to mcp.json

### DIFF
--- a/cli/src/lib/agents/claude.ts
+++ b/cli/src/lib/agents/claude.ts
@@ -8,6 +8,7 @@ import type {
   ResolvedArtifacts,
   RootEntry,
   McpServerEntry,
+  McpOAuthConfig,
   PluginEntry,
 } from "../config.js";
 
@@ -93,11 +94,37 @@ export class ClaudeAdapter implements AgentAdapter {
         mcpServers[name] = {
           url: server.url,
           ...(server.headers && { headers: server.headers }),
+          ...(server.oauth && { oauth: this.translateOAuth(server.oauth) }),
         };
       }
     }
 
     return { mcpServers };
+  }
+
+  /** Translate AIR oauth config to Claude Code oauth format */
+  private translateOAuth(oauth: McpOAuthConfig): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    if (oauth.clientId) {
+      result.clientId = oauth.clientId;
+    }
+    if (oauth.redirectUri) {
+      // Claude Code uses callbackPort; extract port from redirectUri
+      try {
+        const url = new URL(oauth.redirectUri);
+        if (url.port) {
+          result.callbackPort = parseInt(url.port, 10);
+        }
+      } catch {
+        // If redirectUri isn't parseable, omit callbackPort
+      }
+    }
+    // Note: Claude Code does not currently support a scopes field in its
+    // oauth config. We pass it through for forward compatibility.
+    if (oauth.scopes) {
+      result.scopes = oauth.scopes;
+    }
+    return result;
   }
 
   /** Translate an AIR plugin to Claude Code plugin format */

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -36,6 +36,12 @@ export interface ReferenceEntry {
   file: string;
 }
 
+export interface McpOAuthConfig {
+  clientId?: string;
+  scopes?: string[];
+  redirectUri?: string;
+}
+
 export interface McpServerEntry {
   title?: string;
   description?: string;
@@ -45,6 +51,7 @@ export interface McpServerEntry {
   env?: Record<string, string>;
   url?: string;
   headers?: Record<string, string>;
+  oauth?: McpOAuthConfig;
 }
 
 export interface PluginEntry {

--- a/docs/mcp-json-proposal.md
+++ b/docs/mcp-json-proposal.md
@@ -47,6 +47,7 @@ Server names must match `^[a-zA-Z0-9_\[\]-]+$` (alphanumeric, hyphens, underscor
 | `env` | object | No (stdio) | Environment variables (string values) |
 | `url` | string (URI) | Yes (remote) | Endpoint URL for sse/streamable-http servers |
 | `headers` | object | No (remote) | HTTP headers for remote servers (string values) |
+| `oauth` | object | No (remote) | OAuth configuration for servers using OAuth authorization |
 
 ### Transport-Specific Requirements
 
@@ -57,6 +58,7 @@ Server names must match `^[a-zA-Z0-9_\[\]-]+$` (alphanumeric, hyphens, underscor
 **Remote servers** (`type: "sse"` or `type: "streamable-http"`):
 - `url` is required
 - `command` and `args` are not allowed
+- `oauth` is allowed (see [OAuth Configuration](#oauth-configuration))
 
 ## Transport Types
 
@@ -129,9 +131,17 @@ Interpolation is primarily intended for authentication secrets:
 
 Non-secret values should use literals. The file is meant to be a fully-formed configuration — using interpolation for non-secrets undermines that purpose.
 
-### OAuth-Based Servers
+### OAuth Configuration
 
-Servers using OAuth handle authentication out-of-band via the MCP client. OAuth endpoints are discovered automatically via well-known metadata endpoints (RFC 8414, RFC 9728). No explicit OAuth configuration is needed:
+Remote servers can use OAuth for authorization. The `oauth` object configures how the MCP client initiates the OAuth flow:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `clientId` | string | No | OAuth client ID. If omitted, the client uses Dynamic Client Registration (DCR) or discovery. |
+| `scopes` | string[] | No | OAuth scopes to request in the authorization request. Passed as the `scope` parameter (RFC 6749 §3.3). |
+| `redirectUri` | string (URI) | No | Redirect URI for the OAuth callback. For CLI/desktop clients this is typically `http://localhost:{port}/callback` (RFC 8252). |
+
+All `oauth` fields are optional. Servers that support automatic discovery (RFC 8414, RFC 9728) and Dynamic Client Registration may need no configuration at all — just a `url`:
 
 ```json
 {
@@ -142,6 +152,58 @@ Servers using OAuth handle authentication out-of-band via the MCP client. OAuth 
   }
 }
 ```
+
+Servers that require a pre-registered client ID (no DCR support) specify it explicitly:
+
+```json
+{
+  "slack": {
+    "title": "Slack",
+    "type": "streamable-http",
+    "url": "https://mcp.slack.com/mcp",
+    "oauth": {
+      "clientId": "1601185624273.8899143856786",
+      "redirectUri": "http://localhost:3118/callback"
+    }
+  }
+}
+```
+
+The `scopes` field allows a single server to be configured with different access levels under different names. Each entry gets its own OAuth session and consent grant:
+
+```json
+{
+  "bigquery-readonly": {
+    "title": "BigQuery (Read-Only)",
+    "description": "Read-only analytical queries against BigQuery.",
+    "type": "streamable-http",
+    "url": "https://mcp.bigquery.example.com/mcp",
+    "oauth": {
+      "clientId": "bigquery-mcp-client",
+      "scopes": ["https://www.googleapis.com/auth/bigquery.readonly"]
+    }
+  },
+  "bigquery-readwrite": {
+    "title": "BigQuery (Read-Write)",
+    "description": "Full read-write access to BigQuery.",
+    "type": "streamable-http",
+    "url": "https://mcp.bigquery.example.com/mcp",
+    "oauth": {
+      "clientId": "bigquery-mcp-client",
+      "scopes": [
+        "https://www.googleapis.com/auth/bigquery.readonly",
+        "https://www.googleapis.com/auth/bigquery"
+      ]
+    }
+  }
+}
+```
+
+This enables shareable configurations: a recipient copies the file, authenticates with their own identity, and each entry is scoped correctly via the OAuth consent flow.
+
+**Validation rules:**
+- `oauth` is forbidden for `stdio` entries
+- `oauth` and `headers` with an `Authorization` key should not both be present on the same entry — use one auth mechanism or the other
 
 ## Version Pinning
 
@@ -161,6 +223,7 @@ Claude Code uses a similar but distinct `.mcp.json` format:
 |--------------------------|------------------------|
 | Servers at root level | Servers nested under `mcpServers` key |
 | `type` field required | `type` optional (defaults to stdio) |
+| `oauth` object with `clientId`, `scopes`, `redirectUri` | `oauth` object with `clientId`, `callbackPort` |
 
 **This proposal:**
 ```json
@@ -213,7 +276,7 @@ AIR translates between these formats at session start time. See [MCP Servers](mc
   },
   "internal-api": {
     "title": "Internal API",
-    "description": "Connection to internal services",
+    "description": "Connection to internal services via API key",
     "type": "streamable-http",
     "url": "https://internal.example.com/mcp",
     "headers": {
@@ -222,9 +285,42 @@ AIR translates between these formats at session start time. See [MCP Servers](mc
   },
   "linear": {
     "title": "Linear",
-    "description": "Linear project management (OAuth)",
+    "description": "Linear project management (OAuth with auto-discovery)",
     "type": "streamable-http",
     "url": "https://mcp.linear.app/mcp"
+  },
+  "slack": {
+    "title": "Slack",
+    "description": "Slack workspace access (OAuth with pre-registered client)",
+    "type": "streamable-http",
+    "url": "https://mcp.slack.com/mcp",
+    "oauth": {
+      "clientId": "1601185624273.8899143856786",
+      "redirectUri": "http://localhost:3118/callback"
+    }
+  },
+  "bigquery-readonly": {
+    "title": "BigQuery (Read-Only)",
+    "description": "Read-only analytical queries against BigQuery",
+    "type": "streamable-http",
+    "url": "https://mcp.bigquery.example.com/mcp",
+    "oauth": {
+      "clientId": "bigquery-mcp-client",
+      "scopes": ["https://www.googleapis.com/auth/bigquery.readonly"]
+    }
+  },
+  "bigquery-readwrite": {
+    "title": "BigQuery (Read-Write)",
+    "description": "Full read-write access to BigQuery",
+    "type": "streamable-http",
+    "url": "https://mcp.bigquery.example.com/mcp",
+    "oauth": {
+      "clientId": "bigquery-mcp-client",
+      "scopes": [
+        "https://www.googleapis.com/auth/bigquery.readonly",
+        "https://www.googleapis.com/auth/bigquery"
+      ]
+    }
   }
 }
 ```

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -33,6 +33,7 @@ MCP servers are configured in `mcp.json` as a flat map of server names to connec
 | `env` | object | No (stdio) | Environment variables for the server process. |
 | `url` | string | Yes (remote) | Endpoint URL for remote servers. |
 | `headers` | object | No (remote) | HTTP headers for remote servers. |
+| `oauth` | object | No (remote) | OAuth configuration (see below). |
 
 ## Transport Types
 
@@ -98,6 +99,56 @@ For remote servers using HTTP streaming (newer transport):
 **Required fields**: `type`, `url`
 **Forbidden fields**: `command`, `args`
 
+## OAuth Configuration
+
+Remote servers can use OAuth for authorization. The optional `oauth` object configures the OAuth flow:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `clientId` | string | OAuth client ID. Omit if the server supports Dynamic Client Registration. |
+| `scopes` | string[] | OAuth scopes to request in the authorization request. |
+| `redirectUri` | string | Redirect URI for the OAuth callback. |
+
+All fields are optional. Servers with full auto-discovery need no `oauth` config at all:
+
+```json
+{
+  "linear": {
+    "title": "Linear",
+    "type": "streamable-http",
+    "url": "https://mcp.linear.app/mcp"
+  }
+}
+```
+
+Use `scopes` to create entries with different access levels for the same server. Each entry gets its own OAuth session:
+
+```json
+{
+  "bigquery-readonly": {
+    "title": "BigQuery (Read-Only)",
+    "type": "streamable-http",
+    "url": "https://mcp.bigquery.example.com/mcp",
+    "oauth": {
+      "clientId": "bigquery-mcp-client",
+      "scopes": ["https://www.googleapis.com/auth/bigquery.readonly"]
+    }
+  },
+  "bigquery-readwrite": {
+    "title": "BigQuery (Read-Write)",
+    "type": "streamable-http",
+    "url": "https://mcp.bigquery.example.com/mcp",
+    "oauth": {
+      "clientId": "bigquery-mcp-client",
+      "scopes": [
+        "https://www.googleapis.com/auth/bigquery.readonly",
+        "https://www.googleapis.com/auth/bigquery"
+      ]
+    }
+  }
+}
+```
+
 ## Environment Variable Interpolation
 
 All string values support `${ENV_VAR}` interpolation. The agent's runtime resolves these from the user's environment:
@@ -147,6 +198,8 @@ Claude Code uses `.mcp.json` with servers nested under an `mcpServers` key:
 ```
 
 For remote servers, Claude Code uses `url` and optional `headers` instead of `command`/`args`.
+
+For OAuth servers, AIR translates the `oauth` object to Claude Code's format. The `redirectUri` is converted to Claude Code's `callbackPort` by extracting the port number. The `scopes` field is passed through for forward compatibility.
 
 ## Best Practices
 

--- a/schemas/mcp.schema.json
+++ b/schemas/mcp.schema.json
@@ -18,6 +18,30 @@
     "description": "Server name (identifier key). Must be alphanumeric with hyphens, underscores, or brackets allowed."
   },
   "$defs": {
+    "OAuthConfiguration": {
+      "type": "object",
+      "description": "OAuth configuration for remote servers using OAuth authorization.",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "OAuth client ID. If omitted, the client uses Dynamic Client Registration (DCR) or discovery."
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "OAuth scopes to request in the authorization request. Passed as the scope parameter (RFC 6749 §3.3)."
+        },
+        "redirectUri": {
+          "type": "string",
+          "format": "uri",
+          "description": "Redirect URI for the OAuth callback. For CLI/desktop clients this is typically http://localhost:{port}/callback (RFC 8252)."
+        }
+      },
+      "additionalProperties": false
+    },
     "ServerConfiguration": {
       "type": "object",
       "description": "Configuration for a single MCP server.",
@@ -67,6 +91,9 @@
             "type": "string"
           },
           "description": "HTTP headers for remote servers. Values support ${ENV_VAR} interpolation."
+        },
+        "oauth": {
+          "$ref": "#/$defs/OAuthConfiguration"
         }
       },
       "required": ["type"],
@@ -82,7 +109,8 @@
             "required": ["command"],
             "properties": {
               "url": false,
-              "headers": false
+              "headers": false,
+              "oauth": false
             }
           }
         },


### PR DESCRIPTION
## Summary

- Adds an optional `oauth` object (`clientId`, `scopes`, `redirectUri`) to remote MCP server entries in the `mcp.json` proposal
- Enables shareable configs where recipients copy the file, authenticate with their own identity, and each entry is scoped correctly via OAuth consent
- Key use case: multiple entries at the same server URL with different scopes (e.g. `bigquery-readonly` vs `bigquery-readwrite`), each getting its own OAuth session
- Maintains parity with Claude Code's `oauth` object pattern (translates `redirectUri` → `callbackPort`)

## Changes

- **`docs/mcp-json-proposal.md`** — Full OAuth Configuration section with `clientId`, `scopes`, `redirectUri` fields; examples for auto-discovery (Linear), pre-registered client (Slack), and scope-differentiated entries (BigQuery); validation rules; updated Claude Code comparison table and complete example
- **`schemas/mcp.schema.json`** — New `OAuthConfiguration` definition; `oauth` field on `ServerConfiguration`; forbidden for stdio entries
- **`cli/src/lib/config.ts`** — New `McpOAuthConfig` interface; `oauth` field on `McpServerEntry`
- **`cli/src/lib/agents/claude.ts`** — `translateOAuth()` method converting `redirectUri` to `callbackPort`; passes `scopes` through for forward compatibility
- **`docs/mcp-servers.md`** — OAuth Configuration section; translation notes

## Test plan

- [x] All 193 existing tests pass
- [x] TypeScript compiles cleanly
- [x] Schema validates existing example files (no breaking changes — `oauth` is optional)
- [ ] Review that `redirectUri` → `callbackPort` translation handles edge cases
- [ ] Verify Slack and BigQuery examples reflect real-world patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)