### PR TITLE
docs: Scope AIR vs orchestration, document multi-agent patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,21 @@ Hooks are shell commands that fire at agent lifecycle events. Use them for notif
 }
 ```
 
+## Scope
+
+AIR is a **configuration layer** — it resolves, validates, and translates agent configs. It is not an orchestration platform.
+
+| AIR handles | Orchestration platforms handle |
+|-------------|-------------------------------|
+| Config resolution & composition | Session persistence & status tracking |
+| JSON Schema validation | Subagent invocation & coordination |
+| Agent-specific translation | Job queuing, retries, scheduling |
+| Single-session setup via `air start` | Secret management & credential vaults |
+| `${ENV_VAR}` interpolation in configs | Git clone lifecycle & working directories |
+| | Monitoring, cost tracking, dashboards |
+
+Teams building multi-agent systems use AIR as the config layer underneath their orchestration platform. See [Orchestration](docs/orchestration.md) for patterns and guidance.
+
 ## Quickstart
 
 ### 1. Install the CLI
@@ -266,6 +281,7 @@ See [docs/cli.md](docs/cli.md) for the full CLI reference. Key commands:
 | [Hooks](docs/hooks.md) | Lifecycle hooks |
 | [CLI](docs/cli.md) | Full CLI reference |
 | [Configuration](docs/configuration.md) | Configuration loading, composition, and layering |
+| [Orchestration](docs/orchestration.md) | Scope boundaries, multi-agent patterns, and building on top of AIR |
 
 ## Schema Validation
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -124,3 +124,9 @@ When writing artifact descriptions, be explicit about scope:
 - **Project-level**: "API rate limiting configuration" — scoped to a specific project
 
 The description is what agents (and humans) use to decide relevance. Make it count.
+
+## What AIR Is Not
+
+AIR is a configuration layer — it resolves, validates, and translates. It does not orchestrate agent sessions, manage subagents, persist state, or handle secrets.
+
+Teams building multi-agent systems (sequential pipelines, delegated subagents, event-triggered sessions) use AIR as the config layer underneath their orchestration platform. See [Orchestration & Multi-Agent Patterns](orchestration.md) for guidance on what belongs where.

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -1,0 +1,151 @@
+# Orchestration & Multi-Agent Patterns
+
+AIR is a **configuration layer** — it defines what an agent session needs (skills, MCP servers, references, hooks) and translates it for the target agent. It does not manage the lifecycle of sessions, coordinate multiple agents, or persist state between runs.
+
+This document clarifies what AIR handles, what it explicitly leaves to orchestration platforms, and what patterns teams should consider when building multi-agent systems on top of AIR.
+
+## What AIR Does
+
+1. **Config resolution** — load `air.json`, merge artifact indexes, resolve a root's defaults into a concrete set of skills, MCP servers, plugins, hooks, and references.
+2. **Validation** — ensure all JSON files conform to AIR schemas.
+3. **Agent translation** — convert resolved artifacts into agent-specific formats (Claude Code `.mcp.json`, etc.).
+4. **Session setup** — `air start` assembles config and starts a single agent session.
+
+## What AIR Does Not Do
+
+These are orchestration concerns. AIR is intentionally unopinionated about them:
+
+| Concern | Why it's out of scope |
+|---------|----------------------|
+| **Session persistence** | Tracking session status, history, and metadata requires a database. AIR is file-based and stateless. |
+| **Subagent invocation** | Spawning child agent sessions, passing context between them, and collecting results is a coordination problem with many valid solutions. |
+| **Job queuing & retries** | Retry policies, concurrency limits, and failure recovery are platform-level concerns. |
+| **Secret management** | AIR supports `${ENV_VAR}` interpolation in MCP configs, but sourcing those values from vaults, credential stores, or secret managers is the platform's job. |
+| **Git clone lifecycle** | Cloning repos, managing working directories, archiving artifacts after completion — these are execution environment concerns. |
+| **Monitoring & observability** | Dashboards, alerts, transcript storage, cost tracking — all platform-level. |
+| **Triggers & scheduling** | Cron-based, event-driven, or webhook-triggered session creation belongs in the orchestration layer. |
+| **Inter-session communication** | Passing data between sessions (files, transcripts, structured results) requires conventions that depend on the execution environment. |
+
+## Multi-Agent Patterns
+
+Teams building multi-agent systems will encounter these patterns. AIR provides the building blocks (roots, skills, MCP servers) but the orchestration logic lives elsewhere.
+
+### Pattern 1: Sequential Pipeline
+
+An orchestrator agent spawns subagents one at a time, passing results between phases.
+
+```
+Orchestrator (root: discovery)
+  ├── Phase 1: Ingest    (root: discovery-ingest)     → results.json
+  ├── Phase 2: Enrich    (root: discovery-enrich)      ← results.json
+  ├── Phase 3: Review    (root: discovery-review)      ← enriched.json
+  └── Phase 4: Publish   (root: discovery-publish)     ← reviewed.json
+```
+
+**AIR's role**: Each phase is a root with its own skills and MCP servers. AIR resolves the config for each phase independently.
+
+**Orchestration's role**: Deciding execution order, passing data between phases, handling partial failures, chunking large workloads across parallel subagents.
+
+### Pattern 2: Fire-and-Forget Delegation
+
+An agent spawns a subagent for a self-contained task and doesn't wait for the result.
+
+```
+Agent (root: web-app)
+  └── "The deploy skill needs updating"
+      → spawns session on root: agent-infra
+      → reports session URL, continues working
+```
+
+**AIR's role**: Both the parent and child roots are defined in `air.json`. The child root's config is resolved independently.
+
+**Orchestration's role**: Creating the child session, providing its URL back to the parent, managing its lifecycle independently.
+
+### Pattern 3: Tool-Delegated Subagents
+
+An MCP server exposes tools that internally spawn agent sessions. The parent agent calls tools without knowing subagents are involved.
+
+```
+Agent (root: onboarding)
+  ├── MCP tool: research_server(url)    → internally spawns subagent
+  ├── MCP tool: generate_configs(data)  → internally spawns subagent
+  └── MCP tool: validate_setup(config)  → internally spawns subagent
+```
+
+**AIR's role**: The MCP server is defined in `mcp.json`. The subagent roots it spawns are defined in `roots.json`.
+
+**Orchestration's role**: The MCP server implementation handles subagent lifecycle, result extraction, and error handling.
+
+## Security Boundary: Constraining Subagent Access
+
+When an agent can spawn subagents, it needs constraints on what it can spawn. This is a critical security concern that orchestration platforms must address.
+
+Common pattern: **locked-down MCP server variants** that restrict which roots an agent can target. An orchestrator agent gets an MCP server that can only create sessions on a predefined set of subagent roots — it cannot escalate its own access.
+
+```
+Orchestrator root: discovery
+  └── MCP server: "orchestrator-discovery" (can only spawn: ingest, enrich, review, publish)
+
+Subagent root: discovery-ingest
+  └── MCP servers: domain-specific tools only (no orchestrator access — cannot spawn further subagents)
+```
+
+AIR can express this structure (roots with different MCP server sets), but enforcement of access boundaries is the orchestration platform's responsibility.
+
+## Challenges for Subagent Systems
+
+These are open problems that teams will need to solve. AIR does not prescribe solutions, but they're worth understanding when designing multi-agent architectures:
+
+### Transcript Exposure
+
+When a parent agent needs to understand what a subagent did, it needs access to the subagent's transcript or a structured summary. This requires:
+- A mechanism to retrieve transcripts (API, file system, shared storage)
+- Conventions for how subagents report their results (structured output, files, final message format)
+- Decisions about how much context to pass back (full transcript vs. summary vs. structured result)
+
+### Result Passing
+
+Subagents need to return results to their parent. Common approaches:
+- **File-based**: Subagent writes results to a known path; parent reads it. Simple but requires shared filesystem.
+- **Transcript extraction**: Parent reads the subagent's final message and parses structured data from it. Fragile but works across execution environments.
+- **Structured output**: Subagent uses `--output-format json --json-schema <schema>` to return validated JSON. Clean but agent-specific.
+
+### Session Identity & Traceability
+
+Multi-agent runs need traceability — knowing which subagent belongs to which parent, which pipeline run, which trigger. This typically requires:
+- Session metadata (parent ID, run ID, phase number)
+- Dependency graphs for visualization
+- Log correlation across sessions
+
+### Cost & Resource Management
+
+Each subagent is a full agent session with its own token budget. Orchestration platforms need to manage:
+- Budget caps per subagent and per pipeline
+- Concurrency limits (how many subagents run in parallel)
+- Resource cleanup (clones, temp files, MCP server processes)
+
+## Building an Orchestration Layer
+
+If you're building an orchestration platform on top of AIR, here's a suggested architecture:
+
+```
+┌─────────────────────────────────────────┐
+│           Orchestration Platform         │
+│                                          │
+│  Sessions · Jobs · Triggers · Monitoring │
+│  Secret Vault · Clone Management · UI    │
+├─────────────────────────────────────────┤
+│                AIR SDK                   │
+│                                          │
+│  resolveArtifacts() · generateMcpConfig()│
+│  injectSkills() · validateConfig()       │
+├─────────────────────────────────────────┤
+│           Agent Runtime                  │
+│                                          │
+│  claude -p · opencode · cursor           │
+└─────────────────────────────────────────┘
+```
+
+**AIR SDK** sits between the orchestration platform and the agent runtime. The platform calls AIR to resolve configs and generate agent-specific files, then manages the agent process lifecycle itself.
+
+This separation keeps AIR focused on config — a problem with a clean, general solution — and leaves orchestration to platforms that can make opinionated choices about persistence, security, and workflow.

--- a/docs/roots.md
+++ b/docs/roots.md
@@ -100,6 +100,25 @@ When you start a session with a root, AIR:
 3. Clones the repository (if URL is specified)
 4. Starts the agent session in the root's working directory
 
+## Roots in Multi-Agent Systems
+
+Roots are the primary building block for multi-agent architectures. An orchestrator agent operates on one root, and spawns subagents on other roots — each with its own skills, MCP servers, and scope.
+
+```
+Orchestrator root: "pipeline"
+  ├── default_mcp_servers: ["orchestrator-mcp"]     ← can spawn subagents
+  └── default_skills: ["run-pipeline"]
+
+Subagent root: "pipeline-phase-1"
+  ├── default_mcp_servers: ["domain-db"]             ← domain tools only
+  ├── default_skills: ["ingest-data"]
+  └── user_invocable: false                          ← only spawned by orchestrator
+```
+
+Setting `user_invocable: false` on subagent roots signals that they exist to be spawned programmatically, not started directly by users.
+
+AIR resolves the config for each root independently. The orchestration logic — deciding execution order, passing data, handling failures — lives in the orchestration platform, not in AIR. See [Orchestration & Multi-Agent Patterns](orchestration.md) for detailed patterns.
+
 ## Best Practices
 
 1. **Scope descriptions clearly** — anyone in the org should understand what each root is for


### PR DESCRIPTION
## Summary

- Adds `docs/orchestration.md` — a new doc that explicitly scopes what AIR handles (config resolution, validation, agent translation) vs what orchestration platforms handle (subagent lifecycle, secret management, scheduling, monitoring)
- Documents three multi-agent patterns that teams building on AIR will encounter: sequential pipelines, fire-and-forget delegation, and tool-delegated subagents
- Covers open challenges (transcript exposure, result passing, session traceability, cost management) without prescribing solutions
- Adds a **Scope** section to the README with a quick reference table
- Updates `docs/concepts.md` with a "What AIR Is Not" section
- Updates `docs/roots.md` with guidance on using roots in multi-agent systems (`user_invocable: false` for subagent-only roots)

## Motivation

As teams adopt AIR alongside orchestration platforms, the boundary between "config layer" and "orchestration layer" needs to be explicit. This PR draws that line clearly:

- **AIR** = how to configure and set up an agent session
- **Orchestration** = how to manage the lifecycle of many agent sessions

The multi-agent patterns section documents real-world architectures (sequential pipelines with inter-phase data passing, fire-and-forget delegation, MCP-mediated subagents) without making AIR responsible for solving them. The intent is to help teams understand what they'll need to build on top of AIR.

## Verification

- [x] All links between docs are valid (orchestration.md ↔ concepts.md ↔ roots.md ↔ README)
- [x] No existing content modified beyond adding cross-references
- [x] New doc follows existing documentation style and structure
- [x] README scope table accurately reflects current AIR capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)