### PR TITLE
fix: add repository.url for npm provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,14 +43,27 @@ jobs:
 
       - name: Publish packages
         run: |
+          publish_if_needed() {
+            local workspace=$1
+            local pkg_name=$(node -e "console.log(require('./$workspace/package.json').name)")
+            local pkg_version=$(node -e "console.log(require('./$workspace/package.json').version)")
+
+            if npm view "${pkg_name}@${pkg_version}" version > /dev/null 2>&1; then
+              echo "⏭️  ${pkg_name}@${pkg_version} already published, skipping"
+            else
+              echo "📦 Publishing ${pkg_name}@${pkg_version}..."
+              npm publish -w "$workspace" --provenance --access public
+            fi
+          }
+
           # Publish core first (others depend on it)
-          npm publish -w packages/core --provenance --access public || true
+          publish_if_needed packages/core
 
           # Publish extensions
-          npm publish -w packages/extensions/adapter-claude --provenance --access public || true
-          npm publish -w packages/extensions/provider-github --provenance --access public || true
+          publish_if_needed packages/extensions/adapter-claude
+          publish_if_needed packages/extensions/provider-github
 
           # Publish CLI last (depends on core + adapter)
-          npm publish -w packages/cli --provenance --access public || true
+          publish_if_needed packages/cli
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,6 +4,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pulsemcp/air.git",
+    "directory": "packages/cli"
+  },
   "description": "CLI for the AIR (Agent Infrastructure Repository) framework",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pulsemcp/air.git",
+    "directory": "packages/core"
+  },
   "description": "AIR core — config resolution, validation, schemas, and extension interfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -4,6 +4,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pulsemcp/air.git",
+    "directory": "packages/extensions/adapter-claude"
+  },
   "description": "AIR adapter for Claude Code — translates AIR config to Claude Code format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -4,6 +4,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pulsemcp/air.git",
+    "directory": "packages/extensions/provider-github"
+  },
   "description": "AIR catalog provider for GitHub — resolves github:// URIs to artifact indexes",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Add `repository` field to all 4 package.json files — npm provenance validation requires `repository.url` to match the GitHub Actions source repo
- Replace `|| true` in publish workflow with version-check logic that skips already-published versions but surfaces real errors

## Verification
- [x] All 85 tests pass locally
- [x] Root cause identified from publish workflow logs: `E422 - package.json: "repository.url" is "", expected to match "https://github.com/pulsemcp/air"`
- [x] All 4 package.json files now have correct `repository` field with monorepo `directory` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)