### PR TITLE
chore: bump all packages to 0.0.4

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.3",
+    "@pulsemcp/air-sdk": "0.0.4",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.3"
+    "@pulsemcp/air-core": "0.0.4"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.3"
+    "@pulsemcp/air-core": "0.0.4"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.3"
+    "@pulsemcp/air-core": "0.0.4"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary

- Bumps all 5 packages (core, sdk, cli, adapter-claude, provider-github) from 0.0.3 → 0.0.4
- Updates internal dependency references to match (sdk→core, cli→sdk, extensions→core)
- Triggers the `Publish to npm` workflow on merge, which will publish all packages

**Why**: Features merged since 0.0.3 (subagent roots from #11, plugin composability from #12, SDK refactor from #10) haven't been published because the version wasn't bumped. pulsemcp/pulsemcp#2468 depends on `@pulsemcp/air-cli@0.0.4`.

## Verification

- [x] Only version fields changed — no code, no description, no config changes
- [x] Internal dependency versions are consistent (cli→sdk@0.0.4, sdk→core@0.0.4, extensions→core@0.0.4)
- [x] Publish workflow will auto-publish on merge (verified `publish_if_needed` logic skips existing versions, publishes new ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)