### PR TITLE
feat: add default_subagent_roots, --no-subagent-merge, bump to 0.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1775416943-ed2ff4e3",
+  "name": "pulsemcp-air",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -1960,9 +1960,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.3",
+        "@pulsemcp/air-sdk": "0.0.5",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -1981,7 +1981,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -1997,9 +1997,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.3"
+        "@pulsemcp/air-core": "0.0.5"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2012,9 +2012,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.3"
+        "@pulsemcp/air-core": "0.0.5"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2027,9 +2027,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.3"
+        "@pulsemcp/air-core": "0.0.5"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.4",
+    "@pulsemcp/air-sdk": "0.0.5",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -29,6 +29,10 @@ export function prepareCommand(): Command {
       "--mcp-servers <ids>",
       "Comma-separated MCP server IDs (overrides root defaults)"
     )
+    .option(
+      "--no-subagent-merge",
+      "Skip merging subagent roots' artifacts into the parent session (for orchestrators that manage composition externally)"
+    )
     .action(
       async (options: {
         config?: string;
@@ -37,6 +41,7 @@ export function prepareCommand(): Command {
         adapter: string;
         skills?: string;
         mcpServers?: string;
+        subagentMerge: boolean;
       }) => {
         try {
           const result = await prepareSession({
@@ -50,6 +55,7 @@ export function prepareCommand(): Command {
             mcpServers: options.mcpServers
               ? options.mcpServers.split(",").map((s) => s.trim())
               : undefined,
+            skipSubagentMerge: !options.subagentMerge,
           });
 
           if (result.rootAutoDetected && result.root) {

--- a/packages/cli/tests/prepare-command.test.ts
+++ b/packages/cli/tests/prepare-command.test.ts
@@ -362,6 +362,149 @@ describe("prepare command", () => {
     expect(result.stderr).toContain("not found");
   });
 
+  it("merges subagent roots' artifacts into parent session", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        mcp: ["./mcp.json"],
+        skills: ["./skills.json"],
+        roots: ["./roots.json"],
+      },
+      "mcp.json": {
+        "ao-mcp": { type: "stdio", command: "npx", args: ["ao-mcp"] },
+        "pg-prod": { type: "stdio", command: "npx", args: ["pg"] },
+        "web-search": { type: "stdio", command: "npx", args: ["search"] },
+        "proctor": { type: "stdio", command: "npx", args: ["proctor"] },
+      },
+      "skills.json": {
+        "onboard-server": {
+          id: "onboard-server",
+          description: "Onboard a server",
+          path: "skills/onboard-server",
+        },
+        "validate-config": {
+          id: "validate-config",
+          description: "Validate config",
+          path: "skills/validate-config",
+        },
+        "find-source": {
+          id: "find-source",
+          description: "Find canonical source",
+          path: "skills/find-source",
+        },
+      },
+      "skills/onboard-server/SKILL.md": "# Onboard Server",
+      "skills/validate-config/SKILL.md": "# Validate Config",
+      "skills/find-source/SKILL.md": "# Find Source",
+      "roots.json": {
+        "server-onboarding": {
+          name: "server-onboarding",
+          display_name: "Server Onboarding",
+          description: "Onboard MCP servers to PulseMCP",
+          default_mcp_servers: ["ao-mcp"],
+          default_skills: ["onboard-server"],
+          default_subagent_roots: ["onboarding-configs", "onboarding-research"],
+        },
+        "onboarding-configs": {
+          name: "onboarding-configs",
+          display_name: "Onboarding: Configs",
+          description: "Prepare server configs",
+          default_mcp_servers: ["pg-prod"],
+          default_skills: ["validate-config"],
+          subdirectory: "subagents/configs",
+          user_invocable: false,
+        },
+        "onboarding-research": {
+          name: "onboarding-research",
+          display_name: "Onboarding: Research",
+          description: "Research server sources",
+          default_mcp_servers: ["web-search"],
+          default_skills: ["find-source"],
+          subdirectory: "subagents/research",
+          user_invocable: false,
+        },
+      },
+    });
+
+    const target = createTemp({});
+
+    const result = tryRun(
+      `prepare --config ${join(catalog, "air.json")} --root server-onboarding --target ${target}`
+    );
+    expect(result.exitCode).toBe(0);
+
+    // Parent + subagent MCP servers should all be present
+    const mcpJson = JSON.parse(
+      readFileSync(join(target, ".mcp.json"), "utf-8")
+    );
+    expect(mcpJson.mcpServers["ao-mcp"]).toBeDefined();
+    expect(mcpJson.mcpServers["pg-prod"]).toBeDefined();
+    expect(mcpJson.mcpServers["web-search"]).toBeDefined();
+    // proctor was not referenced by any root
+    expect(mcpJson.mcpServers["proctor"]).toBeUndefined();
+
+    // All skills should be injected
+    expect(existsSync(join(target, ".claude", "skills", "onboard-server", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(target, ".claude", "skills", "validate-config", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(target, ".claude", "skills", "find-source", "SKILL.md"))).toBe(true);
+
+    // No file written — context is ephemeral
+    expect(existsSync(join(target, ".claude", "subagent-roots-context.md"))).toBe(false);
+
+    // Output should include subagentContext
+    const output = JSON.parse(result.stdout);
+    expect(output.subagentContext).toBeDefined();
+    expect(output.subagentContext).toContain("Subagent Root Dependencies");
+  });
+
+  it("skips subagent merge with --no-subagent-merge flag", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        mcp: ["./mcp.json"],
+        roots: ["./roots.json"],
+      },
+      "mcp.json": {
+        "ao-mcp": { type: "stdio", command: "npx", args: ["ao-mcp"] },
+        "pg-prod": { type: "stdio", command: "npx", args: ["pg"] },
+      },
+      "roots.json": {
+        "server-onboarding": {
+          name: "server-onboarding",
+          description: "Onboard servers",
+          default_mcp_servers: ["ao-mcp"],
+          default_subagent_roots: ["sub-db"],
+        },
+        "sub-db": {
+          name: "sub-db",
+          description: "DB subagent",
+          default_mcp_servers: ["pg-prod"],
+        },
+      },
+    });
+
+    const target = createTemp({});
+
+    const result = tryRun(
+      `prepare --config ${join(catalog, "air.json")} --root server-onboarding --no-subagent-merge --target ${target}`
+    );
+    expect(result.exitCode).toBe(0);
+
+    // Only parent's MCP server should be present (subagent's was not merged)
+    const mcpJson = JSON.parse(
+      readFileSync(join(target, ".mcp.json"), "utf-8")
+    );
+    expect(mcpJson.mcpServers["ao-mcp"]).toBeDefined();
+    expect(mcpJson.mcpServers["pg-prod"]).toBeUndefined();
+
+    // No subagent context file
+    expect(existsSync(join(target, ".claude", "subagent-roots-context.md"))).toBe(false);
+
+    // No subagentContext in output
+    const output = JSON.parse(result.stdout);
+    expect(output.subagentContext).toBeUndefined();
+  });
+
   it("is idempotent — running prepare twice produces same result", () => {
     const catalog = createTemp({
       "air.json": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -89,6 +89,7 @@ export interface RootEntry {
   default_skills?: string[];
   default_plugins?: string[];
   default_hooks?: string[];
+  default_subagent_roots?: string[];
   user_invocable?: boolean;
   default_stop_condition?: string;
 }
@@ -159,6 +160,13 @@ export interface PrepareSessionOptions {
    * When set, this replaces root.default_mcp_servers entirely.
    */
   mcpServerOverrides?: string[];
+  /**
+   * Skip merging subagent roots' artifacts into the parent session.
+   * When true, default_subagent_roots is ignored during preparation.
+   * Orchestrators that manage subagent composition externally (e.g., via
+   * an MCP server) should set this to true.
+   */
+  skipSubagentMerge?: boolean;
 }
 
 export interface PreparedSession {
@@ -168,6 +176,12 @@ export interface PreparedSession {
   skillPaths: string[];
   /** The command to start the agent in the prepared directory */
   startCommand: StartCommand;
+  /**
+   * System prompt content describing subagent root dependencies.
+   * Present when the root has default_subagent_roots and skipSubagentMerge is false.
+   * Adapters write this to a file and/or include it in the start command.
+   */
+  subagentContext?: string;
 }
 
 /**

--- a/packages/core/tests/validator.test.ts
+++ b/packages/core/tests/validator.test.ts
@@ -115,6 +115,18 @@ describe("validateJson", () => {
       );
       expect(result.valid).toBe(true);
     });
+
+    it("validates root with default_subagent_roots", () => {
+      const result = validateJson(
+        {
+          "my-root": exampleRoot("my-root", {
+            default_subagent_roots: ["sub-configs", "sub-research"],
+          }),
+        },
+        "roots"
+      );
+      expect(result.valid).toBe(true);
+    });
   });
 
   describe("references.json", () => {

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.4"
+    "@pulsemcp/air-core": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/adapter-claude/src/claude-adapter.ts
+++ b/packages/extensions/adapter-claude/src/claude-adapter.ts
@@ -87,6 +87,10 @@ export class ClaudeAdapter implements AgentAdapter {
    * Prepare a working directory for a Claude Code session.
    * Writes .mcp.json, injects skills + references into .claude/skills/,
    * and returns the start command.
+   *
+   * When the root declares default_subagent_roots and skipSubagentMerge is not set,
+   * subagent roots' skills and MCP servers are merged into the parent session and
+   * a system prompt section is generated describing the subagent dependencies.
    */
   async prepareSession(
     artifacts: ResolvedArtifacts,
@@ -99,9 +103,21 @@ export class ClaudeAdapter implements AgentAdapter {
     const skillPaths: string[] = [];
 
     // 1. Resolve which artifacts to activate (overrides take precedence over root defaults)
-    const mcpServerIds = options?.mcpServerOverrides
+    let mcpServerIds = options?.mcpServerOverrides
       ?? root?.default_mcp_servers
       ?? undefined;
+    let skillIds = options?.skillOverrides
+      ?? root?.default_skills
+      ?? Object.keys(artifacts.skills);
+
+    // 1b. Merge subagent roots' artifacts if applicable
+    const subagentRoots = this.resolveSubagentRoots(root, artifacts, options);
+    if (subagentRoots.length > 0) {
+      const merged = this.mergeSubagentArtifacts(subagentRoots, mcpServerIds, skillIds);
+      mcpServerIds = merged.mcpServerIds;
+      skillIds = merged.skillIds;
+    }
+
     const mcpServers = mcpServerIds
       ? this.filterByIds(artifacts.mcp, mcpServerIds)
       : artifacts.mcp;
@@ -109,10 +125,6 @@ export class ClaudeAdapter implements AgentAdapter {
     const plugins = root?.default_plugins
       ? this.filterByIds(artifacts.plugins, root.default_plugins)
       : artifacts.plugins;
-
-    const skillIds = options?.skillOverrides
-      ?? root?.default_skills
-      ?? Object.keys(artifacts.skills);
 
     // 2. Write .mcp.json with resolved secrets
     const resolvedServers = await this.resolveServerSecrets(
@@ -160,14 +172,106 @@ export class ClaudeAdapter implements AgentAdapter {
       }
     }
 
-    // 4. Build start command
+    // 4. Generate ephemeral subagent context for system prompt
+    let subagentContext: string | undefined;
+    if (subagentRoots.length > 0) {
+      subagentContext = this.buildSubagentContext(subagentRoots);
+    }
+
+    // 5. Build start command (include --append-system-prompt if subagent context exists)
     const config = this.generateConfig(artifacts, root, targetDir);
     const startCommand = this.buildStartCommand({
       ...config,
       workDir: targetDir,
     });
+    if (subagentContext) {
+      startCommand.args.push("--append-system-prompt", subagentContext);
+    }
 
-    return { configFiles, skillPaths, startCommand };
+    return { configFiles, skillPaths, startCommand, subagentContext };
+  }
+
+  /**
+   * Resolve subagent roots from the root's default_subagent_roots.
+   * Returns empty array if skipSubagentMerge is set or no subagent roots exist.
+   */
+  private resolveSubagentRoots(
+    root: RootEntry | undefined,
+    artifacts: ResolvedArtifacts,
+    options?: PrepareSessionOptions
+  ): RootEntry[] {
+    if (options?.skipSubagentMerge) return [];
+    if (!root?.default_subagent_roots?.length) return [];
+
+    const resolved: RootEntry[] = [];
+    for (const id of root.default_subagent_roots) {
+      const subRoot = artifacts.roots[id];
+      if (subRoot) {
+        resolved.push(subRoot);
+      }
+    }
+    return resolved;
+  }
+
+  /**
+   * Merge subagent roots' default_mcp_servers and default_skills into the
+   * parent's activated sets (union, preserving order with parent first).
+   */
+  private mergeSubagentArtifacts(
+    subagentRoots: RootEntry[],
+    parentMcpServerIds: string[] | undefined,
+    parentSkillIds: string[]
+  ): { mcpServerIds: string[] | undefined; skillIds: string[] } {
+    const mcpSet = new Set(parentMcpServerIds ?? []);
+    const skillSet = new Set(parentSkillIds);
+
+    for (const sub of subagentRoots) {
+      if (sub.default_mcp_servers) {
+        for (const id of sub.default_mcp_servers) mcpSet.add(id);
+      }
+      if (sub.default_skills) {
+        for (const id of sub.default_skills) skillSet.add(id);
+      }
+    }
+
+    return {
+      mcpServerIds: parentMcpServerIds !== undefined || mcpSet.size > 0
+        ? [...mcpSet]
+        : undefined,
+      skillIds: [...skillSet],
+    };
+  }
+
+  /**
+   * Build a system prompt section describing the subagent root dependencies.
+   * Gives the agent context about what capabilities were merged and from where.
+   */
+  private buildSubagentContext(subagentRoots: RootEntry[]): string {
+    const lines: string[] = [
+      "## Subagent Root Dependencies",
+      "",
+      "This session includes capabilities from the following subagent roots.",
+      "Their skills and MCP servers have been merged into your session.",
+      "",
+    ];
+
+    for (const sub of subagentRoots) {
+      lines.push(`### ${sub.display_name || sub.name}`);
+      lines.push("");
+      lines.push(`**Description**: ${sub.description}`);
+      if (sub.default_mcp_servers?.length) {
+        lines.push(`**MCP Servers**: ${sub.default_mcp_servers.join(", ")}`);
+      }
+      if (sub.default_skills?.length) {
+        lines.push(`**Skills**: ${sub.default_skills.join(", ")}`);
+      }
+      if (sub.subdirectory) {
+        lines.push(`**Subdirectory**: ${sub.subdirectory}`);
+      }
+      lines.push("");
+    }
+
+    return lines.join("\n");
   }
 
   /** Translate AIR mcp.json format to Claude Code .mcp.json format */

--- a/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
+++ b/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
@@ -459,5 +459,216 @@ describe("ClaudeAdapter", () => {
       expect(result.startCommand.command).toBe("claude");
       expect(result.startCommand.cwd).toBe(dir);
     });
+
+    describe("subagent root merging", () => {
+      it("merges subagent roots' MCP servers and skills into parent session", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        // Parent's MCP server
+        artifacts.mcp["github"] = { type: "stdio", command: "gh" };
+        // Subagent's MCP servers
+        artifacts.mcp["postgres"] = { type: "stdio", command: "psql" };
+        artifacts.mcp["slack"] = { type: "stdio", command: "slack" };
+
+        // Parent skill source
+        const parentSkillDir = join(dir, "..", "skills", "deploy");
+        mkdirSync(parentSkillDir, { recursive: true });
+        writeFileSync(join(parentSkillDir, "SKILL.md"), "# Deploy");
+
+        // Subagent skill source
+        const subSkillDir = join(dir, "..", "skills", "validate");
+        mkdirSync(subSkillDir, { recursive: true });
+        writeFileSync(join(subSkillDir, "SKILL.md"), "# Validate");
+
+        artifacts.skills["deploy"] = {
+          id: "deploy",
+          description: "Deploy skill",
+          path: resolve(parentSkillDir),
+        };
+        artifacts.skills["validate"] = {
+          id: "validate",
+          description: "Validate skill",
+          path: resolve(subSkillDir),
+        };
+
+        // Define roots
+        artifacts.roots["sub-configs"] = {
+          name: "sub-configs",
+          description: "Config subagent",
+          default_mcp_servers: ["postgres", "slack"],
+          default_skills: ["validate"],
+        };
+
+        const root: RootEntry = {
+          name: "parent",
+          description: "Parent root",
+          default_mcp_servers: ["github"],
+          default_skills: ["deploy"],
+          default_subagent_roots: ["sub-configs"],
+        };
+
+        const result = await adapter.prepareSession(artifacts, dir, { root });
+
+        // MCP config should include parent + subagent servers
+        const mcpJson = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
+        expect(mcpJson.mcpServers["github"]).toBeDefined();
+        expect(mcpJson.mcpServers["postgres"]).toBeDefined();
+        expect(mcpJson.mcpServers["slack"]).toBeDefined();
+
+        // Both skills should be injected
+        expect(existsSync(join(dir, ".claude", "skills", "deploy", "SKILL.md"))).toBe(true);
+        expect(existsSync(join(dir, ".claude", "skills", "validate", "SKILL.md"))).toBe(true);
+      });
+
+      it("generates subagent context system prompt", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        artifacts.roots["research"] = {
+          name: "research",
+          display_name: "Research Agent",
+          description: "Researches server sources",
+          default_mcp_servers: ["web-search"],
+          default_skills: ["find-source"],
+          subdirectory: "agents/research",
+        };
+
+        const root: RootEntry = {
+          name: "onboarding",
+          description: "Server onboarding",
+          default_subagent_roots: ["research"],
+        };
+
+        const result = await adapter.prepareSession(artifacts, dir, { root });
+
+        // subagentContext should be populated
+        expect(result.subagentContext).toBeDefined();
+        expect(result.subagentContext).toContain("Subagent Root Dependencies");
+        expect(result.subagentContext).toContain("Research Agent");
+        expect(result.subagentContext).toContain("Researches server sources");
+        expect(result.subagentContext).toContain("web-search");
+        expect(result.subagentContext).toContain("find-source");
+        expect(result.subagentContext).toContain("agents/research");
+
+        // No file written — context is ephemeral
+        expect(existsSync(join(dir, ".claude", "subagent-roots-context.md"))).toBe(false);
+
+        // Start command should include --append-system-prompt
+        expect(result.startCommand.args).toContain("--append-system-prompt");
+      });
+
+      it("skips subagent merge when skipSubagentMerge is true", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        artifacts.mcp["github"] = { type: "stdio", command: "gh" };
+        artifacts.mcp["postgres"] = { type: "stdio", command: "psql" };
+
+        artifacts.roots["sub-db"] = {
+          name: "sub-db",
+          description: "DB subagent",
+          default_mcp_servers: ["postgres"],
+        };
+
+        const root: RootEntry = {
+          name: "parent",
+          description: "Parent root",
+          default_mcp_servers: ["github"],
+          default_subagent_roots: ["sub-db"],
+        };
+
+        const result = await adapter.prepareSession(artifacts, dir, {
+          root,
+          skipSubagentMerge: true,
+        });
+
+        // Only parent's MCP server should be present
+        const mcpJson = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
+        expect(mcpJson.mcpServers["github"]).toBeDefined();
+        expect(mcpJson.mcpServers["postgres"]).toBeUndefined();
+
+        // No subagent context
+        expect(result.subagentContext).toBeUndefined();
+        expect(existsSync(join(dir, ".claude", "subagent-roots-context.md"))).toBe(false);
+      });
+
+      it("handles missing subagent root references gracefully", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        artifacts.mcp["github"] = { type: "stdio", command: "gh" };
+
+        const root: RootEntry = {
+          name: "parent",
+          description: "Parent root",
+          default_mcp_servers: ["github"],
+          default_subagent_roots: ["nonexistent-root"],
+        };
+
+        // Should not throw
+        const result = await adapter.prepareSession(artifacts, dir, { root });
+
+        // Only parent's server, no subagent context
+        const mcpJson = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
+        expect(mcpJson.mcpServers["github"]).toBeDefined();
+        expect(result.subagentContext).toBeUndefined();
+      });
+
+      it("merges multiple subagent roots and deduplicates", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        artifacts.mcp["github"] = { type: "stdio", command: "gh" };
+        artifacts.mcp["postgres"] = { type: "stdio", command: "psql" };
+        artifacts.mcp["slack"] = { type: "stdio", command: "slack" };
+
+        artifacts.roots["sub-a"] = {
+          name: "sub-a",
+          description: "Subagent A",
+          default_mcp_servers: ["github", "postgres"],
+        };
+        artifacts.roots["sub-b"] = {
+          name: "sub-b",
+          description: "Subagent B",
+          default_mcp_servers: ["postgres", "slack"],
+        };
+
+        const root: RootEntry = {
+          name: "parent",
+          description: "Parent root",
+          default_mcp_servers: ["github"],
+          default_subagent_roots: ["sub-a", "sub-b"],
+        };
+
+        const result = await adapter.prepareSession(artifacts, dir, { root });
+
+        const mcpJson = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
+        // All three should be present (deduplicated union)
+        expect(Object.keys(mcpJson.mcpServers).sort()).toEqual(["github", "postgres", "slack"]);
+
+        // Context should mention both subagent roots
+        expect(result.subagentContext).toContain("Subagent A");
+        expect(result.subagentContext).toContain("Subagent B");
+      });
+
+      it("does not merge when root has no default_subagent_roots", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        artifacts.mcp["github"] = { type: "stdio", command: "gh" };
+
+        const root: RootEntry = {
+          name: "simple",
+          description: "Simple root",
+          default_mcp_servers: ["github"],
+        };
+
+        const result = await adapter.prepareSession(artifacts, dir, { root });
+
+        expect(result.subagentContext).toBeUndefined();
+        expect(result.startCommand.args).not.toContain("--append-system-prompt");
+      });
+    });
   });
 });

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.4"
+    "@pulsemcp/air-core": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.4"
+    "@pulsemcp/air-core": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/prepare.ts
+++ b/packages/sdk/src/prepare.ts
@@ -21,6 +21,11 @@ export interface PrepareSessionOptions {
   skills?: string[];
   /** MCP server IDs to activate (overrides root defaults). */
   mcpServers?: string[];
+  /**
+   * Skip merging subagent roots' artifacts into the parent session.
+   * Orchestrators that manage subagent composition externally should set this.
+   */
+  skipSubagentMerge?: boolean;
 }
 
 export interface PrepareSessionResult {
@@ -90,6 +95,7 @@ export async function prepareSession(
       root,
       skillOverrides: options?.skills,
       mcpServerOverrides: options?.mcpServers,
+      skipSubagentMerge: options?.skipSubagentMerge,
     }
   );
 

--- a/schemas/roots.schema.json
+++ b/schemas/roots.schema.json
@@ -80,6 +80,13 @@
           },
           "description": "IDs of hooks to activate by default for sessions using this root."
         },
+        "default_subagent_roots": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "IDs of other roots that this root depends on as subagents. The default CLI behavior merges subagent roots' skills and MCP servers into the parent session and appends subagent metadata to the system prompt. Orchestrators that manage subagent composition externally (e.g., via an MCP server) can opt out with --no-subagent-merge."
+        },
         "user_invocable": {
           "type": "boolean",
           "description": "Whether this root can be directly invoked by users to start a session.",


### PR DESCRIPTION
## Summary

Recreates the lost PR #11 changes (subagent root support) and bumps all packages to 0.0.5.

PR #11 was merged but its commit was lost from history (likely overwritten by a subsequent force-push). The published 0.0.4 package does not contain the `--no-subagent-merge` flag, which causes `AirPrepareService` in `pulsemcp/pulsemcp` to fail with `error: unknown option '--no-subagent-merge'`.

**Changes (from PR #11):**
- `default_subagent_roots` field on Root schema — declares subagent dependencies
- Default CLI `prepare` merges subagent roots' skills/MCP servers into the parent session and generates system prompt context
- `--no-subagent-merge` flag for orchestrators (like AO) that manage composition externally
- `skipSubagentMerge` option in SDK `prepareSession()`

**Version bump:**
- All 5 packages bumped from 0.0.4 → 0.0.5 (core, sdk, cli, adapter-claude, provider-github)
- Internal dependency references updated to match

## Verification

- [x] Applied original PR #11 diff cleanly on top of current main
- [x] Build succeeds across all 5 packages (`npm run build`)
- [x] All 207 tests pass (`npm test`) — includes 9 new tests for subagent merge behavior
- [x] `--no-subagent-merge` flag confirmed in `npx air prepare --help` output
- [x] Version bump verified: all package.json files and internal deps reference 0.0.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)