### PR TITLE
fix: translate streamable-http to http in claude adapter, bump to 0.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1775583141-3b200ced",
+  "name": "air-main-1775594727-cd45df86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -1968,9 +1968,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.8",
+        "@pulsemcp/air-sdk": "0.0.9",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -1989,7 +1989,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -2005,9 +2005,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.8"
+        "@pulsemcp/air-core": "0.0.9"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2020,9 +2020,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.8"
+        "@pulsemcp/air-core": "0.0.9"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2035,9 +2035,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.8"
+        "@pulsemcp/air-core": "0.0.9"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2050,9 +2050,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.8"
+        "@pulsemcp/air-core": "0.0.9"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2065,9 +2065,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.8"
+        "@pulsemcp/air-core": "0.0.9"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.8",
+    "@pulsemcp/air-sdk": "0.0.9",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.8"
+    "@pulsemcp/air-core": "0.0.9"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/adapter-claude/src/claude-adapter.ts
+++ b/packages/extensions/adapter-claude/src/claude-adapter.ts
@@ -280,8 +280,10 @@ export class ClaudeAdapter implements AgentAdapter {
           ...(server.env && { env: server.env }),
         };
       } else {
+        // Claude Code uses "http" for the streamable-http transport
+        const claudeType = server.type === "streamable-http" ? "http" : server.type;
         mcpServers[name] = {
-          type: server.type,
+          type: claudeType,
           url: server.url,
           ...(server.headers && { headers: server.headers }),
           ...(server.oauth && { oauth: this.translateOAuth(server.oauth) }),

--- a/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
+++ b/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
@@ -74,7 +74,7 @@ describe("ClaudeAdapter", () => {
       expect(result.mcpServers.test.description).toBeUndefined();
     });
 
-    it("translates remote servers (sse/streamable-http)", () => {
+    it("translates streamable-http to http for Claude Code compatibility", () => {
       const servers: Record<string, McpServerEntry> = {
         remote: {
           type: "streamable-http",
@@ -85,7 +85,7 @@ describe("ClaudeAdapter", () => {
 
       const result = adapter.translateMcpServers(servers) as any;
       expect(result.mcpServers.remote).toEqual({
-        type: "streamable-http",
+        type: "http",
         url: "https://mcp.example.com/api",
         headers: { Authorization: "Bearer ${TOKEN}" },
       });
@@ -305,7 +305,7 @@ describe("ClaudeAdapter", () => {
       await adapter.prepareSession(artifacts, dir);
 
       const mcpJson = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
-      expect(mcpJson.mcpServers.granola.type).toBe("streamable-http");
+      expect(mcpJson.mcpServers.granola.type).toBe("http");
       expect(mcpJson.mcpServers.granola.url).toBe("https://mcp.granola.ai/mcp");
       expect(mcpJson.mcpServers.events.type).toBe("sse");
       expect(mcpJson.mcpServers.events.url).toBe("https://mcp.example.com/sse");

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.8"
+    "@pulsemcp/air-core": "0.0.9"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.8"
+    "@pulsemcp/air-core": "0.0.9"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.8"
+    "@pulsemcp/air-core": "0.0.9"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.8"
+    "@pulsemcp/air-core": "0.0.9"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary

- Claude Code CLI uses `"type": "http"` for the streamable HTTP MCP transport, but AIR's schema defines it as `"streamable-http"`. The claude adapter's `translateMcpServers()` was passing the type through unchanged, causing Claude Code to reject MCP server configs with schema validation errors (AO session 2957).
- Translates `"streamable-http"` → `"http"` in `translateMcpServers()` so the adapter outputs what Claude Code expects. The `"sse"` type is preserved unchanged.
- Bumps all 7 packages from 0.0.8 → 0.0.9.
- Related: #22 (CI testing against real Claude Code CLI)

## Verification

- [x] All 229 tests pass across 19 test files (`npx vitest run`)
- [x] Existing `translateMcpServers` test updated to verify `streamable-http` input → `http` output
- [x] `prepareSession` integration test updated to verify `http` in written `.mcp.json`
- [x] `sse` type preserved unchanged (existing test still passes)
- [x] Full build succeeds (`npm run build`)
- [x] Version bump verified: all 7 packages at 0.0.9, no `0.0.8` references remain in any `package.json`
- [x] Self-review: diff is minimal — 3 lines changed in adapter source, 3 test expectations updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)