### PR TITLE
docs: add comprehensive user-facing CLI guides

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -11,16 +11,16 @@ For detailed reference documentation, see the [docs/](../) directory.
 
 ## Common Workflows
 
-- **[Managing Skills](skills/readme.md)** — Define reusable skills, list them, and understand how they get injected into agent sessions.
-- **[Configuring MCP Servers](mcp-servers/readme.md)** — Define MCP server entries for local and remote servers, wire them into sessions, and handle secrets.
+- **[Managing Skills](managing-skills.md)** — Define reusable skills, list them, and understand how they get injected into agent sessions.
+- **[Configuring MCP Servers](configuring-mcp-servers.md)** — Define MCP server entries for local and remote servers, wire them into sessions, and handle secrets.
 - **[Running Sessions](running-sessions.md)** — Use `air start` and `air prepare` to launch agent sessions with the right configuration.
 - **[Validating Configuration](validating-configuration.md)** — Catch config errors early with `air validate` before they cause runtime failures.
-- **[Installing Extensions](extensions/installing.md)** — Use `air install` to add adapters, providers, and transforms declared in your configuration.
+- **[Installing Extensions](installing-extensions.md)** — Use `air install` to add adapters, providers, and transforms declared in your configuration.
 
 ## Advanced Usage
 
-- **[Extensions System](extensions/readme.md)** — How adapter, provider, and transform extensions work. Install, configure, and build on the extension pipeline.
-- **[Roots and Multi-Root Setups](roots/readme.md)** — Organize agent configurations across repositories and teams with roots.
-- **[Hooks](hooks/readme.md)** — Automate actions around agent lifecycle events with shell-command hooks.
-- **[References](references/readme.md)** — Share reference documents across skills to keep documentation DRY.
+- **[Extensions System](extensions.md)** — How adapter, provider, and transform extensions work. Install, configure, and build on the extension pipeline.
+- **[Roots and Multi-Root Setups](roots.md)** — Organize agent configurations across repositories and teams with roots.
+- **[Hooks](hooks.md)** — Automate actions around agent lifecycle events with shell-command hooks.
+- **[References](references.md)** — Share reference documents across skills to keep documentation DRY.
 - **[Composition and Overrides](composition-and-overrides.md)** — Layer multiple config files, use override semantics, and pull remote configs with providers.

--- a/docs/guides/composition-and-overrides.md
+++ b/docs/guides/composition-and-overrides.md
@@ -222,5 +222,5 @@ To effectively "remove" an artifact from an earlier layer, you'd need to overrid
 ## Next steps
 
 - **[Understanding air.json](understanding-air-json.md)** — Root config file structure.
-- **[Extensions System](extensions/readme.md)** — Providers that enable remote configuration.
-- **[Roots and Multi-Root Setups](roots/readme.md)** — Subagent composition.
+- **[Extensions System](extensions.md)** — Providers that enable remote configuration.
+- **[Roots and Multi-Root Setups](roots.md)** — Subagent composition.

--- a/docs/guides/configuring-mcp-servers.md
+++ b/docs/guides/configuring-mcp-servers.md
@@ -236,6 +236,6 @@ Avoid unpinned versions like `@modelcontextprotocol/server-github` or `@latest` 
 
 ## Next steps
 
-- **[Running Sessions](../running-sessions.md)** — See how MCP servers get activated during sessions.
-- **[Extensions System](../extensions/readme.md)** — Use transforms to inject secrets or modify server configs.
-- **[Composition and Overrides](../composition-and-overrides.md)** — Layer org, team, and local server configs.
+- **[Running Sessions](running-sessions.md)** — See how MCP servers get activated during sessions.
+- **[Extensions System](extensions.md)** — Use transforms to inject secrets or modify server configs.
+- **[Composition and Overrides](composition-and-overrides.md)** — Layer org, team, and local server configs.

--- a/docs/guides/extensions.md
+++ b/docs/guides/extensions.md
@@ -44,7 +44,7 @@ Or install manually:
 npm install @pulsemcp/air-adapter-claude @pulsemcp/air-provider-github
 ```
 
-See [Installing Extensions](installing.md) for details.
+See [Installing Extensions](installing-extensions.md) for details.
 
 ## Adapters
 
@@ -194,6 +194,6 @@ Here's the complete flow during `air prepare`:
 
 ## Next steps
 
-- **[Installing Extensions](installing.md)** — Install declared extensions.
-- **[Composition and Overrides](../composition-and-overrides.md)** — Use providers for remote config.
-- **[Running Sessions](../running-sessions.md)** — See extensions in action during sessions.
+- **[Installing Extensions](installing-extensions.md)** — Install declared extensions.
+- **[Composition and Overrides](composition-and-overrides.md)** — Use providers for remote config.
+- **[Running Sessions](running-sessions.md)** — See extensions in action during sessions.

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -227,6 +227,6 @@ Hooks (2):
 
 ## Next steps
 
-- **[Roots and Multi-Root Setups](../roots/readme.md)** — Assign hooks to specific roots.
-- **[Validating Configuration](../validating-configuration.md)** — Validate your hooks config.
-- **[Extensions System](../extensions/readme.md)** — Hooks and the extension pipeline.
+- **[Roots and Multi-Root Setups](roots.md)** — Assign hooks to specific roots.
+- **[Validating Configuration](validating-configuration.md)** — Validate your hooks config.
+- **[Extensions System](extensions.md)** — Hooks and the extension pipeline.

--- a/docs/guides/installing-extensions.md
+++ b/docs/guides/installing-extensions.md
@@ -104,6 +104,6 @@ Local paths are resolved relative to the directory containing `air.json`. They d
 
 ## Next steps
 
-- **[Extensions System](readme.md)** — How adapters, providers, and transforms work.
-- **[Understanding air.json](../understanding-air-json.md)** — The `extensions` field in detail.
-- **[Running Sessions](../running-sessions.md)** — Using extensions in session preparation.
+- **[Extensions System](extensions.md)** — How adapters, providers, and transforms work.
+- **[Understanding air.json](understanding-air-json.md)** — The `extensions` field in detail.
+- **[Running Sessions](running-sessions.md)** — Using extensions in session preparation.

--- a/docs/guides/managing-skills.md
+++ b/docs/guides/managing-skills.md
@@ -149,7 +149,7 @@ Skills (2):
 
 ## Skills with references
 
-Skills can declare dependencies on [reference documents](../references/readme.md) to keep knowledge DRY:
+Skills can declare dependencies on [reference documents](references.md) to keep knowledge DRY:
 
 ```json
 {
@@ -195,6 +195,6 @@ This activates only the listed skills, ignoring root defaults.
 
 ## Next steps
 
-- **[References](../references/readme.md)** — Share documents across skills without duplication.
-- **[Roots and Multi-Root Setups](../roots/readme.md)** — Assign default skills to specific roots.
-- **[Running Sessions](../running-sessions.md)** — See how skills get activated in practice.
+- **[References](references.md)** — Share documents across skills without duplication.
+- **[Roots and Multi-Root Setups](roots.md)** — Assign default skills to specific roots.
+- **[Running Sessions](running-sessions.md)** — See how skills get activated in practice.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -111,7 +111,7 @@ Then install them:
 air install
 ```
 
-This reads the `extensions` array and installs any missing npm packages. See [Installing Extensions](extensions/installing.md) for details.
+This reads the `extensions` array and installs any missing npm packages. See [Installing Extensions](installing-extensions.md) for details.
 
 ## 6. Preview your session
 
@@ -136,6 +136,6 @@ This prepares the configuration and shows the command to launch Claude Code with
 ## Next steps
 
 - **[Understanding air.json](understanding-air-json.md)** — Learn how the root config file works in detail.
-- **[Managing Skills](skills/readme.md)** — Add reusable skills to your configuration.
-- **[Configuring MCP Servers](mcp-servers/readme.md)** — Add more MCP servers and handle secrets.
-- **[Roots and Multi-Root Setups](roots/readme.md)** — Organize configs across multiple repositories.
+- **[Managing Skills](managing-skills.md)** — Add reusable skills to your configuration.
+- **[Configuring MCP Servers](configuring-mcp-servers.md)** — Add more MCP servers and handle secrets.
+- **[Roots and Multi-Root Setups](roots.md)** — Organize configs across multiple repositories.

--- a/docs/guides/references.md
+++ b/docs/guides/references.md
@@ -147,6 +147,6 @@ Later entries override earlier ones by ID (full replacement). A team can overrid
 
 ## Next steps
 
-- **[Managing Skills](../skills/readme.md)** — Link references to skills.
-- **[Composition and Overrides](../composition-and-overrides.md)** — Override org-level references at the team level.
-- **[Validating Configuration](../validating-configuration.md)** — Validate your references index.
+- **[Managing Skills](managing-skills.md)** — Link references to skills.
+- **[Composition and Overrides](composition-and-overrides.md)** — Override org-level references at the team level.
+- **[Validating Configuration](validating-configuration.md)** — Validate your references index.

--- a/docs/guides/roots.md
+++ b/docs/guides/roots.md
@@ -187,6 +187,6 @@ Roots (2):
 
 ## Next steps
 
-- **[Running Sessions](../running-sessions.md)** — Use roots with `air start` and `air prepare`.
-- **[Managing Skills](../skills/readme.md)** — Define skills to assign to roots.
-- **[Configuring MCP Servers](../mcp-servers/readme.md)** — Define servers to assign to roots.
+- **[Running Sessions](running-sessions.md)** — Use roots with `air start` and `air prepare`.
+- **[Managing Skills](managing-skills.md)** — Define skills to assign to roots.
+- **[Configuring MCP Servers](configuring-mcp-servers.md)** — Define servers to assign to roots.

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -60,7 +60,7 @@ Hooks (1):
 
 ### Using roots
 
-If you have [roots](roots/readme.md) configured, activate one to scope the session:
+If you have [roots](roots.md) configured, activate one to scope the session:
 
 ```bash
 air start claude --root web-app
@@ -105,7 +105,7 @@ By default, it prepares the current directory. Use `--target` to specify a diffe
 | `--no-subagent-merge` | Skip merging subagent roots' artifacts |
 | `--skip-validation` | Skip `${VAR}` validation |
 
-Extensions can contribute additional flags — see [Extensions System](extensions/readme.md).
+Extensions can contribute additional flags — see [Extensions System](extensions.md).
 
 ### Output
 
@@ -201,6 +201,6 @@ air start claude --root web-app
 
 ## Next steps
 
-- **[Roots and Multi-Root Setups](roots/readme.md)** — Configure roots for different projects.
-- **[Extensions System](extensions/readme.md)** — Add adapters, providers, and transforms.
+- **[Roots and Multi-Root Setups](roots.md)** — Configure roots for different projects.
+- **[Extensions System](extensions.md)** — Add adapters, providers, and transforms.
 - **[Composition and Overrides](composition-and-overrides.md)** — Advanced config layering.

--- a/docs/guides/understanding-air-json.md
+++ b/docs/guides/understanding-air-json.md
@@ -154,7 +154,7 @@ Extensions provide three types of functionality:
 - **Providers** — resolve remote URIs like `github://` in artifact paths
 - **Transforms** — modify `.mcp.json` after session preparation (e.g., secrets injection)
 
-Order matters for transforms — they run in declaration order. See [Extensions System](extensions/readme.md) for details.
+Order matters for transforms — they run in declaration order. See [Extensions System](extensions.md) for details.
 
 ## Minimal configuration
 
@@ -216,4 +216,4 @@ This checks the file against the AIR JSON Schema. See [Validating Configuration]
 
 - **[Quickstart](quickstart.md)** — Full walkthrough of setting up AIR from scratch.
 - **[Composition and Overrides](composition-and-overrides.md)** — Advanced layering and remote config patterns.
-- **[Extensions System](extensions/readme.md)** — How to install and configure extensions.
+- **[Extensions System](extensions.md)** — How to install and configure extensions.

--- a/docs/guides/validating-configuration.md
+++ b/docs/guides/validating-configuration.md
@@ -166,5 +166,5 @@ air validate ~/.air/air.json || exit 1
 ## Next steps
 
 - **[Understanding air.json](understanding-air-json.md)** — Learn about the root config file structure.
-- **[Configuring MCP Servers](mcp-servers/readme.md)** — MCP server schema details.
-- **[Hooks](hooks/readme.md)** — Hook schema and lifecycle events.
+- **[Configuring MCP Servers](configuring-mcp-servers.md)** — MCP server schema details.
+- **[Hooks](hooks.md)** — Hook schema and lifecycle events.


### PR DESCRIPTION
## Summary

- Adds 12 task-oriented user guides in `docs/guides/`, organized into three categories with a README index
- Covers all 6 CLI commands (`init`, `validate`, `list`, `start`, `prepare`, `install`) and all 6 artifact types (skills, references, MCP servers, plugins, roots, hooks)
- Each guide includes practical examples with real CLI commands and config snippets, and cross-references related guides
- Synced with all PRs landed on main (#30, #31, #33, #34, #35, #36, #38, #39) — guides reflect the current state of the codebase
- Locally tested end-to-end with the AIR CLI

### Getting Started
| Guide | Description |
|-------|-------------|
| [Quickstart](docs/guides/quickstart.md) | Install → init → validate → start, end-to-end |
| [Understanding air.json](docs/guides/understanding-air-json.md) | Structure, fields, composition semantics, common mistakes |

### Common Workflows
| Guide | Description |
|-------|-------------|
| [Managing Skills](docs/guides/managing-skills.md) | Define SKILL.md, index entries, references, session injection |
| [Configuring MCP Servers](docs/guides/configuring-mcp-servers.md) | stdio/SSE/HTTP transports, env vars, OAuth, version pinning |
| [Running Sessions](docs/guides/running-sessions.md) | `air start` vs `air prepare`, roots, auto-detection, orchestrator patterns |
| [Validating Configuration](docs/guides/validating-configuration.md) | Schema detection, error reading, CI/pre-commit usage |
| [Installing Extensions](docs/guides/installing-extensions.md) | `air install`, local paths, CI pipeline setup |

### Advanced Usage
| Guide | Description |
|-------|-------------|
| [Extensions System](docs/guides/extensions.md) | Adapters, providers, transforms, the prepareSession pipeline |
| [Roots & Multi-Root](docs/guides/roots.md) | Scoping, auto-detection, monorepos, subagent roots |
| [Hooks](docs/guides/hooks.md) | Two-layer directory-based hooks with HOOK.json definitions |
| [References](docs/guides/references.md) | DRY shared documents, linking to skills, composition |
| [Composition & Overrides](docs/guides/composition-and-overrides.md) | Layering patterns, full replacement, remote configs, plugin composition |

### Key updates from main sync
- **Hooks** (PR #39): Rewritten for directory-based `HOOK.json` model — index entries now use `path` instead of inline `event`/`command`/`args`
- **Roots** (PR #30): Removed `default_stop_condition` field, updated `additionalProperties` claims
- **Quickstart** (PR #34): Documents repo-aware `air init` with `--force` and `--path` flags
- **GitHub URIs** (PR #33): Updated to show preferred `github://owner/repo@ref/path` syntax
- **Env vars** (PR #38): Documents `${VAR:-default}` fallback syntax

### Bug found during local testing
- **Path resolution docs** (`6f39b65`): The `path` field in skills.json and `file` field in references.json are resolved relative to the **index file's directory**, not `air.json`. Guides incorrectly said "relative to air.json" — fixed in managing-skills.md and references.md.

## Verification

- [x] **CI green** — All 4 checks pass on latest commit `6f39b65`:
  ```
  test (18)        completed success
  test (20)        completed success
  test (22)        completed success
  validate-schemas completed success
  ```

- [x] **All 323 tests pass** — `npx vitest run` across all 22 test files

- [x] **All 12 guides + README index created** in `docs/guides/`:
  ```
  README.md                    composition-and-overrides.md
  configuring-mcp-servers.md   extensions.md
  hooks.md                     installing-extensions.md
  managing-skills.md           quickstart.md
  references.md                roots.md
  running-sessions.md          understanding-air-json.md
  validating-configuration.md
  ```

- [x] **Local CLI testing completed** — every CLI command tested end-to-end with real config containing one of each artifact type:
  - `air init` — blank scaffolding mode (from non-git dir) and repo-aware mode (discovers artifacts, generates `github://` URIs with `@ref`)
  - `air init --force` — overwrites existing config
  - `air validate` — all 7 artifact files validate (air.json, skills.json, references.json, mcp.json, plugins.json, roots.json, hooks.json)
  - `air list {type}` — all 6 types produce correct output (skills, references, mcp, plugins, roots, hooks)
  - `air start claude --dry-run` — with and without `--root`
  - `air prepare claude --target` — verified `.mcp.json` written, skills injected to `.claude/skills/`, hooks injected to `.claude/hooks/`, references copied alongside skills
  - `air prepare` with `${VAR:-default}` env vars — defaults resolved correctly, env override works
  - `air prepare --skip-validation` — bypasses unresolved variable check
  - `air install` — installs declared extensions

- [x] **Three rounds of subagent PR review completed — all feedback addressed**:
  - Round 1 (`f33ce21`): Fixed ~15 issues including output format mismatches, missing fields, incorrect claims
  - Round 2 (`1e89639`): Fixed contradictory `additionalProperties` claim and incomplete legacy URI syntax
  - Round 3 (post-`6f39b65`): Final accuracy check confirmed all items correct — no issues found

- [x] **Doc bug found and fixed during local testing** — path resolution claims in managing-skills.md and references.md incorrectly said "relative to air.json" when paths are actually relative to the index file's directory (`6f39b65`)

- [x] **Cross-references between guides are consistent** — all inter-guide links target existing files

- [x] **Code examples validated against source code** — hooks schema, roots schema, init CLI, list CLI output, GitHub URI format, env transform, path resolution logic all verified against actual implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)