### PR TITLE
feat: support repo-level @ref syntax in GitHub resolver URIs

### DIFF
--- a/packages/extensions/provider-github/README.md
+++ b/packages/extensions/provider-github/README.md
@@ -47,20 +47,23 @@ const artifacts = await resolveArtifacts("./air.json", {
 
 ```
 github://owner/repo/path/to/file.json
-github://owner/repo/path/to/file.json@ref
+github://owner/repo@ref/path/to/file.json
 ```
 
 | Component | Description |
 |-----------|-------------|
 | `owner` | GitHub organization or user |
 | `repo` | Repository name |
+| `@ref` | Optional git ref (branch, tag, commit SHA) — appended to the repo name |
 | `path` | Path to the JSON file within the repo |
-| `@ref` | Optional git ref (branch, tag, commit SHA) |
 
 Examples:
 - `github://acme/air-org/skills/skills.json` — latest from default branch
-- `github://acme/air-org/mcp/mcp.json@v1.0.0` — pinned to a tag
-- `github://acme/air-org/mcp/mcp.json@main` — explicit branch
+- `github://acme/air-org@v1.0.0/mcp/mcp.json` — pinned to a tag
+- `github://acme/air-org@main/mcp/mcp.json` — explicit branch
+- `github://acme/air-org@abc123/mcp/mcp.json` — pinned to a commit SHA
+
+The legacy syntax `github://owner/repo/path@ref` (ref at end of path) is also supported for backward compatibility.
 
 ## Authentication
 

--- a/packages/extensions/provider-github/src/github-provider.ts
+++ b/packages/extensions/provider-github/src/github-provider.ts
@@ -43,8 +43,15 @@ function validateUriComponent(value: string, label: string): void {
 /**
  * Parse a github:// URI into its components.
  *
- * Format: github://owner/repo/path/to/file.json
- * With ref: github://owner/repo/path/to/file.json@ref
+ * Supported formats:
+ *   github://owner/repo/path/to/file.json              — default branch
+ *   github://owner/repo@ref/path/to/file.json          — ref on repo (preferred)
+ *   github://owner/repo/path/to/file.json@ref          — ref on path (legacy)
+ *
+ * The repo-level syntax (owner/repo@ref) is preferred because it clearly
+ * separates the repository reference from the file path and avoids ambiguity
+ * when file paths contain "@" characters. The path-level syntax is supported
+ * for backward compatibility.
  */
 export function parseGitHubUri(uri: string): GitHubUri {
   const withoutScheme = uri.replace(/^github:\/\//, "");
@@ -52,20 +59,31 @@ export function parseGitHubUri(uri: string): GitHubUri {
 
   if (parts.length < 3) {
     throw new Error(
-      `Invalid github:// URI: "${uri}". Expected format: github://owner/repo/path/to/file.json`
+      `Invalid github:// URI: "${uri}". Expected format: github://owner/repo[@ref]/path/to/file.json`
     );
   }
 
   const owner = parts[0];
-  const repo = parts[1];
+  let repoSegment = parts[1];
+  let ref: string | undefined;
+
+  // Extract optional @ref from the repo segment (preferred syntax)
+  const repoAtIndex = repoSegment.indexOf("@");
+  if (repoAtIndex > 0) {
+    ref = repoSegment.slice(repoAtIndex + 1);
+    repoSegment = repoSegment.slice(0, repoAtIndex);
+  }
+
+  const repo = repoSegment;
   let filePath = parts.slice(2).join("/");
 
-  // Extract optional @ref from the last segment
-  let ref: string | undefined;
-  const atIndex = filePath.lastIndexOf("@");
-  if (atIndex > 0) {
-    ref = filePath.slice(atIndex + 1);
-    filePath = filePath.slice(0, atIndex);
+  // If no ref on repo, check for legacy @ref at the end of the path
+  if (!ref) {
+    const pathAtIndex = filePath.lastIndexOf("@");
+    if (pathAtIndex > 0) {
+      ref = filePath.slice(pathAtIndex + 1);
+      filePath = filePath.slice(0, pathAtIndex);
+    }
   }
 
   // Validate all components to prevent shell injection and path traversal

--- a/packages/extensions/provider-github/tests/github-provider.test.ts
+++ b/packages/extensions/provider-github/tests/github-provider.test.ts
@@ -18,7 +18,47 @@ describe("parseGitHubUri", () => {
     });
   });
 
-  it("parses URI with @ref", () => {
+  // --- repo-level @ref syntax (preferred) ---
+
+  it("parses URI with @ref on repo segment", () => {
+    const result = parseGitHubUri(
+      "github://acme/air-org@v1.0.0/mcp/mcp.json"
+    );
+    expect(result).toEqual({
+      owner: "acme",
+      repo: "air-org",
+      path: "mcp/mcp.json",
+      ref: "v1.0.0",
+    });
+  });
+
+  it("parses URI with branch ref on repo segment", () => {
+    const result = parseGitHubUri(
+      "github://pulsemcp/pulsemcp@main/agents/skills/skills.json"
+    );
+    expect(result).toEqual({
+      owner: "pulsemcp",
+      repo: "pulsemcp",
+      path: "agents/skills/skills.json",
+      ref: "main",
+    });
+  });
+
+  it("parses URI with commit SHA ref on repo segment", () => {
+    const result = parseGitHubUri(
+      "github://acme/repo@abc123/path/file.json"
+    );
+    expect(result).toEqual({
+      owner: "acme",
+      repo: "repo",
+      path: "path/file.json",
+      ref: "abc123",
+    });
+  });
+
+  // --- legacy path-level @ref syntax (backward compat) ---
+
+  it("parses URI with legacy @ref on path", () => {
     const result = parseGitHubUri(
       "github://acme/air-org/mcp/mcp.json@v1.0.0"
     );
@@ -30,7 +70,7 @@ describe("parseGitHubUri", () => {
     });
   });
 
-  it("parses URI with branch ref", () => {
+  it("parses URI with legacy branch ref on path", () => {
     const result = parseGitHubUri(
       "github://pulsemcp/pulsemcp/agents/skills/skills.json@main"
     );
@@ -42,6 +82,8 @@ describe("parseGitHubUri", () => {
     });
   });
 
+  // --- general parsing ---
+
   it("handles deeply nested paths", () => {
     const result = parseGitHubUri(
       "github://org/repo/a/b/c/d/file.json"
@@ -52,6 +94,20 @@ describe("parseGitHubUri", () => {
       path: "a/b/c/d/file.json",
     });
   });
+
+  it("handles deeply nested paths with repo-level ref", () => {
+    const result = parseGitHubUri(
+      "github://org/repo@develop/a/b/c/d/file.json"
+    );
+    expect(result).toEqual({
+      owner: "org",
+      repo: "repo",
+      path: "a/b/c/d/file.json",
+      ref: "develop",
+    });
+  });
+
+  // --- error cases ---
 
   it("throws on URI with too few segments", () => {
     expect(() => parseGitHubUri("github://acme/repo")).toThrow(
@@ -71,9 +127,15 @@ describe("parseGitHubUri", () => {
     );
   });
 
-  it("rejects path traversal in ref", () => {
+  it("rejects path traversal in ref on path", () => {
     expect(() =>
       parseGitHubUri("github://acme/repo/file.json@../../etc")
+    ).toThrow("Path traversal");
+  });
+
+  it("rejects path traversal in ref on repo", () => {
+    expect(() =>
+      parseGitHubUri("github://acme/repo@../../etc/file.json")
     ).toThrow("Path traversal");
   });
 
@@ -83,9 +145,15 @@ describe("parseGitHubUri", () => {
     ).toThrow("Invalid owner");
   });
 
-  it("rejects shell metacharacters in ref", () => {
+  it("rejects shell metacharacters in ref on path", () => {
     expect(() =>
       parseGitHubUri("github://acme/repo/file.json@main;rm -rf /")
+    ).toThrow("Invalid ref");
+  });
+
+  it("rejects shell metacharacters in ref on repo", () => {
+    expect(() =>
+      parseGitHubUri("github://acme/repo@main;rm -rf //file.json")
     ).toThrow("Invalid ref");
   });
 });


### PR DESCRIPTION
## Summary

- Adds `github://owner/repo@branch/path/to/file.json` as the preferred syntax for specifying a git ref (branch, tag, commit SHA) in GitHub resolver URIs
- Keeps backward compatibility with the existing `github://owner/repo/path/to/file.json@ref` syntax
- When no `@ref` is specified, continues defaulting to the repo's default branch (`HEAD`)

The repo-level syntax is preferred because it clearly separates the repository reference from the file path and avoids ambiguity when file paths happen to contain `@` characters.

### Examples

| URI | Ref | Path |
|-----|-----|------|
| `github://acme/repo/skills.json` | HEAD (default) | `skills.json` |
| `github://acme/repo@main/skills.json` | `main` | `skills.json` |
| `github://acme/repo@v1.0.0/mcp/mcp.json` | `v1.0.0` | `mcp/mcp.json` |
| `github://acme/repo/mcp/mcp.json@v1.0.0` | `v1.0.0` (legacy) | `mcp/mcp.json` |

### Changes

- **`github-provider.ts`**: Updated `parseGitHubUri()` to first check for `@ref` on the repo segment, then fall back to legacy `@ref` at end of path
- **`github-provider.test.ts`**: Added tests for repo-level `@ref` (branch, tag, SHA), deeply nested paths with ref, and security validation for the new syntax. Existing backward-compat tests preserved
- **`README.md`**: Updated URI format docs to show the preferred syntax, with a note about legacy support

## Verification

- [x] All 25 provider-github tests pass (new + existing)
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] Backward compatibility verified — existing URIs without `@ref` and with legacy path-level `@ref` continue to parse correctly
- [x] Security validation confirmed — path traversal and shell metacharacters rejected in both repo-level and path-level `@ref`
- [x] Self-review completed

### Test results (proof the change works)

```
 ✓ |@pulsemcp/air-provider-github| tests/github-provider.test.ts (25 tests) 2806ms
   ✓ parseGitHubUri > parses a basic github:// URI
   ✓ parseGitHubUri > parses URI with @ref on repo segment
   ✓ parseGitHubUri > parses URI with branch ref on repo segment
   ✓ parseGitHubUri > parses URI with commit SHA ref on repo segment
   ✓ parseGitHubUri > parses URI with legacy @ref on path
   ✓ parseGitHubUri > parses URI with legacy branch ref on path
   ✓ parseGitHubUri > handles deeply nested paths
   ✓ parseGitHubUri > handles deeply nested paths with repo-level ref
   ✓ parseGitHubUri > rejects path traversal in ref on repo
   ✓ parseGitHubUri > rejects shell metacharacters in ref on repo
   ... (25/25 passed)

 Test Files  1 passed (1)
      Tests  25 passed (25)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)