### PR TITLE
fix: improve error messages and edge case handling for @ref syntax

### DIFF
--- a/packages/extensions/provider-github/README.md
+++ b/packages/extensions/provider-github/README.md
@@ -62,8 +62,11 @@ Examples:
 - `github://acme/air-org@v1.0.0/mcp/mcp.json` — pinned to a tag
 - `github://acme/air-org@main/mcp/mcp.json` — explicit branch
 - `github://acme/air-org@abc123/mcp/mcp.json` — pinned to a commit SHA
+- `github://acme/air-org/mcp/mcp.json@feature/branch` — ref with slashes (use legacy syntax)
 
 The legacy syntax `github://owner/repo/path@ref` (ref at end of path) is also supported for backward compatibility.
+
+> **Note:** Refs containing slashes (e.g., `feature/branch`) cannot be expressed with the repo-level `@ref` syntax because the URI is split on `/`. Use the legacy path-level syntax for such refs.
 
 ## Authentication
 

--- a/packages/extensions/provider-github/src/github-provider.ts
+++ b/packages/extensions/provider-github/src/github-provider.ts
@@ -52,12 +52,23 @@ function validateUriComponent(value: string, label: string): void {
  * separates the repository reference from the file path and avoids ambiguity
  * when file paths contain "@" characters. The path-level syntax is supported
  * for backward compatibility.
+ *
+ * Note: refs containing slashes (e.g., feature/branch) cannot be expressed
+ * with the repo-level syntax because the URI is split on "/". Use the legacy
+ * path-level syntax for such refs: github://owner/repo/path@feature/branch
  */
 export function parseGitHubUri(uri: string): GitHubUri {
   const withoutScheme = uri.replace(/^github:\/\//, "");
   const parts = withoutScheme.split("/");
 
   if (parts.length < 3) {
+    // Detect repo@ref with no path for a more helpful error
+    if (parts.length === 2 && parts[1]?.includes("@")) {
+      throw new Error(
+        `Missing file path in github:// URI: "${uri}". ` +
+          `URI must include a path after the ref: github://owner/repo@ref/path/to/file.json`
+      );
+    }
     throw new Error(
       `Invalid github:// URI: "${uri}". Expected format: github://owner/repo[@ref]/path/to/file.json`
     );
@@ -72,6 +83,12 @@ export function parseGitHubUri(uri: string): GitHubUri {
   if (repoAtIndex > 0) {
     ref = repoSegment.slice(repoAtIndex + 1);
     repoSegment = repoSegment.slice(0, repoAtIndex);
+    if (ref.length === 0) {
+      throw new Error(
+        `Empty ref after "@" in github:// URI: "${uri}". ` +
+          `Either remove the "@" or specify a ref: github://owner/repo@ref/path`
+      );
+    }
   }
 
   const repo = repoSegment;
@@ -83,6 +100,15 @@ export function parseGitHubUri(uri: string): GitHubUri {
     if (pathAtIndex > 0) {
       ref = filePath.slice(pathAtIndex + 1);
       filePath = filePath.slice(0, pathAtIndex);
+    }
+  } else {
+    // Repo-level ref already found — reject if path also has @ref (ambiguous)
+    const pathAtIndex = filePath.lastIndexOf("@");
+    if (pathAtIndex > 0) {
+      throw new Error(
+        `Ambiguous github:// URI: "${uri}". ` +
+          `Ref specified on both repo ("@${ref}") and path. Use only one: github://owner/repo@ref/path`
+      );
     }
   }
 

--- a/packages/extensions/provider-github/tests/github-provider.test.ts
+++ b/packages/extensions/provider-github/tests/github-provider.test.ts
@@ -156,6 +156,36 @@ describe("parseGitHubUri", () => {
       parseGitHubUri("github://acme/repo@main;rm -rf //file.json")
     ).toThrow("Invalid ref");
   });
+
+  it("gives helpful error for repo@ref with no path", () => {
+    expect(() =>
+      parseGitHubUri("github://acme/repo@main")
+    ).toThrow("Missing file path");
+  });
+
+  it("rejects empty ref after @ on repo segment", () => {
+    expect(() =>
+      parseGitHubUri("github://acme/repo@/path/file.json")
+    ).toThrow('Empty ref after "@"');
+  });
+
+  it("rejects ambiguous double @ref on repo and path", () => {
+    expect(() =>
+      parseGitHubUri("github://acme/repo@v1/path/file.json@v2")
+    ).toThrow("Ambiguous");
+  });
+
+  it("handles ref with slashes via legacy path syntax", () => {
+    const result = parseGitHubUri(
+      "github://acme/repo/path/file.json@feature/branch"
+    );
+    expect(result).toEqual({
+      owner: "acme",
+      repo: "repo",
+      path: "path/file.json",
+      ref: "feature/branch",
+    });
+  });
 });
 
 describe("getCacheDir", () => {


### PR DESCRIPTION
## Summary

Follow-up to #33. Improves error messages and edge case handling for the `@ref` syntax in the GitHub resolver:

- **Better error for missing path**: `github://owner/repo@ref` (no file path) now gives a clear error explaining a path is required, instead of the generic "too few segments" error
- **Empty ref detection**: `github://owner/repo@/path` now throws "Empty ref after @" instead of a confusing validation error
- **Ambiguous double-ref rejection**: `github://acme/repo@v1/path@v2` is now explicitly rejected with an "Ambiguous" error instead of silently failing validation
- **Slash-in-ref documentation**: README and JSDoc now document that refs containing slashes (e.g., `feature/branch`) must use the legacy path-level syntax
- **4 new edge case tests** covering all the above scenarios

## Verification

- [x] All 29 provider-github tests pass (25 existing + 4 new edge case tests)
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] Backward compatibility verified — existing URIs still parse correctly
- [x] Self-review completed by subagent with fresh eyes; all MUST FIX and SHOULD FIX items addressed

### Test results (proof the change works)

```
 ✓ |@pulsemcp/air-provider-github| tests/github-provider.test.ts (29 tests) 2833ms
   ✓ parseGitHubUri > gives helpful error for repo@ref with no path
   ✓ parseGitHubUri > rejects empty ref after @ on repo segment
   ✓ parseGitHubUri > rejects ambiguous double @ref on repo and path
   ✓ parseGitHubUri > handles ref with slashes via legacy path syntax
   ... (29/29 passed)

 Test Files  1 passed (1)
      Tests  29 passed (29)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)