### PR TITLE
chore: normalize trailing-slash stripping in workflow globs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build extensions
         run: |
           for dir in packages/extensions/*/; do
-            npm run build -w "$dir"
+            npm run build -w "${dir%/}"
           done
 
       - name: Build SDK and CLI
@@ -44,7 +44,7 @@ jobs:
         run: |
           npx tsc --noEmit -p packages/core/tsconfig.json
           for dir in packages/extensions/*/; do
-            npx tsc --noEmit -p "${dir}tsconfig.json"
+            npx tsc --noEmit -p "${dir%/}/tsconfig.json"
           done
           npx tsc --noEmit -p packages/sdk/tsconfig.json
           npx tsc --noEmit -p packages/cli/tsconfig.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build extensions
         run: |
           for dir in packages/extensions/*/; do
-            npm run build -w "$dir"
+            npm run build -w "${dir%/}"
           done
 
       - name: Build SDK and CLI


### PR DESCRIPTION
## Summary

Follow-up to #31. Consistently use `${dir%/}` to strip the trailing slash from glob-expanded directory paths in all `for` loops across both CI and publish workflows.

PR #31 introduced `for dir in packages/extensions/*/` globs to auto-discover extension packages, but used `${dir%/}` (slash-stripped) in the publish step while leaving `$dir` (with trailing slash) in the build and type-check loops. Both work — npm and tsc handle trailing slashes fine — but the inconsistency is confusing.

## Changes

- `ci.yml`: build loop `$dir` → `${dir%/}`, type-check loop `${dir}tsconfig.json` → `${dir%/}/tsconfig.json`
- `publish.yml`: build loop `$dir` → `${dir%/}`

## Verification

- [x] Verified locally: cleaned all `dist/` dirs, rebuilt with the normalized paths, all 262 tests pass
- [x] CI green on this PR
- [x] Self-reviewed — change is purely cosmetic (3 lines, same behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)