### PR TITLE
feat: interactive TUI for air start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.15] - 2026-04-10
+
+### Added
+- Interactive terminal UI for `air start claude` with tab-based artifact browsing, per-item toggle, search filtering, and cross-artifact selection summary (#59)
+- `--skip-confirmation` flag to bypass TUI and launch agent directly
+- `--` passthrough args support to forward arguments to the agent process
+- Automatic TTY detection with non-interactive fallback
+
 ## [0.0.14] - 2026-04-09
 
 ### Fixed

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -15,8 +15,22 @@ air start claude
 1. Finds the adapter for the specified agent (e.g., `@pulsemcp/air-adapter-claude`)
 2. Resolves all artifacts from your `air.json`
 3. Checks if the agent CLI is available on your PATH
-4. Prints the session configuration summary
-5. Shows the command to launch the agent
+4. Opens an interactive TUI for browsing and selecting artifacts
+5. Prepares the session (writes `.mcp.json`, injects skills, etc.)
+6. Launches the agent
+
+### Interactive TUI
+
+When run in a TTY, `air start` opens an interactive terminal UI where you can:
+
+- **Browse artifact types** — use left/right arrows to switch between MCP, Skills, Hooks, and Plugins tabs
+- **Select/deselect artifacts** — use up/down arrows to navigate, Space to toggle, `a` for all, `n` for none, `o` for only current
+- **Search** — press `/` to filter items by name or description, Escape to clear
+- **Launch** — press Enter to start the agent with your selections, `q` or Ctrl+C to cancel
+
+The footer shows a cross-artifact selection summary so you can see what's selected across all tabs.
+
+When not in a TTY (e.g., in a CI pipeline) or when `--skip-confirmation` is passed, the TUI is skipped and the agent launches with root defaults.
 
 ### Options
 
@@ -26,7 +40,17 @@ Required argument: `<agent>` — the agent to start (e.g., `claude`).
 |------|-------------|
 | `--root <name>` | Activate a specific root |
 | `--dry-run` | Preview configuration without starting |
-| `--skip-confirmation` | Don't prompt for confirmation |
+| `--skip-confirmation` | Skip the interactive TUI and launch directly |
+
+### Passing arguments to the agent
+
+Use `--` to forward arguments to the agent process:
+
+```bash
+air start claude -- --dangerously-skip-permissions
+```
+
+Everything after `--` is passed directly to the agent's start command.
 
 ### Dry run
 
@@ -66,7 +90,7 @@ If you have [roots](roots.md) configured, activate one to scope the session:
 air start claude --root web-app
 ```
 
-This activates only the MCP servers, skills, plugins, and hooks listed in the root's defaults. Without `--root`, all artifacts are available.
+This activates only the MCP servers, skills, plugins, and hooks listed in the root's defaults. Without `--root`, `air start` auto-detects the root from the current directory's git context and pre-selects the root's defaults in the TUI.
 
 ## air prepare — programmatic sessions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air",
+  "name": "air-main-1775780737-3e033d42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -1203,9 +1203,9 @@
       "dev": true
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "dev": true,
       "funding": [
         {
@@ -1968,9 +1968,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.14",
+        "@pulsemcp/air-sdk": "0.0.15",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -1989,7 +1989,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -2005,9 +2005,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.14"
+        "@pulsemcp/air-core": "0.0.15"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2020,9 +2020,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.14"
+        "@pulsemcp/air-core": "0.0.15"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2035,9 +2035,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.14"
+        "@pulsemcp/air-core": "0.0.15"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2050,9 +2050,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.14"
+        "@pulsemcp/air-core": "0.0.15"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2065,9 +2065,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.14"
+        "@pulsemcp/air-core": "0.0.15"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1775776373-c017fe72",
+  "name": "air",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -14,13 +14,142 @@
         "vitest": "^2.1.0"
       }
     },
-    "node_modules/@esbuild/linux-x64": {
+    "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -29,10 +158,283 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
     },
     "node_modules/@pulsemcp/air-adapter-claude": {
       "resolved": "packages/extensions/adapter-claude",
@@ -62,13 +464,235 @@
       "resolved": "packages/extensions/secrets-file",
       "link": true
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
+    "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -76,33 +700,115 @@
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/spy": "2.1.9",
         "@vitest/utils": "2.1.9",
@@ -115,8 +821,9 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/spy": "2.1.9",
         "estree-walker": "^3.0.3",
@@ -140,8 +847,9 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^1.2.0"
       },
@@ -151,8 +859,9 @@
     },
     "node_modules/@vitest/runner": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/utils": "2.1.9",
         "pathe": "^1.1.2"
@@ -163,8 +872,9 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "2.1.9",
         "magic-string": "^0.30.12",
@@ -176,8 +886,9 @@
     },
     "node_modules/@vitest/spy": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tinyspy": "^3.0.2"
       },
@@ -187,8 +898,9 @@
     },
     "node_modules/@vitest/utils": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "2.1.9",
         "loupe": "^3.1.2",
@@ -200,7 +912,8 @@
     },
     "node_modules/ajv": {
       "version": "8.18.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -214,7 +927,8 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -229,24 +943,27 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/cac": {
       "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/chai": {
       "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -260,7 +977,8 @@
     },
     "node_modules/chalk": {
       "version": "5.6.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -270,23 +988,26 @@
     },
     "node_modules/check-error": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 16"
       }
     },
     "node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -301,22 +1022,25 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -351,26 +1075,31 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "funding": [
         {
           "type": "github",
@@ -380,13 +1109,27 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
+      ]
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
       ],
-      "license": "BSD-3-Clause"
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/get-tsconfig": {
       "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -396,28 +1139,34 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/loupe": {
       "version": "3.2.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -425,7 +1174,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -435,24 +1183,29 @@
     },
     "node_modules/pathe": {
       "version": "1.1.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
     },
     "node_modules/pathval": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
     },
     "node_modules/postcss": {
       "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -468,7 +1221,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -480,23 +1232,26 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rollup": {
       "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -538,65 +1293,75 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
     },
     "node_modules/std-env": {
       "version": "3.10.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
     },
     "node_modules/tinypool": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/tinyrainbow": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/tinyspy": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/tsx": {
       "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -611,13 +1376,142 @@
         "fsevents": "~2.3.3"
       }
     },
-    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -626,11 +1520,236 @@
         "node": ">=18"
       }
     },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tsx/node_modules/esbuild": {
       "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -668,8 +1787,9 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -680,13 +1800,15 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
     },
     "node_modules/vite": {
       "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -743,8 +1865,9 @@
     },
     "node_modules/vite-node": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.3.7",
@@ -764,8 +1887,9 @@
     },
     "node_modules/vitest": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -828,8 +1952,9 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.14",
+    "@pulsemcp/air-sdk": "0.0.15",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,9 +1,13 @@
+import { spawn } from "child_process";
 import { Command } from "commander";
 import {
   startSession,
+  prepareSession,
+  detectRoot,
   type ResolvedArtifacts,
   type RootEntry,
 } from "@pulsemcp/air-sdk";
+import { runInteractiveSelector } from "../tui/interactive-selector.js";
 
 export function startCommand(): Command {
   const cmd = new Command("start")
@@ -15,6 +19,7 @@ export function startCommand(): Command {
       "--skip-confirmation",
       "Don't prompt for confirmation before starting"
     )
+    .allowUnknownOption(true)
     .action(
       async (
         agent: string,
@@ -22,8 +27,12 @@ export function startCommand(): Command {
           root?: string;
           dryRun?: boolean;
           skipConfirmation?: boolean;
-        }
+        },
       ) => {
+        const dashDashIdx = process.argv.indexOf("--");
+        const passthroughArgs =
+          dashDashIdx !== -1 ? process.argv.slice(dashDashIdx + 1) : [];
+
         let result;
         try {
           result = await startSession(agent, {
@@ -37,9 +46,29 @@ export function startCommand(): Command {
           process.exit(1);
         }
 
+        // Auto-detect root if not specified
+        let root = result.root;
+        let rootId = options.root;
+        let rootAutoDetected = false;
+        if (!options.root && !root) {
+          root = detectRoot(result.artifacts.roots, process.cwd());
+          if (root) {
+            rootAutoDetected = true;
+            // Find the key for the detected root
+            rootId = Object.entries(result.artifacts.roots).find(
+              ([, v]) => v === root
+            )?.[0];
+          }
+        } else if (!options.root && root) {
+          rootAutoDetected = true;
+          rootId = Object.entries(result.artifacts.roots).find(
+            ([, v]) => v === root
+          )?.[0];
+        }
+
         // Dry run
         if (options.dryRun) {
-          printDryRun(agent, result.artifacts, result.root);
+          printDryRun(agent, result.artifacts, root);
           process.exit(0);
         }
 
@@ -51,12 +80,65 @@ export function startCommand(): Command {
           process.exit(1);
         }
 
-        printDryRun(agent, result.artifacts, result.root);
+        // Interactive TUI or skip
+        let selectedSkills: string[] | undefined;
+        let selectedMcpServers: string[] | undefined;
 
-        console.log(`\nStarting ${result.adapterDisplayName}...`);
-        console.log(
-          `Command: ${result.startCommand.command} ${result.startCommand.args.join(" ")}`
-        );
+        const isTTY = process.stdout.isTTY && process.stdin.isTTY;
+
+        if (isTTY && !options.skipConfirmation) {
+          const tuiResult = await runInteractiveSelector(
+            result.artifacts,
+            root,
+            rootId,
+            rootAutoDetected
+          );
+
+          if (!tuiResult) {
+            process.exit(0);
+          }
+
+          selectedSkills = tuiResult.skills;
+          selectedMcpServers = tuiResult.mcpServers;
+        }
+
+        // Prepare session (write .mcp.json, inject skills, etc.)
+        let prepared;
+        try {
+          prepared = await prepareSession({
+            root: rootId,
+            target: process.cwd(),
+            adapter: agent,
+            skills: selectedSkills,
+            mcpServers: selectedMcpServers,
+          });
+        } catch (err) {
+          const message =
+            err instanceof Error ? err.message : "Unknown error";
+          console.error(`Error preparing session: ${message}`);
+          process.exit(1);
+        }
+
+        // Spawn the agent
+        const startCmd = prepared.session.startCommand;
+        const args = [...startCmd.args, ...passthroughArgs];
+        const env = { ...process.env, ...startCmd.env };
+        const cwd = startCmd.cwd || process.cwd();
+
+        const child = spawn(startCmd.command, args, {
+          stdio: "inherit",
+          env,
+          cwd,
+        });
+
+        child.on("error", (err) => {
+          console.error(`Failed to start ${agent}: ${err.message}`);
+          process.exit(1);
+        });
+
+        child.on("exit", (code) => {
+          process.exit(code ?? 0);
+        });
       }
     );
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -46,24 +46,19 @@ export function startCommand(): Command {
           process.exit(1);
         }
 
-        // Auto-detect root if not specified
+        // Resolve root: use explicit option, fall back to auto-detection
         let root = result.root;
         let rootId = options.root;
         let rootAutoDetected = false;
-        if (!options.root && !root) {
-          root = detectRoot(result.artifacts.roots, process.cwd());
-          if (root) {
+        if (!options.root) {
+          const detected = detectRoot(result.artifacts.roots, process.cwd());
+          if (detected) {
+            root = detected;
             rootAutoDetected = true;
-            // Find the key for the detected root
             rootId = Object.entries(result.artifacts.roots).find(
-              ([, v]) => v === root
+              ([, v]) => v === detected
             )?.[0];
           }
-        } else if (!options.root && root) {
-          rootAutoDetected = true;
-          rootId = Object.entries(result.artifacts.roots).find(
-            ([, v]) => v === root
-          )?.[0];
         }
 
         // Dry run

--- a/packages/cli/src/tui/interactive-selector.ts
+++ b/packages/cli/src/tui/interactive-selector.ts
@@ -29,7 +29,7 @@ function padLine(line: string, width: number): string {
  * alternate screen buffer so the main scrollback is untouched.
  */
 function draw(state: TuiState): void {
-  const viewportHeight = getViewportHeight();
+  const viewportHeight = getViewportHeight(state.tabs.length);
   const lines = render(state, viewportHeight);
   const cols = process.stdout.columns || 80;
   const rows = process.stdout.rows || 24;
@@ -52,7 +52,7 @@ function clampScroll(state: TuiState): void {
   const cat = state.tabs[state.activeTab];
   if (!cat) return;
   const visible = getVisibleItems(state);
-  const viewportHeight = getViewportHeight();
+  const viewportHeight = getViewportHeight(state.tabs.length);
 
   if (state.cursors[cat] >= visible.length) {
     state.cursors[cat] = Math.max(0, visible.length - 1);
@@ -92,24 +92,37 @@ export async function runInteractiveSelector(
     process.stdout.write("\x1B[?1049h");
     draw(state);
 
+    const onResize = () => draw(state);
+    process.stdout.on("resize", onResize);
+
     const cleanup = () => {
       process.stdin.removeListener("keypress", onKeypress);
+      process.stdout.removeListener("resize", onResize);
+      process.removeListener("SIGTERM", onSignal);
+      process.removeListener("SIGHUP", onSignal);
       process.stdin.setRawMode(wasRaw ?? false);
       process.stdin.pause();
       // Leave alternate screen buffer — restores original terminal content
       process.stdout.write("\x1B[?25h\x1B[?1049l");
     };
 
+    const onSignal = () => {
+      cleanup();
+      resolve(null);
+    };
+    process.on("SIGTERM", onSignal);
+    process.on("SIGHUP", onSignal);
+
     const onKeypress = (
       str: string | undefined,
       key: readline.Key
     ) => {
+      try {
       if (!key) return;
 
       const activeCat = state.tabs[state.activeTab];
-      const isOverridable = activeCat
-        ? OVERRIDABLE_CATEGORIES.has(activeCat)
-        : false;
+      if (!activeCat) return;
+      const isOverridable = OVERRIDABLE_CATEGORIES.has(activeCat);
 
       // ── Search mode input handling ──
       if (state.searchActive) {
@@ -270,6 +283,10 @@ export async function runInteractiveSelector(
         items[idx].selected = true;
         draw(state);
         return;
+      }
+      } catch {
+        cleanup();
+        resolve(null);
       }
     };
 

--- a/packages/cli/src/tui/interactive-selector.ts
+++ b/packages/cli/src/tui/interactive-selector.ts
@@ -1,0 +1,278 @@
+import * as readline from "readline";
+import type { ResolvedArtifacts, RootEntry } from "@pulsemcp/air-sdk";
+import {
+  buildInitialState,
+  getSelectedIds,
+  getVisibleItems,
+  OVERRIDABLE_CATEGORIES,
+  type TuiResult,
+  type TuiState,
+} from "./types.js";
+import { render, getViewportHeight } from "./render.js";
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1B\[[0-9;]*[A-Za-z]/g;
+
+function visibleLength(s: string): number {
+  return s.replace(ANSI_RE, "").length;
+}
+
+function padLine(line: string, width: number): string {
+  const vl = visibleLength(line);
+  if (vl >= width) return line;
+  return line + " ".repeat(width - vl);
+}
+
+/**
+ * Render the full frame using absolute cursor positioning for every line.
+ * No \n, no clears — just direct row,col placement. Runs inside the
+ * alternate screen buffer so the main scrollback is untouched.
+ */
+function draw(state: TuiState): void {
+  const viewportHeight = getViewportHeight();
+  const lines = render(state, viewportHeight);
+  const cols = process.stdout.columns || 80;
+  const rows = process.stdout.rows || 24;
+
+  let buf = "\x1B[?25l"; // hide cursor
+
+  // Fill every terminal row: content lines, then blank padding
+  for (let row = 0; row < rows; row++) {
+    const line = row < lines.length ? lines[row] : "";
+    // Absolute move to row+1, col 1 (1-indexed)
+    buf += `\x1B[${row + 1};1H` + padLine(line, cols);
+  }
+
+  buf += "\x1B[?25h"; // show cursor
+  process.stdout.write(buf);
+}
+
+/** Keep cursor within visible items and adjust scroll offset */
+function clampScroll(state: TuiState): void {
+  const cat = state.tabs[state.activeTab];
+  if (!cat) return;
+  const visible = getVisibleItems(state);
+  const viewportHeight = getViewportHeight();
+
+  if (state.cursors[cat] >= visible.length) {
+    state.cursors[cat] = Math.max(0, visible.length - 1);
+  }
+  if (state.cursors[cat] < 0) {
+    state.cursors[cat] = 0;
+  }
+
+  const cursor = state.cursors[cat];
+  if (cursor < state.scrollOffsets[cat]) {
+    state.scrollOffsets[cat] = cursor;
+  }
+  if (cursor >= state.scrollOffsets[cat] + viewportHeight) {
+    state.scrollOffsets[cat] = cursor - viewportHeight + 1;
+  }
+}
+
+export async function runInteractiveSelector(
+  artifacts: ResolvedArtifacts,
+  root?: RootEntry,
+  rootId?: string,
+  rootAutoDetected = false
+): Promise<TuiResult | null> {
+  const state = buildInitialState(artifacts, root, rootId, rootAutoDetected);
+
+  if (state.tabs.length === 0) {
+    return getSelectedIds(state);
+  }
+
+  return new Promise<TuiResult | null>((resolve) => {
+    readline.emitKeypressEvents(process.stdin);
+    const wasRaw = process.stdin.isRaw;
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+
+    // Switch to alternate screen buffer (like vim/htop)
+    process.stdout.write("\x1B[?1049h");
+    draw(state);
+
+    const cleanup = () => {
+      process.stdin.removeListener("keypress", onKeypress);
+      process.stdin.setRawMode(wasRaw ?? false);
+      process.stdin.pause();
+      // Leave alternate screen buffer — restores original terminal content
+      process.stdout.write("\x1B[?25h\x1B[?1049l");
+    };
+
+    const onKeypress = (
+      str: string | undefined,
+      key: readline.Key
+    ) => {
+      if (!key) return;
+
+      const activeCat = state.tabs[state.activeTab];
+      const isOverridable = activeCat
+        ? OVERRIDABLE_CATEGORIES.has(activeCat)
+        : false;
+
+      // ── Search mode input handling ──
+      if (state.searchActive) {
+        if (key.name === "escape") {
+          state.searchActive = false;
+          state.searchQuery = "";
+          state.cursors[activeCat] = 0;
+          state.scrollOffsets[activeCat] = 0;
+          clampScroll(state);
+          draw(state);
+          return;
+        }
+        if (key.name === "return") {
+          state.searchActive = false;
+          const visible = getVisibleItems(state);
+          if (visible.length > 0) {
+            const targetId = visible[state.cursors[activeCat]]?.id;
+            state.searchQuery = "";
+            if (targetId) {
+              const fullIdx = state.items[activeCat].findIndex(
+                (i) => i.id === targetId
+              );
+              if (fullIdx !== -1) state.cursors[activeCat] = fullIdx;
+            }
+          } else {
+            state.searchQuery = "";
+          }
+          state.scrollOffsets[activeCat] = 0;
+          clampScroll(state);
+          draw(state);
+          return;
+        }
+        if (key.name === "backspace") {
+          state.searchQuery = state.searchQuery.slice(0, -1);
+          state.cursors[activeCat] = 0;
+          state.scrollOffsets[activeCat] = 0;
+          clampScroll(state);
+          draw(state);
+          return;
+        }
+        if (key.name === "up" || key.name === "down") {
+          const visible = getVisibleItems(state);
+          if (visible.length > 0) {
+            const cursor = state.cursors[activeCat];
+            if (key.name === "up") {
+              state.cursors[activeCat] =
+                (cursor - 1 + visible.length) % visible.length;
+            } else {
+              state.cursors[activeCat] = (cursor + 1) % visible.length;
+            }
+            clampScroll(state);
+          }
+          draw(state);
+          return;
+        }
+        if (key.name === "space" && isOverridable) {
+          const visible = getVisibleItems(state);
+          const cursor = state.cursors[activeCat];
+          if (visible[cursor]) {
+            const targetId = visible[cursor].id;
+            const item = state.items[activeCat].find(
+              (i) => i.id === targetId
+            );
+            if (item) item.selected = !item.selected;
+          }
+          draw(state);
+          return;
+        }
+        if (str && str.length === 1 && !key.ctrl && !key.meta) {
+          state.searchQuery += str;
+          state.cursors[activeCat] = 0;
+          state.scrollOffsets[activeCat] = 0;
+          clampScroll(state);
+          draw(state);
+          return;
+        }
+        draw(state);
+        return;
+      }
+
+      // ── Normal mode ──
+
+      if (key.name === "q" || (key.ctrl && key.name === "c")) {
+        cleanup();
+        resolve(null);
+        return;
+      }
+
+      if (key.name === "return") {
+        cleanup();
+        resolve(getSelectedIds(state));
+        return;
+      }
+
+      if (str === "/") {
+        state.searchActive = true;
+        state.searchQuery = "";
+        state.cursors[activeCat] = 0;
+        state.scrollOffsets[activeCat] = 0;
+        draw(state);
+        return;
+      }
+
+      if (key.name === "left") {
+        state.activeTab =
+          (state.activeTab - 1 + state.tabs.length) % state.tabs.length;
+        clampScroll(state);
+        draw(state);
+        return;
+      }
+      if (key.name === "right") {
+        state.activeTab = (state.activeTab + 1) % state.tabs.length;
+        clampScroll(state);
+        draw(state);
+        return;
+      }
+
+      const items = state.items[activeCat];
+      if (key.name === "up" && items.length > 0) {
+        state.cursors[activeCat] =
+          (state.cursors[activeCat] - 1 + items.length) % items.length;
+        clampScroll(state);
+        draw(state);
+        return;
+      }
+      if (key.name === "down" && items.length > 0) {
+        state.cursors[activeCat] =
+          (state.cursors[activeCat] + 1) % items.length;
+        clampScroll(state);
+        draw(state);
+        return;
+      }
+
+      if (!isOverridable) return;
+
+      if (key.name === "space" && items.length > 0) {
+        const idx = state.cursors[activeCat];
+        items[idx].selected = !items[idx].selected;
+        draw(state);
+        return;
+      }
+
+      if (str === "a") {
+        for (const item of items) item.selected = true;
+        draw(state);
+        return;
+      }
+
+      if (str === "n") {
+        for (const item of items) item.selected = false;
+        draw(state);
+        return;
+      }
+
+      if (str === "o" && items.length > 0) {
+        const idx = state.cursors[activeCat];
+        for (const item of items) item.selected = false;
+        items[idx].selected = true;
+        draw(state);
+        return;
+      }
+    };
+
+    process.stdin.on("keypress", onKeypress);
+  });
+}

--- a/packages/cli/src/tui/render.ts
+++ b/packages/cli/src/tui/render.ts
@@ -7,13 +7,16 @@ import {
   getAllSelectionSummary,
 } from "./types.js";
 
-/** Number of fixed lines: header(3) + tab bar(2) + footer(varies) */
+/** Number of fixed lines: header(3) + tab bar(2) */
 const HEADER_LINES = 5;
-const FOOTER_LINES = 8; // search + separator + summary lines + legend + padding
+/** Fixed footer lines: scroll indicator(1) + search bar(1) + separator(1) + legend blank(1) + legend(1) + trailing blank(1) = 6 */
+const FIXED_FOOTER_LINES = 6;
 
-export function getViewportHeight(): number {
+export function getViewportHeight(tabCount: number): number {
   const rows = process.stdout.rows || 24;
-  return Math.max(rows - HEADER_LINES - FOOTER_LINES, 3);
+  // Footer varies: 6 fixed lines + one summary line per tab
+  const footerLines = FIXED_FOOTER_LINES + tabCount;
+  return Math.max(rows - HEADER_LINES - footerLines, 3);
 }
 
 export function render(state: TuiState, viewportHeight: number): string[] {
@@ -40,10 +43,8 @@ export function render(state: TuiState, viewportHeight: number): string[] {
 
     if (i === state.activeTab) {
       tabParts.push(chalk.bold.inverse(` ${label} (${countStr}) `));
-    } else if (!isOverridable) {
-      tabParts.push(chalk.dim(` ${label} (${countStr}) `));
     } else {
-      tabParts.push(chalk.dim(` ${label}`) + chalk.dim(` (${countStr}) `));
+      tabParts.push(chalk.dim(` ${label} (${countStr}) `));
     }
   }
   lines.push("  " + tabParts.join(" "));
@@ -59,7 +60,7 @@ export function render(state: TuiState, viewportHeight: number): string[] {
   const scrollOffset = activeCat ? state.scrollOffsets[activeCat] : 0;
 
   if (activeCat && !isOverridable) {
-    lines.push(chalk.dim("  (read-only — override not yet supported)"));
+    lines.push(chalk.dim("  (read-only \u2014 override not yet supported)"));
   }
 
   if (visibleItems.length === 0) {
@@ -119,10 +120,10 @@ export function render(state: TuiState, viewportHeight: number): string[] {
       lines.push(`  ${prefix} ${chalk.dim(label)}: ${chalk.dim("(none)")}`);
     } else {
       const ids = s.selected.join(", ");
-      const availableWidth = maxWidth - label.length - 6;
+      const availableWidth = Math.max(maxWidth - label.length - 6, 0);
       const display =
         ids.length > availableWidth
-          ? ids.slice(0, availableWidth - 3) + "..."
+          ? ids.slice(0, Math.max(availableWidth - 3, 0)) + "..."
           : ids;
       lines.push(`  ${prefix} ${chalk.white(label)}: ${chalk.green(display)}`);
     }
@@ -163,7 +164,7 @@ function renderItem(
   let id: string;
   let desc: string;
   if (!isOverridable) {
-    id = item.selected ? chalk.dim(item.id) : chalk.dim(item.id);
+    id = chalk.dim(item.id);
     desc = chalk.dim(` — ${truncate(item.description, 60)}`);
   } else if (item.selected) {
     id = chalk.white(item.id);

--- a/packages/cli/src/tui/render.ts
+++ b/packages/cli/src/tui/render.ts
@@ -1,0 +1,182 @@
+import chalk from "chalk";
+import type { TuiState, ArtifactItem } from "./types.js";
+import {
+  CATEGORY_LABELS,
+  OVERRIDABLE_CATEGORIES,
+  getVisibleItems,
+  getAllSelectionSummary,
+} from "./types.js";
+
+/** Number of fixed lines: header(3) + tab bar(2) + footer(varies) */
+const HEADER_LINES = 5;
+const FOOTER_LINES = 8; // search + separator + summary lines + legend + padding
+
+export function getViewportHeight(): number {
+  const rows = process.stdout.rows || 24;
+  return Math.max(rows - HEADER_LINES - FOOTER_LINES, 3);
+}
+
+export function render(state: TuiState, viewportHeight: number): string[] {
+  const lines: string[] = [];
+
+  // ── Header ──
+  lines.push("");
+  const rootLabel = state.root?.display_name || state.rootId || "unknown";
+  const rootInfo = state.root
+    ? `${rootLabel}${state.rootAutoDetected ? chalk.dim(" (auto-detected)") : ""}`
+    : "none";
+  lines.push(`  AIR Session ${chalk.dim("—")} Root: ${chalk.cyan(rootInfo)}`);
+  lines.push("");
+
+  // ── Tab bar ──
+  const tabParts: string[] = [];
+  for (let i = 0; i < state.tabs.length; i++) {
+    const cat = state.tabs[i];
+    const label = CATEGORY_LABELS[cat];
+    const items = state.items[cat];
+    const selectedCount = items.filter((it) => it.selected).length;
+    const countStr = `${selectedCount}/${items.length}`;
+    const isOverridable = OVERRIDABLE_CATEGORIES.has(cat);
+
+    if (i === state.activeTab) {
+      tabParts.push(chalk.bold.inverse(` ${label} (${countStr}) `));
+    } else if (!isOverridable) {
+      tabParts.push(chalk.dim(` ${label} (${countStr}) `));
+    } else {
+      tabParts.push(chalk.dim(` ${label}`) + chalk.dim(` (${countStr}) `));
+    }
+  }
+  lines.push("  " + tabParts.join(" "));
+  lines.push("");
+
+  // ── Item list (scrollable viewport) ──
+  const activeCat = state.tabs[state.activeTab];
+  const isOverridable = activeCat
+    ? OVERRIDABLE_CATEGORIES.has(activeCat)
+    : false;
+  const visibleItems = getVisibleItems(state);
+  const cursor = activeCat ? state.cursors[activeCat] : 0;
+  const scrollOffset = activeCat ? state.scrollOffsets[activeCat] : 0;
+
+  if (activeCat && !isOverridable) {
+    lines.push(chalk.dim("  (read-only — override not yet supported)"));
+  }
+
+  if (visibleItems.length === 0) {
+    if (state.searchActive && state.searchQuery) {
+      lines.push(chalk.dim("  No matches"));
+    } else {
+      lines.push(chalk.dim("  (no items)"));
+    }
+    // Pad remaining viewport
+    for (let i = 1; i < viewportHeight; i++) {
+      lines.push("");
+    }
+  } else {
+    const end = Math.min(scrollOffset + viewportHeight, visibleItems.length);
+    const start = scrollOffset;
+
+    for (let i = start; i < end; i++) {
+      const item = visibleItems[i];
+      lines.push(renderItem(item, i === cursor, isOverridable));
+    }
+    // Pad remaining viewport lines
+    for (let i = end - start; i < viewportHeight; i++) {
+      lines.push("");
+    }
+
+    // Scroll indicator
+    if (visibleItems.length > viewportHeight) {
+      const pct = Math.round(
+        ((scrollOffset + viewportHeight) / visibleItems.length) * 100
+      );
+      lines.push(
+        chalk.dim(`  ── ${scrollOffset + 1}-${end} of ${visibleItems.length} (${pct}%) ──`)
+      );
+    } else {
+      lines.push("");
+    }
+  }
+
+  // ── Search bar ──
+  if (state.searchActive) {
+    lines.push(`  ${chalk.cyan("/")}${state.searchQuery}${chalk.cyan("█")}`);
+  } else {
+    lines.push("");
+  }
+
+  // ── Cross-artifact selection summary ──
+  lines.push(chalk.dim("  ─────────────────────────────────────────"));
+  const summaries = getAllSelectionSummary(state);
+  const maxWidth = (process.stdout.columns || 80) - 4;
+
+  for (const s of summaries) {
+    const isActive = s.category === activeCat;
+    const prefix = isActive ? chalk.cyan("▸") : " ";
+    const label = `${s.label} (${s.selected.length}/${s.total})`;
+
+    if (s.selected.length === 0) {
+      lines.push(`  ${prefix} ${chalk.dim(label)}: ${chalk.dim("(none)")}`);
+    } else {
+      const ids = s.selected.join(", ");
+      const availableWidth = maxWidth - label.length - 6;
+      const display =
+        ids.length > availableWidth
+          ? ids.slice(0, availableWidth - 3) + "..."
+          : ids;
+      lines.push(`  ${prefix} ${chalk.white(label)}: ${chalk.green(display)}`);
+    }
+  }
+
+  // ── Key legend ──
+  lines.push("");
+  const legendParts = [
+    `${chalk.dim("←→")} tabs`,
+    `${chalk.dim("↑↓")} navigate`,
+  ];
+  if (isOverridable) {
+    legendParts.push(
+      `${chalk.dim("Space")} toggle`,
+      `${chalk.dim("a")} all`,
+      `${chalk.dim("n")} none`,
+      `${chalk.dim("o")} only`
+    );
+  }
+  legendParts.push(
+    `${chalk.dim("/")} search`,
+    `${chalk.dim("Enter")} start`,
+    `${chalk.dim("q")} quit`
+  );
+  lines.push("  " + legendParts.join("  "));
+  lines.push("");
+
+  return lines;
+}
+
+function renderItem(
+  item: ArtifactItem,
+  isCursor: boolean,
+  isOverridable: boolean
+): string {
+  const marker = item.selected ? chalk.green("●") : chalk.dim("○");
+
+  let id: string;
+  let desc: string;
+  if (!isOverridable) {
+    id = item.selected ? chalk.dim(item.id) : chalk.dim(item.id);
+    desc = chalk.dim(` — ${truncate(item.description, 60)}`);
+  } else if (item.selected) {
+    id = chalk.white(item.id);
+    desc = chalk.dim(` — ${truncate(item.description, 60)}`);
+  } else {
+    id = chalk.dim(item.id);
+    desc = chalk.dim(` — ${truncate(item.description, 60)}`);
+  }
+
+  const prefix = isCursor ? chalk.cyan("> ") : "  ";
+  return `${prefix}${marker} ${id}${desc}`;
+}
+
+function truncate(str: string, maxLen: number): string {
+  return str.length > maxLen ? str.slice(0, maxLen - 1) + "…" : str;
+}

--- a/packages/cli/src/tui/types.ts
+++ b/packages/cli/src/tui/types.ts
@@ -1,0 +1,128 @@
+import type { ResolvedArtifacts, RootEntry } from "@pulsemcp/air-sdk";
+
+export type ArtifactCategory = "mcp" | "skills" | "hooks" | "plugins";
+
+export interface ArtifactItem {
+  id: string;
+  description: string;
+  selected: boolean;
+}
+
+export interface TuiState {
+  tabs: ArtifactCategory[];
+  activeTab: number;
+  items: Record<ArtifactCategory, ArtifactItem[]>;
+  cursors: Record<ArtifactCategory, number>;
+  /** Scroll offset per tab (index of top visible item) */
+  scrollOffsets: Record<ArtifactCategory, number>;
+  root?: RootEntry;
+  /** The key of the root in artifacts.roots */
+  rootId?: string;
+  rootAutoDetected: boolean;
+  /** Search/filter mode */
+  searchActive: boolean;
+  searchQuery: string;
+}
+
+export interface TuiResult {
+  mcpServers: string[];
+  skills: string[];
+}
+
+/** Categories where prepareSession supports override arrays */
+export const OVERRIDABLE_CATEGORIES: Set<ArtifactCategory> = new Set([
+  "mcp",
+  "skills",
+]);
+
+export const CATEGORY_LABELS: Record<ArtifactCategory, string> = {
+  mcp: "MCP",
+  skills: "Skills",
+  hooks: "Hooks",
+  plugins: "Plugins",
+};
+
+/** Get items for the active tab, filtered by search query if active */
+export function getVisibleItems(state: TuiState): ArtifactItem[] {
+  const cat = state.tabs[state.activeTab];
+  if (!cat) return [];
+  const items = state.items[cat];
+  if (!state.searchActive || !state.searchQuery) return items;
+  const q = state.searchQuery.toLowerCase();
+  return items.filter(
+    (item) =>
+      item.id.toLowerCase().includes(q) ||
+      item.description.toLowerCase().includes(q)
+  );
+}
+
+export function buildInitialState(
+  artifacts: ResolvedArtifacts,
+  root?: RootEntry,
+  rootId?: string,
+  rootAutoDetected = false
+): TuiState {
+  const buildItems = (
+    entries: Record<string, { description?: string; title?: string }>,
+    defaults?: string[]
+  ): ArtifactItem[] => {
+    const defaultSet = defaults ? new Set(defaults) : null;
+    return Object.entries(entries)
+      .map(([id, entry]) => ({
+        id,
+        description: entry.description || entry.title || "(no description)",
+        selected: defaultSet ? defaultSet.has(id) : false,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id));
+  };
+
+  const items: Record<ArtifactCategory, ArtifactItem[]> = {
+    mcp: buildItems(artifacts.mcp, root?.default_mcp_servers),
+    skills: buildItems(artifacts.skills, root?.default_skills),
+    hooks: buildItems(artifacts.hooks, root?.default_hooks),
+    plugins: buildItems(artifacts.plugins, root?.default_plugins),
+  };
+
+  const tabs = (
+    ["mcp", "skills", "hooks", "plugins"] as ArtifactCategory[]
+  ).filter((cat) => items[cat].length > 0);
+
+  const cursors = { mcp: 0, skills: 0, hooks: 0, plugins: 0 };
+  const scrollOffsets = { mcp: 0, skills: 0, hooks: 0, plugins: 0 };
+
+  return {
+    tabs,
+    activeTab: 0,
+    items,
+    cursors,
+    scrollOffsets,
+    root,
+    rootId,
+    rootAutoDetected,
+    searchActive: false,
+    searchQuery: "",
+  };
+}
+
+export function getSelectedIds(state: TuiState): TuiResult {
+  return {
+    mcpServers: state.items.mcp
+      .filter((i) => i.selected)
+      .map((i) => i.id),
+    skills: state.items.skills
+      .filter((i) => i.selected)
+      .map((i) => i.id),
+  };
+}
+
+/** Get selection summary across all artifact types */
+export function getAllSelectionSummary(
+  state: TuiState
+): { category: ArtifactCategory; label: string; selected: string[]; total: number }[] {
+  return state.tabs.map((cat) => ({
+    category: cat,
+    label: CATEGORY_LABELS[cat],
+    selected: state.items[cat].filter((i) => i.selected).map((i) => i.id),
+    total: state.items[cat].length,
+  }));
+}

--- a/packages/cli/tests/tui-state.test.ts
+++ b/packages/cli/tests/tui-state.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect } from "vitest";
+import type { ResolvedArtifacts } from "@pulsemcp/air-sdk";
+import {
+  buildInitialState,
+  getSelectedIds,
+  getVisibleItems,
+  getAllSelectionSummary,
+} from "../src/tui/types.js";
+
+function makeArtifacts(
+  overrides: Partial<ResolvedArtifacts> = {}
+): ResolvedArtifacts {
+  return {
+    skills: {},
+    references: {},
+    mcp: {},
+    plugins: {},
+    roots: {},
+    hooks: {},
+    ...overrides,
+  };
+}
+
+describe("buildInitialState", () => {
+  it("returns empty tabs when all artifact categories are empty", () => {
+    const state = buildInitialState(makeArtifacts());
+    expect(state.tabs).toEqual([]);
+    expect(state.items.mcp).toEqual([]);
+    expect(state.items.skills).toEqual([]);
+  });
+
+  it("includes only non-empty categories as tabs", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          server1: {
+            type: "stdio",
+            command: "node",
+            description: "A server",
+          },
+        },
+        skills: {
+          skill1: { description: "A skill", path: "/skills/skill1" },
+        },
+      })
+    );
+    expect(state.tabs).toEqual(["mcp", "skills"]);
+    expect(state.items.hooks).toEqual([]);
+    expect(state.items.plugins).toEqual([]);
+  });
+
+  it("selects items matching root defaults", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          server1: {
+            type: "stdio",
+            command: "node",
+            description: "Server 1",
+          },
+          server2: {
+            type: "stdio",
+            command: "node",
+            description: "Server 2",
+          },
+        },
+      }),
+      {
+        description: "Test root",
+        default_mcp_servers: ["server1"],
+      }
+    );
+    expect(state.items.mcp.find((i) => i.id === "server1")?.selected).toBe(
+      true
+    );
+    expect(state.items.mcp.find((i) => i.id === "server2")?.selected).toBe(
+      false
+    );
+  });
+
+  it("ignores default IDs that don't exist in artifacts", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          server1: {
+            type: "stdio",
+            command: "node",
+            description: "Server 1",
+          },
+        },
+      }),
+      {
+        description: "Test root",
+        default_mcp_servers: ["server1", "nonexistent"],
+      }
+    );
+    expect(state.items.mcp).toHaveLength(1);
+    expect(state.items.mcp[0].selected).toBe(true);
+  });
+
+  it("sorts items alphabetically by ID", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        skills: {
+          zebra: { description: "Z skill", path: "/skills/zebra" },
+          alpha: { description: "A skill", path: "/skills/alpha" },
+          middle: { description: "M skill", path: "/skills/middle" },
+        },
+      })
+    );
+    expect(state.items.skills.map((i) => i.id)).toEqual([
+      "alpha",
+      "middle",
+      "zebra",
+    ]);
+  });
+
+  it("stores root metadata", () => {
+    const root = { description: "My root", display_name: "My Root" };
+    const state = buildInitialState(makeArtifacts(), root, "my-root", true);
+    expect(state.root).toBe(root);
+    expect(state.rootId).toBe("my-root");
+    expect(state.rootAutoDetected).toBe(true);
+  });
+});
+
+describe("getVisibleItems", () => {
+  it("returns all items when search is inactive", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          server1: {
+            type: "stdio",
+            command: "node",
+            description: "Server 1",
+          },
+          server2: {
+            type: "stdio",
+            command: "node",
+            description: "Server 2",
+          },
+        },
+      })
+    );
+    expect(getVisibleItems(state)).toHaveLength(2);
+  });
+
+  it("filters items by search query matching ID", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          "my-server": {
+            type: "stdio",
+            command: "node",
+            description: "First",
+          },
+          "other-thing": {
+            type: "stdio",
+            command: "node",
+            description: "Second",
+          },
+        },
+      })
+    );
+    state.searchActive = true;
+    state.searchQuery = "server";
+    expect(getVisibleItems(state)).toHaveLength(1);
+    expect(getVisibleItems(state)[0].id).toBe("my-server");
+  });
+
+  it("filters items by search query matching description", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          a: { type: "stdio", command: "node", description: "Database proxy" },
+          b: { type: "stdio", command: "node", description: "File watcher" },
+        },
+      })
+    );
+    state.searchActive = true;
+    state.searchQuery = "database";
+    expect(getVisibleItems(state)).toHaveLength(1);
+    expect(getVisibleItems(state)[0].id).toBe("a");
+  });
+
+  it("returns all items when search is active but query is empty", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          a: { type: "stdio", command: "node", description: "Server A" },
+          b: { type: "stdio", command: "node", description: "Server B" },
+        },
+      })
+    );
+    state.searchActive = true;
+    state.searchQuery = "";
+    expect(getVisibleItems(state)).toHaveLength(2);
+  });
+
+  it("returns empty array when no tabs exist", () => {
+    const state = buildInitialState(makeArtifacts());
+    expect(getVisibleItems(state)).toEqual([]);
+  });
+});
+
+describe("getSelectedIds", () => {
+  it("returns only selected MCP servers and skills", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          server1: {
+            type: "stdio",
+            command: "node",
+            description: "Server 1",
+          },
+          server2: {
+            type: "stdio",
+            command: "node",
+            description: "Server 2",
+          },
+        },
+        skills: {
+          skill1: { description: "Skill 1", path: "/skills/skill1" },
+          skill2: { description: "Skill 2", path: "/skills/skill2" },
+        },
+      }),
+      {
+        description: "Root",
+        default_mcp_servers: ["server1"],
+        default_skills: ["skill2"],
+      }
+    );
+    const result = getSelectedIds(state);
+    expect(result.mcpServers).toEqual(["server1"]);
+    expect(result.skills).toEqual(["skill2"]);
+  });
+
+  it("returns empty arrays when nothing is selected", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          server1: {
+            type: "stdio",
+            command: "node",
+            description: "Server 1",
+          },
+        },
+      })
+    );
+    const result = getSelectedIds(state);
+    expect(result.mcpServers).toEqual([]);
+    expect(result.skills).toEqual([]);
+  });
+});
+
+describe("getAllSelectionSummary", () => {
+  it("returns summary for each visible tab", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          server1: {
+            type: "stdio",
+            command: "node",
+            description: "Server 1",
+          },
+        },
+        skills: {
+          skill1: { description: "Skill 1", path: "/skills/skill1" },
+        },
+      }),
+      {
+        description: "Root",
+        default_mcp_servers: ["server1"],
+      }
+    );
+    const summary = getAllSelectionSummary(state);
+    expect(summary).toHaveLength(2);
+    expect(summary[0]).toEqual({
+      category: "mcp",
+      label: "MCP",
+      selected: ["server1"],
+      total: 1,
+    });
+    expect(summary[1]).toEqual({
+      category: "skills",
+      label: "Skills",
+      selected: [],
+      total: 1,
+    });
+  });
+
+  it("returns empty array when no tabs exist", () => {
+    const state = buildInitialState(makeArtifacts());
+    expect(getAllSelectionSummary(state)).toEqual([]);
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.14"
+    "@pulsemcp/air-core": "0.0.15"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.14"
+    "@pulsemcp/air-core": "0.0.15"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.14"
+    "@pulsemcp/air-core": "0.0.15"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.14"
+    "@pulsemcp/air-core": "0.0.15"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.14"
+    "@pulsemcp/air-core": "0.0.15"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary

- Adds a full interactive terminal UI to `air start claude` that lets users browse artifact types (MCP, Skills, Hooks, Plugins) with left/right tabs, select/deselect individual artifacts with up/down + space, then launch the agent with Enter
- Includes `/` search mode for filtering long lists, select all/none/only shortcuts, scrollable viewport, cross-artifact selection summary in footer, and `--` passthrough args to the agent
- Flicker-free rendering using alternate screen buffer and absolute cursor positioning
- Falls back to non-interactive mode when not a TTY or `--skip-confirmation` is passed
- Version bump to 0.0.15

## Changes

### New files
- `packages/cli/src/tui/types.ts` — TUI state types, initial state builder, selection helpers
- `packages/cli/src/tui/render.ts` — chalk-based terminal renderer with viewport scrolling
- `packages/cli/src/tui/interactive-selector.ts` — keypress handler, alternate screen buffer, signal cleanup
- `packages/cli/tests/tui-state.test.ts` — 15 unit tests for pure TUI state functions

### Modified files
- `packages/cli/src/commands/start.ts` — integrates TUI, root auto-detection, passthrough args
- `docs/guides/running-sessions.md` — documents TUI, keyboard shortcuts, `--` passthrough
- `CHANGELOG.md` — 0.0.15 entry
- All `package.json` files — version bump to 0.0.15

## Verification

- [x] CI green — all 4 checks pass (test on Node 18/20/22, validate-schemas)
- [x] 361 tests passing (346 existing + 15 new TUI state tests)
- [x] TypeScript builds clean across all packages (`npm run build`)
- [x] Fresh-eyes code review performed by subagent; all must-fix and should-fix issues addressed:
  - Simplified root auto-detection (removed unreachable branch)
  - Added try/catch in keypress handler to prevent hanging Promise
  - Added SIGTERM/SIGHUP signal handlers for terminal cleanup
  - Added terminal resize handler
  - Guarded against undefined activeCat
  - Fixed dynamic footer height (was hardcoded, now computed from tab count)
  - Removed dead code (identical ternary branches in renderItem, redundant tab styling)
  - Added negative-width guard in summary truncation
  - Added 15 unit tests for pure state functions (buildInitialState, getVisibleItems, getSelectedIds, getAllSelectionSummary)
- [x] Documentation updated (docs/guides/running-sessions.md)
- [x] Version bumped to 0.0.15 across all packages and internal deps
- [x] No stale `0.0.14` references outside node_modules/lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)