### PR TITLE
feat: end-to-end CI tests with all extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,41 @@ jobs:
       - name: Run tests
         run: npx vitest run
 
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code@2.1.98
+
+      - name: Build core
+        run: npm run build -w packages/core
+
+      - name: Build extensions
+        run: |
+          for dir in packages/extensions/*/; do
+            npm run build -w "${dir%/}"
+          done
+
+      - name: Build SDK and CLI
+        run: |
+          npm run build -w packages/sdk
+          npm run build -w packages/cli
+
+      - name: Run E2E tests
+        run: npx vitest run tests/e2e/e2e.test.ts
+
   validate-schemas:
     runs-on: ubuntu-latest
 

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1,0 +1,586 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { execSync } from "child_process";
+import { resolve, join } from "path";
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  chmodSync,
+} from "fs";
+import { tmpdir } from "os";
+
+const ROOT = resolve(__dirname, "../..");
+const CLI = resolve(ROOT, "packages/cli/src/index.ts");
+const FIXTURES = resolve(__dirname, "fixtures");
+
+const run = (args: string, env?: Record<string, string>) =>
+  execSync(`npx tsx ${CLI} ${args}`, {
+    encoding: "utf-8",
+    cwd: ROOT,
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, ...env },
+  });
+
+const tryRun = (args: string, env?: Record<string, string>) => {
+  try {
+    return { stdout: run(args, env), stderr: "", exitCode: 0 };
+  } catch (err: any) {
+    return {
+      stdout: err.stdout || "",
+      stderr: err.stderr || "",
+      exitCode: err.status,
+    };
+  }
+};
+
+const tempDirs: string[] = [];
+
+function createTempDir(): string {
+  const dir = resolve(
+    tmpdir(),
+    `air-e2e-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  tempDirs.push(dir);
+  return dir;
+}
+
+const tryRunInDir = (args: string, cwd: string, env?: Record<string, string>) => {
+  try {
+    return {
+      stdout: execSync(`npx tsx ${CLI} ${args}`, {
+        encoding: "utf-8",
+        cwd,
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, ...env },
+      }),
+      stderr: "",
+      exitCode: 0,
+    };
+  } catch (err: any) {
+    return {
+      stdout: err.stdout || "",
+      stderr: err.stderr || "",
+      exitCode: err.status,
+    };
+  }
+};
+
+function createStubClaude(dir: string, argsFile?: string): string {
+  const script = argsFile
+    ? `#!/bin/sh\nfor arg in "$@"; do echo "$arg"; done > "${argsFile}"\nexit 0\n`
+    : "#!/bin/sh\nexit 0\n";
+  writeFileSync(join(dir, "claude"), script);
+  chmodSync(join(dir, "claude"), 0o755);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    if (existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  tempDirs.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// 1. air validate
+// ---------------------------------------------------------------------------
+
+describe("air validate", () => {
+  it("validates all example files", () => {
+    const examples = [
+      "examples/air.json",
+      "examples/skills/skills.json",
+      "examples/mcp/mcp.json",
+      "examples/roots/roots.json",
+      "examples/references/references.json",
+      "examples/plugins/plugins.json",
+      "examples/hooks/hooks.json",
+    ];
+
+    for (const file of examples) {
+      const result = tryRun(`validate ${file}`);
+      expect(result.exitCode, `${file} should be valid`).toBe(0);
+    }
+  });
+
+  it("validates all e2e fixture files", () => {
+    const fixtures = [
+      "air.json",
+      "skills/skills.json",
+      "mcp/mcp.json",
+      "roots/roots.json",
+      "references/references.json",
+      "plugins/plugins.json",
+      "hooks/hooks.json",
+    ];
+
+    for (const file of fixtures) {
+      const result = tryRun(`validate ${resolve(FIXTURES, file)}`);
+      expect(result.exitCode, `fixture ${file} should be valid`).toBe(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. air init
+// ---------------------------------------------------------------------------
+
+describe("air init", () => {
+  it("discovers artifacts from the AIR repo and generates github:// URIs", () => {
+    const dir = createTempDir();
+    const airJsonPath = join(dir, "air.json");
+
+    const result = tryRun(`init --path ${airJsonPath} --force`);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("pulsemcp/air");
+    expect(result.stdout).toContain("Discovered");
+
+    const airJson = JSON.parse(readFileSync(airJsonPath, "utf-8"));
+    expect(airJson.extensions).toContain("@pulsemcp/air-provider-github");
+
+    // At least one artifact array should contain github:// URIs
+    const allArrays = [
+      ...(airJson.skills || []),
+      ...(airJson.references || []),
+      ...(airJson.mcp || []),
+      ...(airJson.roots || []),
+      ...(airJson.plugins || []),
+      ...(airJson.hooks || []),
+    ];
+    const hasGithubUri = allArrays.some((uri: string) =>
+      uri.startsWith("github://")
+    );
+    expect(hasGithubUri).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. air list
+// ---------------------------------------------------------------------------
+
+describe("air list", () => {
+  const fixtureEnv = { AIR_CONFIG: join(FIXTURES, "air.json") };
+
+  it("lists skills", () => {
+    const result = tryRun("list skills", fixtureEnv);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("deploy");
+    expect(result.stdout).toContain("incident-response");
+    expect(result.stdout).toContain("query-builder");
+    expect(result.stdout).toContain("provision-env");
+    expect(result.stdout).toContain("component-review");
+    expect(result.stdout).toContain("lint-fix");
+    expect(result.stdout).toContain("format-check");
+  });
+
+  it("lists mcp servers", () => {
+    const result = tryRun("list mcp", fixtureEnv);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("github-server");
+    expect(result.stdout).toContain("postgres-db");
+    expect(result.stdout).toContain("analytics-api");
+    expect(result.stdout).toContain("terraform-server");
+    expect(result.stdout).toContain("design-system");
+  });
+
+  it("lists roots", () => {
+    const result = tryRun("list roots", fixtureEnv);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("platform-orchestrator");
+    expect(result.stdout).toContain("data-pipeline");
+    expect(result.stdout).toContain("infra-agent");
+    expect(result.stdout).toContain("frontend-app");
+  });
+
+  it("lists plugins", () => {
+    const result = tryRun("list plugins", fixtureEnv);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("platform-quality");
+  });
+
+  it("lists hooks", () => {
+    const result = tryRun("list hooks", fixtureEnv);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("session-audit");
+    expect(result.stdout).toContain("lint-check");
+  });
+
+  it("lists references", () => {
+    const result = tryRun("list references", fixtureEnv);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("git-workflow");
+    expect(result.stdout).toContain("deploy-checklist");
+    expect(result.stdout).toContain("runbook");
+    expect(result.stdout).toContain("design-guide");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. air install
+// ---------------------------------------------------------------------------
+
+describe("air install", () => {
+  it("reports workspace extensions as already installed", () => {
+    // Use --prefix pointing to the monorepo root where workspace packages
+    // are symlinked in node_modules/
+    const result = tryRun(
+      `install --config ${join(FIXTURES, "air.json")} --prefix ${ROOT}`
+    );
+    expect(result.exitCode).toBe(0);
+
+    const output = JSON.parse(result.stdout);
+    expect(output.alreadyInstalled).toContain("@pulsemcp/air-adapter-claude");
+    expect(output.alreadyInstalled).toContain("@pulsemcp/air-provider-github");
+    expect(output.alreadyInstalled).toContain("@pulsemcp/air-secrets-env");
+    expect(output.alreadyInstalled).toContain("@pulsemcp/air-secrets-file");
+    expect(output.installed).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. air prepare — orchestrator root (subagent merging)
+// ---------------------------------------------------------------------------
+
+describe("air prepare", () => {
+  it("prepares orchestrator root with subagent merging and secrets resolution", () => {
+    const target = createTempDir();
+
+    const result = tryRun(
+      `prepare claude` +
+        ` --config ${join(FIXTURES, "air.json")}` +
+        ` --root platform-orchestrator` +
+        ` --target ${target}` +
+        ` --secrets-file ${join(FIXTURES, "secrets.json")}`,
+      { GITHUB_TOKEN: "ghp_test_e2e_token" }
+    );
+    expect(result.exitCode).toBe(0);
+
+    // -- .mcp.json written with merged servers (parent + both subagents) --
+    const mcpJsonPath = join(target, ".mcp.json");
+    expect(existsSync(mcpJsonPath)).toBe(true);
+    const mcpJson = JSON.parse(readFileSync(mcpJsonPath, "utf-8"));
+
+    // Parent's servers
+    expect(mcpJson.mcpServers["github-server"]).toBeDefined();
+    expect(mcpJson.mcpServers["postgres-db"]).toBeDefined();
+    // Subagent servers merged in
+    expect(mcpJson.mcpServers["analytics-api"]).toBeDefined();
+    expect(mcpJson.mcpServers["terraform-server"]).toBeDefined();
+    // Not referenced by any active root
+    expect(mcpJson.mcpServers["design-system"]).toBeUndefined();
+
+    // -- Secrets resolved by secrets-env --
+    expect(mcpJson.mcpServers["github-server"].env.GITHUB_PERSONAL_ACCESS_TOKEN).toBe(
+      "ghp_test_e2e_token"
+    );
+
+    // -- Secrets resolved by secrets-file --
+    expect(mcpJson.mcpServers["postgres-db"].env.DATABASE_URI).toBe(
+      "postgresql://admin:s3cret@db.acme.internal:5432/platform"
+    );
+    expect(mcpJson.mcpServers["analytics-api"].headers.Authorization).toBe(
+      "Bearer ak_live_acme_analytics_token"
+    );
+
+    // -- Skills injected (parent + subagents) --
+    expect(existsSync(join(target, ".claude", "skills", "deploy", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(target, ".claude", "skills", "incident-response", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(target, ".claude", "skills", "query-builder", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(target, ".claude", "skills", "provision-env", "SKILL.md"))).toBe(true);
+    // Plugin-expanded skills
+    expect(existsSync(join(target, ".claude", "skills", "lint-fix", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(target, ".claude", "skills", "format-check", "SKILL.md"))).toBe(true);
+
+    // -- Skill references copied --
+    const deployRef = join(target, ".claude", "skills", "deploy", "references", "GIT_WORKFLOW.md");
+    expect(existsSync(deployRef)).toBe(true);
+    expect(readFileSync(deployRef, "utf-8")).toContain("Branch Naming");
+
+    const deployChecklist = join(target, ".claude", "skills", "deploy", "references", "DEPLOY_CHECKLIST.md");
+    expect(existsSync(deployChecklist)).toBe(true);
+
+    // -- Hooks injected --
+    expect(existsSync(join(target, ".claude", "hooks", "session-audit", "HOOK.json"))).toBe(true);
+    // Plugin-expanded hook
+    expect(existsSync(join(target, ".claude", "hooks", "lint-check", "HOOK.json"))).toBe(true);
+
+    // -- JSON output structure --
+    const output = JSON.parse(result.stdout);
+    expect(output.configFiles).toContain(mcpJsonPath);
+    expect(output.skillPaths.length).toBeGreaterThanOrEqual(6);
+    expect(output.hookPaths.length).toBeGreaterThanOrEqual(2);
+    expect(output.startCommand).toBeDefined();
+
+    // -- Subagent context generated --
+    expect(output.subagentContext).toBeDefined();
+    expect(output.subagentContext).toContain("Data Pipeline Agent");
+    expect(output.subagentContext).toContain("Infrastructure Agent");
+    expect(output.subagentContext).toContain("subagents/data");
+    expect(output.subagentContext).toContain("subagents/infra");
+  });
+
+  it("prepares frontend root without subagents", () => {
+    const target = createTempDir();
+
+    const result = tryRun(
+      `prepare claude` +
+        ` --config ${join(FIXTURES, "air.json")}` +
+        ` --root frontend-app` +
+        ` --target ${target}` +
+        ` --skip-validation`,
+      { GITHUB_TOKEN: "ghp_test_e2e_token" }
+    );
+    expect(result.exitCode).toBe(0);
+
+    const mcpJson = JSON.parse(readFileSync(join(target, ".mcp.json"), "utf-8"));
+
+    // Only frontend root's servers
+    expect(mcpJson.mcpServers["github-server"]).toBeDefined();
+    expect(mcpJson.mcpServers["design-system"]).toBeDefined();
+    expect(mcpJson.mcpServers["postgres-db"]).toBeUndefined();
+    expect(mcpJson.mcpServers["analytics-api"]).toBeUndefined();
+    expect(mcpJson.mcpServers["terraform-server"]).toBeUndefined();
+
+    // Frontend's skills + plugin-expanded skills
+    expect(existsSync(join(target, ".claude", "skills", "component-review", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(target, ".claude", "skills", "lint-fix", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(target, ".claude", "skills", "format-check", "SKILL.md"))).toBe(true);
+    // Not frontend's skills
+    expect(existsSync(join(target, ".claude", "skills", "deploy"))).toBe(false);
+
+    // Frontend hooks
+    expect(existsSync(join(target, ".claude", "hooks", "lint-check", "HOOK.json"))).toBe(true);
+    expect(existsSync(join(target, ".claude", "hooks", "session-audit"))).toBe(false);
+
+    // No subagent context
+    const output = JSON.parse(result.stdout);
+    expect(output.subagentContext).toBeUndefined();
+  });
+
+  it("skips subagent merge with --no-subagent-merge", () => {
+    const target = createTempDir();
+
+    const result = tryRun(
+      `prepare claude` +
+        ` --config ${join(FIXTURES, "air.json")}` +
+        ` --root platform-orchestrator` +
+        ` --target ${target}` +
+        ` --no-subagent-merge` +
+        ` --skip-validation`,
+      { GITHUB_TOKEN: "ghp_test_e2e_token" }
+    );
+    expect(result.exitCode).toBe(0);
+
+    const mcpJson = JSON.parse(readFileSync(join(target, ".mcp.json"), "utf-8"));
+
+    // Only parent's direct servers — subagent servers NOT merged
+    expect(mcpJson.mcpServers["github-server"]).toBeDefined();
+    expect(mcpJson.mcpServers["postgres-db"]).toBeDefined();
+    expect(mcpJson.mcpServers["analytics-api"]).toBeUndefined();
+    expect(mcpJson.mcpServers["terraform-server"]).toBeUndefined();
+
+    // No subagent context
+    const output = JSON.parse(result.stdout);
+    expect(output.subagentContext).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. air start
+// ---------------------------------------------------------------------------
+
+describe("air start", () => {
+  const fixtureEnv = { AIR_CONFIG: join(FIXTURES, "air.json") };
+
+  it("prints session config in dry-run mode", () => {
+    const result = tryRun(
+      "start claude --dry-run --root platform-orchestrator",
+      fixtureEnv
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("AIR Session Configuration");
+    expect(result.stdout).toContain("claude");
+    expect(result.stdout).toContain("github-server");
+    expect(result.stdout).toContain("deploy");
+  });
+
+  it("succeeds when claude is on PATH", () => {
+    const targetDir = createTempDir();
+    const stubDir = createTempDir();
+    createStubClaude(stubDir);
+
+    // `start` runs prepareSession + spawn — secrets must be resolvable via
+    // env vars and --skip-confirmation bypasses the interactive TUI.
+    const result = tryRunInDir(
+      "start claude --root platform-orchestrator --skip-confirmation",
+      targetDir,
+      {
+        ...fixtureEnv,
+        PATH: `${stubDir}:${process.env.PATH}`,
+        GITHUB_TOKEN: "ghp_test_e2e_token",
+        PG_CONNECTION_STRING: "postgresql://test:test@localhost/test",
+        ANALYTICS_SECRET: "test_analytics_key",
+      }
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("fails when claude is not on PATH", () => {
+    // Build a PATH that keeps node/npx but removes any directory containing
+    // a `claude` binary, so the CLI's `which claude` check fails.
+    const filteredPath = (process.env.PATH || "")
+      .split(":")
+      .filter((dir) => {
+        try {
+          return !existsSync(join(dir, "claude"));
+        } catch {
+          return true;
+        }
+      })
+      .join(":");
+
+    const result = tryRun(
+      "start claude --root platform-orchestrator",
+      { ...fixtureEnv, PATH: filteredPath }
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("not installed");
+  });
+
+  it("writes correct artifacts with --skip-confirmation (orchestrator root)", () => {
+    const targetDir = createTempDir();
+    const stubDir = createTempDir();
+    createStubClaude(stubDir);
+
+    const result = tryRunInDir(
+      "start claude --root platform-orchestrator --skip-confirmation",
+      targetDir,
+      {
+        ...fixtureEnv,
+        PATH: `${stubDir}:${process.env.PATH}`,
+        GITHUB_TOKEN: "ghp_test_e2e_token",
+        PG_CONNECTION_STRING: "postgresql://test:test@localhost/test",
+        ANALYTICS_SECRET: "test_analytics_key",
+      }
+    );
+    expect(result.exitCode).toBe(0);
+
+    // -- .mcp.json written with merged servers (parent + subagents) --
+    const mcpJson = JSON.parse(readFileSync(join(targetDir, ".mcp.json"), "utf-8"));
+    expect(mcpJson.mcpServers["github-server"]).toBeDefined();
+    expect(mcpJson.mcpServers["postgres-db"]).toBeDefined();
+    expect(mcpJson.mcpServers["analytics-api"]).toBeDefined();
+    expect(mcpJson.mcpServers["terraform-server"]).toBeDefined();
+    expect(mcpJson.mcpServers["design-system"]).toBeUndefined();
+
+    // -- Secrets resolved via env --
+    expect(mcpJson.mcpServers["github-server"].env.GITHUB_PERSONAL_ACCESS_TOKEN).toBe(
+      "ghp_test_e2e_token"
+    );
+
+    // -- Skills injected (parent + subagents + plugin-expanded) --
+    expect(existsSync(join(targetDir, ".claude", "skills", "deploy", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(targetDir, ".claude", "skills", "incident-response", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(targetDir, ".claude", "skills", "query-builder", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(targetDir, ".claude", "skills", "provision-env", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(targetDir, ".claude", "skills", "lint-fix", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(targetDir, ".claude", "skills", "format-check", "SKILL.md"))).toBe(true);
+
+    // -- Hooks injected --
+    expect(existsSync(join(targetDir, ".claude", "hooks", "session-audit", "HOOK.json"))).toBe(true);
+    expect(existsSync(join(targetDir, ".claude", "hooks", "lint-check", "HOOK.json"))).toBe(true);
+
+    // -- Skill references copied --
+    expect(existsSync(join(targetDir, ".claude", "skills", "deploy", "references", "GIT_WORKFLOW.md"))).toBe(true);
+  });
+
+  it("forwards passthrough args after -- to the agent", () => {
+    const targetDir = createTempDir();
+    const stubDir = createTempDir();
+    const argsFile = join(targetDir, "received-args.txt");
+    createStubClaude(stubDir, argsFile);
+
+    const result = tryRunInDir(
+      `start claude --root frontend-app --skip-confirmation -- --verbose -p "test prompt"`,
+      targetDir,
+      {
+        ...fixtureEnv,
+        PATH: `${stubDir}:${process.env.PATH}`,
+        GITHUB_TOKEN: "ghp_test_e2e_token",
+        AIR_TEST_ARGS_FILE: argsFile,
+      }
+    );
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(argsFile)).toBe(true);
+
+    const receivedArgs = readFileSync(argsFile, "utf-8");
+    expect(receivedArgs).toContain("--verbose");
+    expect(receivedArgs).toContain("-p");
+    expect(receivedArgs).toContain("test prompt");
+  });
+
+  it("writes correct artifacts for frontend-app root (no subagents)", () => {
+    const targetDir = createTempDir();
+    const stubDir = createTempDir();
+    createStubClaude(stubDir);
+
+    const result = tryRunInDir(
+      "start claude --root frontend-app --skip-confirmation",
+      targetDir,
+      {
+        ...fixtureEnv,
+        PATH: `${stubDir}:${process.env.PATH}`,
+        GITHUB_TOKEN: "ghp_test_e2e_token",
+      }
+    );
+    expect(result.exitCode).toBe(0);
+
+    // -- Only frontend root's MCP servers --
+    const mcpJson = JSON.parse(readFileSync(join(targetDir, ".mcp.json"), "utf-8"));
+    expect(mcpJson.mcpServers["github-server"]).toBeDefined();
+    expect(mcpJson.mcpServers["design-system"]).toBeDefined();
+    expect(mcpJson.mcpServers["postgres-db"]).toBeUndefined();
+    expect(mcpJson.mcpServers["analytics-api"]).toBeUndefined();
+    expect(mcpJson.mcpServers["terraform-server"]).toBeUndefined();
+
+    // -- Frontend skills + plugin-expanded --
+    expect(existsSync(join(targetDir, ".claude", "skills", "component-review", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(targetDir, ".claude", "skills", "lint-fix", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(targetDir, ".claude", "skills", "format-check", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(targetDir, ".claude", "skills", "deploy"))).toBe(false);
+
+    // -- Frontend hooks only --
+    expect(existsSync(join(targetDir, ".claude", "hooks", "lint-check", "HOOK.json"))).toBe(true);
+    expect(existsSync(join(targetDir, ".claude", "hooks", "session-audit"))).toBe(false);
+  });
+
+  it("completes in non-TTY mode without --skip-confirmation", () => {
+    const targetDir = createTempDir();
+    const stubDir = createTempDir();
+    createStubClaude(stubDir);
+
+    // No --skip-confirmation: since stdio is piped (non-TTY), TUI is
+    // skipped automatically and root defaults are used.
+    const result = tryRunInDir(
+      "start claude --root frontend-app",
+      targetDir,
+      {
+        ...fixtureEnv,
+        PATH: `${stubDir}:${process.env.PATH}`,
+        GITHUB_TOKEN: "ghp_test_e2e_token",
+      }
+    );
+    expect(result.exitCode).toBe(0);
+
+    // Artifacts should still be written using root defaults
+    expect(existsSync(join(targetDir, ".mcp.json"))).toBe(true);
+    const mcpJson = JSON.parse(readFileSync(join(targetDir, ".mcp.json"), "utf-8"));
+    expect(mcpJson.mcpServers["github-server"]).toBeDefined();
+    expect(mcpJson.mcpServers["design-system"]).toBeDefined();
+  });
+});

--- a/tests/e2e/fixtures/.gitignore
+++ b/tests/e2e/fixtures/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package.json
+package-lock.json

--- a/tests/e2e/fixtures/air.json
+++ b/tests/e2e/fixtures/air.json
@@ -1,0 +1,28 @@
+{
+  "name": "acme-platform",
+  "description": "Acme Corp platform engineering — multi-team agent configuration with subagent roots",
+  "extensions": [
+    "@pulsemcp/air-adapter-claude",
+    "@pulsemcp/air-provider-github",
+    "@pulsemcp/air-secrets-env",
+    "@pulsemcp/air-secrets-file"
+  ],
+  "skills": [
+    "./skills/skills.json"
+  ],
+  "references": [
+    "./references/references.json"
+  ],
+  "mcp": [
+    "./mcp/mcp.json"
+  ],
+  "roots": [
+    "./roots/roots.json"
+  ],
+  "plugins": [
+    "./plugins/plugins.json"
+  ],
+  "hooks": [
+    "./hooks/hooks.json"
+  ]
+}

--- a/tests/e2e/fixtures/hooks/hooks.json
+++ b/tests/e2e/fixtures/hooks/hooks.json
@@ -1,0 +1,12 @@
+{
+  "session-audit": {
+    "title": "Session Audit Log",
+    "description": "Log session start and end events to the platform audit trail.",
+    "path": "session-audit"
+  },
+  "lint-check": {
+    "title": "Pre-Commit Lint",
+    "description": "Run linting on staged files before allowing a commit.",
+    "path": "lint-check"
+  }
+}

--- a/tests/e2e/fixtures/hooks/lint-check/HOOK.json
+++ b/tests/e2e/fixtures/hooks/lint-check/HOOK.json
@@ -1,0 +1,5 @@
+{
+  "type": "hook",
+  "event": "pre_commit",
+  "command": "npx eslint --fix ."
+}

--- a/tests/e2e/fixtures/hooks/session-audit/HOOK.json
+++ b/tests/e2e/fixtures/hooks/session-audit/HOOK.json
@@ -1,0 +1,5 @@
+{
+  "type": "hook",
+  "event": "session_start",
+  "command": "echo 'Session started' >> /tmp/audit.log"
+}

--- a/tests/e2e/fixtures/mcp/mcp.json
+++ b/tests/e2e/fixtures/mcp/mcp.json
@@ -1,0 +1,44 @@
+{
+  "github-server": {
+    "title": "GitHub",
+    "description": "Create and manage issues, PRs, branches, and files in GitHub repos.",
+    "type": "stdio",
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-github@0.6.2"],
+    "env": {
+      "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+    }
+  },
+  "postgres-db": {
+    "title": "PostgreSQL — Platform DB",
+    "description": "Read-only access to the platform PostgreSQL database.",
+    "type": "stdio",
+    "command": "uvx",
+    "args": ["--from", "postgres-mcp==0.3.0", "postgres-mcp", "--access-mode=restricted"],
+    "env": {
+      "DATABASE_URI": "${PG_CONNECTION_STRING}"
+    }
+  },
+  "analytics-api": {
+    "title": "Analytics API",
+    "description": "Query analytics data and generate reports from the data warehouse.",
+    "type": "streamable-http",
+    "url": "https://mcp.analytics.acme.internal/v1",
+    "headers": {
+      "Authorization": "Bearer ${ANALYTICS_SECRET}"
+    }
+  },
+  "terraform-server": {
+    "title": "Terraform",
+    "description": "Manage infrastructure resources via Terraform plans and applies.",
+    "type": "stdio",
+    "command": "npx",
+    "args": ["-y", "@acme/terraform-mcp@1.0.0"]
+  },
+  "design-system": {
+    "title": "Design System",
+    "description": "Browse and query the Acme design system component library.",
+    "type": "streamable-http",
+    "url": "https://mcp.design.acme.internal/v1"
+  }
+}

--- a/tests/e2e/fixtures/plugins/plugins.json
+++ b/tests/e2e/fixtures/plugins/plugins.json
@@ -1,0 +1,9 @@
+{
+  "platform-quality": {
+    "title": "Platform Quality Suite",
+    "description": "Linting, formatting, and pre-commit checks — standard quality gates for all platform repos.",
+    "version": "1.0.0",
+    "skills": ["lint-fix", "format-check"],
+    "hooks": ["lint-check"]
+  }
+}

--- a/tests/e2e/fixtures/references/DEPLOY_CHECKLIST.md
+++ b/tests/e2e/fixtures/references/DEPLOY_CHECKLIST.md
@@ -1,0 +1,14 @@
+# Deploy Checklist
+
+## Pre-Deploy
+
+- [ ] All tests passing on CI
+- [ ] PR approved and merged to main
+- [ ] Database migrations reviewed
+- [ ] Feature flags configured
+
+## Post-Deploy
+
+- [ ] Smoke tests passing
+- [ ] Error rates nominal
+- [ ] Key metrics dashboards checked

--- a/tests/e2e/fixtures/references/DESIGN_GUIDE.md
+++ b/tests/e2e/fixtures/references/DESIGN_GUIDE.md
@@ -1,0 +1,13 @@
+# Design System Guide
+
+## Component Patterns
+
+- Use the `<Button>` component for all interactive actions
+- Use design tokens for colors: `--color-primary`, `--color-secondary`
+- Spacing follows an 8px grid: `--space-1` (8px), `--space-2` (16px), etc.
+
+## Accessibility
+
+- All interactive elements must have visible focus indicators
+- Images must have alt text
+- Form inputs must have associated labels

--- a/tests/e2e/fixtures/references/GIT_WORKFLOW.md
+++ b/tests/e2e/fixtures/references/GIT_WORKFLOW.md
@@ -1,0 +1,15 @@
+# Git Workflow
+
+## Branch Naming
+
+- Feature branches: `feature/<ticket-id>-<short-description>`
+- Bug fixes: `fix/<ticket-id>-<short-description>`
+- Hotfixes: `hotfix/<description>`
+
+## PR Process
+
+1. Create a branch from `main`
+2. Make changes and push
+3. Open a PR with a description and link to the ticket
+4. Get at least one approval
+5. Squash and merge

--- a/tests/e2e/fixtures/references/RUNBOOK.md
+++ b/tests/e2e/fixtures/references/RUNBOOK.md
@@ -1,0 +1,21 @@
+# Incident Runbook
+
+## Severity Levels
+
+- **SEV1**: Complete service outage — all hands on deck
+- **SEV2**: Degraded service — primary on-call responds
+- **SEV3**: Minor issue — next business day
+
+## Escalation
+
+1. Page the on-call engineer
+2. If no response in 10 minutes, page the backup
+3. If SEV1, start a war room in #incidents
+
+## Rollback
+
+```bash
+git revert <commit> && git push origin main
+```
+
+Trigger the deployment pipeline to roll back to the previous version.

--- a/tests/e2e/fixtures/references/references.json
+++ b/tests/e2e/fixtures/references/references.json
@@ -1,0 +1,22 @@
+{
+  "git-workflow": {
+    "title": "Git Workflow",
+    "description": "Standard git workflow — branch naming, PR conventions, and merge strategy.",
+    "path": "GIT_WORKFLOW.md"
+  },
+  "deploy-checklist": {
+    "title": "Deploy Checklist",
+    "description": "Pre-deploy and post-deploy verification steps for staging and production.",
+    "path": "DEPLOY_CHECKLIST.md"
+  },
+  "runbook": {
+    "title": "Incident Runbook",
+    "description": "Step-by-step incident response procedures — escalation paths, rollback steps, and communication templates.",
+    "path": "RUNBOOK.md"
+  },
+  "design-guide": {
+    "title": "Design System Guide",
+    "description": "Component patterns, accessibility requirements, and design token usage.",
+    "path": "DESIGN_GUIDE.md"
+  }
+}

--- a/tests/e2e/fixtures/roots/roots.json
+++ b/tests/e2e/fixtures/roots/roots.json
@@ -1,0 +1,39 @@
+{
+  "platform-orchestrator": {
+    "display_name": "Platform Orchestrator",
+    "description": "Main platform engineering root — orchestrates deployments, incident response, and delegates to data and infra subagents.",
+    "url": "https://github.com/acme/platform.git",
+    "default_branch": "main",
+    "default_mcp_servers": ["github-server", "postgres-db"],
+    "default_skills": ["deploy", "incident-response", "lint-fix", "format-check"],
+    "default_plugins": ["platform-quality"],
+    "default_hooks": ["session-audit", "lint-check"],
+    "default_subagent_roots": ["data-pipeline", "infra-agent"]
+  },
+  "data-pipeline": {
+    "display_name": "Data Pipeline Agent",
+    "description": "ETL pipeline management — query building, data validation, and warehouse operations.",
+    "subdirectory": "subagents/data",
+    "user_invocable": false,
+    "default_mcp_servers": ["analytics-api"],
+    "default_skills": ["query-builder"]
+  },
+  "infra-agent": {
+    "display_name": "Infrastructure Agent",
+    "description": "Infrastructure provisioning — Terraform plans, environment setup, and resource management.",
+    "subdirectory": "subagents/infra",
+    "user_invocable": false,
+    "default_mcp_servers": ["terraform-server"],
+    "default_skills": ["provision-env"]
+  },
+  "frontend-app": {
+    "display_name": "Frontend Application",
+    "description": "React frontend — component development, design system integration, and UI reviews.",
+    "url": "https://github.com/acme/frontend.git",
+    "default_branch": "main",
+    "default_mcp_servers": ["github-server", "design-system"],
+    "default_skills": ["component-review", "lint-fix", "format-check"],
+    "default_plugins": ["platform-quality"],
+    "default_hooks": ["lint-check"]
+  }
+}

--- a/tests/e2e/fixtures/secrets.json
+++ b/tests/e2e/fixtures/secrets.json
@@ -1,0 +1,4 @@
+{
+  "PG_CONNECTION_STRING": "postgresql://admin:s3cret@db.acme.internal:5432/platform",
+  "ANALYTICS_SECRET": "ak_live_acme_analytics_token"
+}

--- a/tests/e2e/fixtures/skills/component-review/SKILL.md
+++ b/tests/e2e/fixtures/skills/component-review/SKILL.md
@@ -1,0 +1,9 @@
+# Component Review
+
+Review React components for quality and design system compliance.
+
+## Checklist
+
+- Accessibility: ARIA labels, keyboard navigation, focus management
+- Design tokens: colors, spacing, typography from the design system
+- Performance: memo usage, render count, bundle impact

--- a/tests/e2e/fixtures/skills/deploy/SKILL.md
+++ b/tests/e2e/fixtures/skills/deploy/SKILL.md
@@ -1,0 +1,11 @@
+# Deploy to Staging
+
+Deploy the current branch to the staging environment.
+
+## Steps
+
+1. Verify the branch is up to date with main
+2. Run the pre-deploy checklist (see references)
+3. Trigger the staging deployment pipeline
+4. Wait for smoke tests to pass
+5. Report deployment status in the PR

--- a/tests/e2e/fixtures/skills/format-check/SKILL.md
+++ b/tests/e2e/fixtures/skills/format-check/SKILL.md
@@ -1,0 +1,7 @@
+# Format Check
+
+Check code formatting with Prettier and fix any violations.
+
+## Usage
+
+Run Prettier on all staged files. Fix formatting issues in place and report what changed.

--- a/tests/e2e/fixtures/skills/incident-response/SKILL.md
+++ b/tests/e2e/fixtures/skills/incident-response/SKILL.md
@@ -1,0 +1,11 @@
+# Incident Response
+
+Triage and respond to production incidents.
+
+## Steps
+
+1. Acknowledge the incident and set severity level
+2. Gather relevant logs and metrics
+3. Identify the root cause
+4. Implement a fix or rollback
+5. Write the post-incident summary

--- a/tests/e2e/fixtures/skills/lint-fix/SKILL.md
+++ b/tests/e2e/fixtures/skills/lint-fix/SKILL.md
@@ -1,0 +1,7 @@
+# Lint & Fix
+
+Run ESLint with auto-fix on staged files and report remaining issues.
+
+## Usage
+
+Run the linter, auto-fix what can be fixed, and report any remaining violations to the user with file paths and line numbers.

--- a/tests/e2e/fixtures/skills/provision-env/SKILL.md
+++ b/tests/e2e/fixtures/skills/provision-env/SKILL.md
@@ -1,0 +1,10 @@
+# Provision Environment
+
+Provision cloud infrastructure using Terraform.
+
+## Steps
+
+1. Review the Terraform plan
+2. Check for security group and IAM policy changes
+3. Apply the plan in the target environment
+4. Verify resource creation and connectivity

--- a/tests/e2e/fixtures/skills/query-builder/SKILL.md
+++ b/tests/e2e/fixtures/skills/query-builder/SKILL.md
@@ -1,0 +1,9 @@
+# Query Builder
+
+Build and optimize SQL queries for the analytics data warehouse.
+
+## Guidelines
+
+- Always use CTEs for complex queries
+- Include EXPLAIN ANALYZE output for queries touching large tables
+- Prefer window functions over self-joins

--- a/tests/e2e/fixtures/skills/skills.json
+++ b/tests/e2e/fixtures/skills/skills.json
@@ -1,0 +1,40 @@
+{
+  "deploy": {
+    "title": "Deploy to Staging",
+    "description": "Deploy the current branch to the staging environment, run smoke tests, and report status.",
+    "path": "deploy",
+    "references": ["git-workflow", "deploy-checklist"]
+  },
+  "incident-response": {
+    "title": "Incident Response",
+    "description": "Triage production incidents — gather logs, identify root cause, and coordinate the fix.",
+    "path": "incident-response",
+    "references": ["runbook"]
+  },
+  "query-builder": {
+    "title": "Query Builder",
+    "description": "Build and optimize SQL queries for the analytics data warehouse.",
+    "path": "query-builder"
+  },
+  "provision-env": {
+    "title": "Provision Environment",
+    "description": "Provision cloud infrastructure using Terraform — VPCs, databases, and compute resources.",
+    "path": "provision-env"
+  },
+  "component-review": {
+    "title": "Component Review",
+    "description": "Review React components for accessibility, design system compliance, and performance.",
+    "path": "component-review",
+    "references": ["design-guide"]
+  },
+  "lint-fix": {
+    "title": "Lint & Fix",
+    "description": "Run ESLint with auto-fix on staged files and report remaining issues.",
+    "path": "lint-fix"
+  },
+  "format-check": {
+    "title": "Format Check",
+    "description": "Check code formatting with Prettier and fix any violations.",
+    "path": "format-check"
+  }
+}

--- a/tests/e2e/vitest.config.ts
+++ b/tests/e2e/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["**/*.test.ts"],
+    testTimeout: 30000,
+  },
+});
+

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -5,4 +5,5 @@ export default defineWorkspace([
   "packages/sdk/vitest.config.ts",
   "packages/cli/vitest.config.ts",
   "packages/extensions/*/vitest.config.ts",
+  "tests/e2e/vitest.config.ts",
 ]);


### PR DESCRIPTION
## Summary

- Add end-to-end CI tests exercising all CLI commands (`validate`, `init`, `list`, `install`, `prepare`, `start`) with all 4 official extensions (`adapter-claude`, `provider-github`, `secrets-env`, `secrets-file`)
- On-disk E2E fixtures modeling a multi-root org ("Acme Platform") with subagent roots, mixed transports (stdio + streamable-http), nested plugins, and dual secrets resolution
- Dedicated `e2e` CI job with pinned Claude Code binary (`@anthropic-ai/claude-code@2.1.98`)
- Full coverage of `air start` TUI flow changes from #59

## Fixture Design

The fixtures model "Acme Platform" — a realistic multi-team org with:
- **4 roots**: orchestrator (parent with 2 subagents), data-pipeline (subagent, subdirectory), infra-agent (subagent), frontend-app (independent)
- **5 MCP servers**: mixed stdio + streamable-http transports, secrets via both `secrets-env` and `secrets-file`
- **7 skills** with reference cross-dependencies
- **1 plugin** expanding to 2 skills + 1 hook
- **2 hooks**, **4 references**

## Test Coverage (20 tests)

1. `air validate` — all example files + all fixture files
2. `air init` — repo discovery, `github://` URI generation
3. `air list` — all 6 artifact types
4. `air install` — workspace extension detection
5. `air prepare` (orchestrator) — subagent merging, secrets resolution, skill/hook/reference injection
6. `air prepare` (frontend) — independent root without subagents
7. `air prepare --no-subagent-merge` — skip subagent merging
8. `air start --dry-run` — prints session config
9. `air start` — stub binary with full prepareSession + spawn flow
10. `air start` — missing binary detection
11. `air start --skip-confirmation` (orchestrator) — verifies .mcp.json, skills, hooks, references written to target dir
12. `air start -- --verbose -p "test"` — passthrough args forwarded to agent binary
13. `air start --skip-confirmation` (frontend-app) — per-root artifact verification (no subagent servers/skills)
14. `air start` (non-TTY) — auto-skips TUI, uses root defaults, doesn't hang

## TUI Flow Coverage (#59)

Since E2E tests run with piped stdio (non-TTY), the interactive TUI never activates. Coverage focuses on:
- **`--skip-confirmation` flag**: bypasses TUI, uses root defaults, runs full `prepareSession()` → `spawn()` flow
- **Non-TTY detection**: verifies `start` completes without `--skip-confirmation` when not a TTY
- **Passthrough args (`--`)**: verifies args after `--` are forwarded to the spawned agent via `process.argv.indexOf("--")`
- **Artifact verification**: confirms `.mcp.json`, skills, hooks, and references are correctly written to `process.cwd()` (the target dir)

## Verification

- [ ] All 381 tests pass locally (361 existing + 20 new E2E)
- [ ] E2E tests cover all 6 CLI commands with all 4 extensions
- [ ] CI job uses pinned Claude Code version for reproducibility
- [ ] Clean single-commit branch rebased on main (post-TUI merge)

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)