### PR TITLE
docs: clarify prerequisites and per-session config philosophy

### DIFF
--- a/docs/guides/configuring-mcp-servers.md
+++ b/docs/guides/configuring-mcp-servers.md
@@ -2,6 +2,10 @@
 
 MCP (Model Context Protocol) servers provide tools and data to AI agents. AIR manages MCP server configuration so your agents get the right servers activated for each session.
 
+## User-level MCP servers and AIR
+
+AIR manages MCP server configuration per-session. If you already have user-scoped MCP servers configured in your agent (e.g., in `~/.claude/.mcp.json`), you should migrate them into AIR index files and remove the user-level config. Otherwise both will be active during sessions, leading to duplicated servers, version conflicts, and configuration that isn't shared with your team or version-controlled. See the [Quickstart](quickstart.md#how-air-manages-configuration) for more context.
+
 ## Defining MCP servers
 
 MCP servers are defined in a JSON index file (typically `~/.air/mcp/mcp.json`). Each entry is keyed by server name and describes how to connect.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -7,6 +7,15 @@ Get from zero to a working AIR setup in under five minutes.
 - Node.js 18 or later
 - npm
 - An AI coding agent (e.g., [Claude Code](https://docs.anthropic.com/en/docs/claude-code))
+- **A repository with at least one artifact index file.** AIR manages configuration that already exists — the CLI reads from JSON index files (e.g., `skills/skills.json`, `mcp/mcp.json`) that define your artifacts. You need at least one index file with at least one entry for any of the [artifact types](../concepts.md#artifact-types) before AIR has anything to work with. See the [examples/](../../examples/) directory for reference.
+
+## How AIR manages configuration
+
+AIR uses **per-session, project-level configuration**. Every time you start a session, AIR assembles the active configuration from your `air.json` and its referenced index files — nothing is persisted into the agent's own user-level config.
+
+This means you should **disable or remove any user-scoped agent configuration** you may already have (e.g., user-level MCP servers in `~/.claude/.mcp.json`, global tool settings). If left in place, user-level config will be active alongside AIR-managed config, which leads to duplication, conflicts, and config that isn't version-controlled or shared with your team. The goal is for `air.json` and its artifact indexes to be the single source of truth for every session.
+
+See [Per-Session Configuration](../concepts.md#4-per-session-configuration) in the design principles for more detail.
 
 ## 1. Install the CLI
 

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -2,6 +2,10 @@
 
 AIR provides two commands for launching agent sessions: `air start` for interactive use and `air prepare` for programmatic/orchestrator use.
 
+## Before you start
+
+AIR manages configuration **per-session** — it assembles everything from `air.json` and writes it fresh each time. To avoid conflicts and duplication, disable any user-scoped agent configuration before running sessions (e.g., user-level MCP servers in `~/.claude/.mcp.json`, global tool settings). AIR-managed config should be the single source of truth. See the [Quickstart](quickstart.md#how-air-manages-configuration) for details.
+
 ## air start — interactive sessions
 
 `air start` is the primary command for starting an agent session interactively:


### PR DESCRIPTION
## Summary
- Adds a prerequisite to the quickstart explaining that users need a repository with at least one artifact index JSON file (with at least one artifact entry) before running the `air` CLI
- Adds a new "How AIR manages configuration" section to the quickstart explaining the per-session, project-level config philosophy and the need to disable user-scoped agent configuration (e.g., user-level MCP servers)
- Adds corresponding notes to the running-sessions and configuring-mcp-servers guides pointing back to the quickstart

## Verification
- [x] CI green (docs-only change, no build/test impact)
- [x] Self-review completed — all links verified, prose is clear and actionable
- [x] No code changes; only documentation updates to 3 guide files

🤖 Generated with [Claude Code](https://claude.com/claude-code)