### PR TITLE
fix: stop auto-generating roots.json during air init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.17] - 2026-04-10
+
+### Fixed
+- `air init` no longer auto-generates a `roots/roots.json` file in the repo — it only discovers existing artifact index files, consistent with how all other artifact types work
+
+### Changed
+- Removed `generatedRootsPath` and `generatedRootName` from `InitFromRepoResult` (breaking for SDK consumers that relied on these fields)
+
 ## [0.0.16] - 2026-04-10
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,9 +24,7 @@ Initialize a new AIR configuration at `~/.air/`.
 air init
 ```
 
-When run inside a git repo with AIR artifact index files, discovers them automatically and generates:
-- `~/.air/air.json` — root config with `github://` resolver URIs
-- `~/.air/roots/roots.json` — auto-generated root entry for the current repo, with `default_skills`, `default_mcp_servers`, and `default_hooks` populated from discovered artifacts
+When run inside a git repo with AIR artifact index files, discovers them automatically and generates `~/.air/air.json` with `github://` resolver URIs for each discovered artifact type. Only artifact types that have existing index files in the repo are included.
 
 When no artifacts are found (or outside a git repo), creates a minimal `~/.air/air.json` scaffold.
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -26,7 +26,7 @@ air --version
 air init
 ```
 
-When run inside a git repo that contains AIR artifact index files (skills.json, mcp.json, etc.), `air init` **discovers them automatically**, detects the GitHub remote and default branch, and generates an `air.json` with `github://` resolver URIs for all artifact types — including roots. It also **auto-generates a `roots.json`** in the repo directory (if one doesn't already exist) with a root entry for the current repo, populated with `default_skills`, `default_mcp_servers`, and `default_hooks` from the discovered artifacts. The generated `air.json` includes all officially maintained extensions by default, giving you a batteries-included setup. This is the fastest way to get started with an existing repo.
+When run inside a git repo that contains AIR artifact index files (skills.json, mcp.json, etc.), `air init` **discovers them automatically**, detects the GitHub remote and default branch, and generates an `air.json` with `github://` resolver URIs for each discovered artifact type. Only artifact types with existing index files in the repo are included — nothing is auto-generated. The generated `air.json` includes all officially maintained extensions by default, giving you a batteries-included setup. This is the fastest way to get started with an existing repo.
 
 When no artifacts are found (or you're not in a git repo), it falls back to creating a blank scaffolding:
 

--- a/docs/guides/roots.md
+++ b/docs/guides/roots.md
@@ -12,9 +12,11 @@ Without roots, every session gets every artifact. That works for simple setups, 
 
 Roots solve this by defining per-project defaults.
 
-## Auto-generated roots
+## Discovered roots
 
-When you run `air init` inside a git repo, a root entry is automatically generated at `roots/roots.json` within the repo directory (if one doesn't already exist there). It captures the repo's GitHub URL, default branch, and populates `default_skills`, `default_mcp_servers`, and `default_hooks` from the artifacts discovered in the repo. The generated `air.json` references it via a `github://` URI, consistent with how other artifact types are referenced. Commit and push the generated `roots.json` to make it resolvable via the `github://` URI.
+When you run `air init` inside a git repo, any existing `roots.json` index files in the repo are discovered and referenced in the generated `air.json` via `github://` URIs, just like other artifact types. If no roots index file exists in the repo, roots are simply omitted from `air.json` — no files are auto-generated.
+
+To add a root, create a `roots.json` file in your repo (e.g., `roots/roots.json`), then re-run `air init --force` to pick it up.
 
 ## Defining a root
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1775791842-0a4b1b2b",
+  "name": "air-main-1775862982-a136b6c4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -1968,9 +1968,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.16",
+        "@pulsemcp/air-sdk": "0.0.17",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -1989,7 +1989,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -2005,9 +2005,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.16"
+        "@pulsemcp/air-core": "0.0.17"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2020,9 +2020,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.16"
+        "@pulsemcp/air-core": "0.0.17"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2035,9 +2035,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.16"
+        "@pulsemcp/air-core": "0.0.17"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2050,9 +2050,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.16"
+        "@pulsemcp/air-core": "0.0.17"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2065,9 +2065,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.16"
+        "@pulsemcp/air-core": "0.0.17"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.16",
+    "@pulsemcp/air-sdk": "0.0.17",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -30,9 +30,6 @@ export function initCommand(): Command {
           for (const artifact of result.discovered) {
             console.log(`  [${artifact.type}] ${artifact.repoPath}`);
           }
-          console.log(
-            `\nGenerated root "${result.generatedRootName}" at ${result.generatedRootsPath}`
-          );
           console.log(`\nConfig written to ${result.airJsonPath}`);
         } else {
           console.log(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.16"
+    "@pulsemcp/air-core": "0.0.17"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.16"
+    "@pulsemcp/air-core": "0.0.17"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.16"
+    "@pulsemcp/air-core": "0.0.17"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.16"
+    "@pulsemcp/air-core": "0.0.17"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.16"
+    "@pulsemcp/air-core": "0.0.17"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/init-from-repo.ts
+++ b/packages/sdk/src/init-from-repo.ts
@@ -13,7 +13,6 @@ import {
   getAllSchemaTypes,
   validateJson,
   type SchemaType,
-  type RootEntry,
 } from "@pulsemcp/air-core";
 import { initConfig } from "./init.js";
 
@@ -75,10 +74,6 @@ export interface InitFromRepoResult {
   discovered: DiscoveredArtifact[];
   /** Whether an existing config was overwritten. */
   overwritten: boolean;
-  /** Absolute path to the auto-generated roots.json, if created. */
-  generatedRootsPath: string;
-  /** Name/key of the auto-generated root entry. */
-  generatedRootName: string;
 }
 
 /**
@@ -231,42 +226,12 @@ export function discoverArtifacts(
 }
 
 /**
- * Extract artifact entry IDs from discovered artifact files.
- * Reads each file, parses the JSON, and collects the top-level keys (IDs).
- */
-function extractArtifactIds(
-  discovered: DiscoveredArtifact[],
-  repoRoot: string
-): Partial<Record<string, string[]>> {
-  const ids: Partial<Record<string, string[]>> = {};
-  for (const artifact of discovered) {
-    const filePath = resolve(repoRoot, artifact.repoPath);
-    try {
-      const content = readFileSync(filePath, "utf-8");
-      const data = JSON.parse(content);
-      const { $schema, ...entries } = data;
-      const entryIds = Object.keys(entries);
-      if (entryIds.length > 0) {
-        if (!ids[artifact.type]) ids[artifact.type] = [];
-        ids[artifact.type]!.push(...entryIds);
-      }
-    } catch {
-      continue;
-    }
-  }
-  return ids;
-}
-
-/**
  * Initialize an AIR config from artifact files discovered in a git repository.
  *
  * Scans the git repo for artifact index files (skills.json, mcp.json, etc.),
  * detects the GitHub remote, and generates an air.json with github:// URIs
- * pointing to the repository's default branch.
- *
- * Also auto-generates a roots.json entry describing the current repo,
- * populated with default_skills, default_mcp_servers, and default_hooks
- * from the discovered artifacts.
+ * pointing to the repository's default branch. Only artifact types that have
+ * existing index files in the repo are included — nothing is auto-generated.
  *
  * @throws Error if not in a git repo, no GitHub remote, no artifacts found,
  *         or air.json already exists (unless force is true).
@@ -346,46 +311,8 @@ export function initFromRepo(
   const repoName = repo.split("/")[1] || "my-config";
   const configName = repoName.replace(/[^a-zA-Z0-9_-]/g, "-");
 
-  // Auto-generate roots.json for the current repo.
-  // Write to the repo directory (not ~/.air/) so it can be committed and
-  // referenced via github:// URI, consistent with other artifact types.
-  const artifactIds = extractArtifactIds(discovered, repoRoot);
-
-  const rootEntry: RootEntry = {
-    display_name: configName,
-    description: `Agent root for ${repo}.`,
-    url: remoteUrl.trim(),
-    default_branch: branch,
-    ...(artifactIds.skills?.length && { default_skills: artifactIds.skills }),
-    ...(artifactIds.mcp?.length && { default_mcp_servers: artifactIds.mcp }),
-    ...(artifactIds.plugins?.length && { default_plugins: artifactIds.plugins }),
-    ...(artifactIds.hooks?.length && { default_hooks: artifactIds.hooks }),
-  };
-
-  // Determine path for generated roots.json in the repo
-  const rootsRelPath = "roots/roots.json";
-  const rootsPath = resolve(repoRoot, rootsRelPath);
-  const hasExistingRoots = existsSync(rootsPath);
-
-  // Only write if the repo doesn't already have a roots.json at this path
-  if (!hasExistingRoots) {
-    mkdirSync(resolve(repoRoot, "roots"), { recursive: true });
-    const rootsJson: Record<string, unknown> = {
-      $schema: "https://raw.githubusercontent.com/pulsemcp/air/main/schemas/roots.schema.json",
-      [configName]: rootEntry,
-    };
-    writeFileSync(rootsPath, JSON.stringify(rootsJson, null, 2) + "\n");
-  }
-
-  // Add github:// URI for the generated roots to the grouped artifacts
-  const generatedRootsUri = `github://${repo}@${branch}/${rootsRelPath}`;
-  if (!hasExistingRoots) {
-    if (!grouped.roots) grouped.roots = [];
-    // Prepend so discovered roots from other locations can override
-    grouped.roots.unshift(generatedRootsUri);
-  }
-
-  // Build air.json — all artifact types use github:// URIs consistently
+  // Build air.json — only include artifact types that were discovered.
+  // If no roots index exists in the repo, roots are simply omitted.
   const airJson: Record<string, unknown> = {
     name: configName,
     extensions: [
@@ -413,8 +340,6 @@ export function initFromRepo(
     branch,
     discovered,
     overwritten,
-    generatedRootsPath: rootsPath,
-    generatedRootName: configName,
   };
 }
 
@@ -451,11 +376,6 @@ export function smartInit(options?: InitFromRepoOptions): SmartInitResult {
       const targetPath = options?.path ?? getDefaultAirJsonPath();
       if (existsSync(targetPath)) {
         unlinkSync(targetPath);
-      }
-      // Clean up auto-generated roots.json from a previous repo-mode init
-      const rootsPath = resolve(dirname(targetPath), "roots", "roots.json");
-      if (existsSync(rootsPath)) {
-        unlinkSync(rootsPath);
       }
     }
 

--- a/packages/sdk/tests/init-from-repo.test.ts
+++ b/packages/sdk/tests/init-from-repo.test.ts
@@ -354,11 +354,8 @@ describe("initFromRepo", () => {
     expect(airJson.mcp).toEqual([
       "github://acme/air-config@main/mcp/mcp.json",
     ]);
-    // roots uses github:// URI like other artifacts
-    expect(airJson.roots).toEqual([
-      "github://acme/air-config@main/roots/roots.json",
-    ]);
-    // Should not include empty artifact types
+    // Should not include artifact types without index files in the repo
+    expect(airJson.roots).toBeUndefined();
     expect(airJson.references).toBeUndefined();
     expect(airJson.plugins).toBeUndefined();
     expect(airJson.hooks).toBeUndefined();
@@ -606,7 +603,7 @@ describe("initFromRepo", () => {
     ]);
   });
 
-  it("auto-generates roots.json for the current repo", () => {
+  it("does not auto-generate roots.json when none exists in the repo", () => {
     const repoDir = createGitRepo(
       "https://github.com/acme/my-project.git",
       {
@@ -623,118 +620,17 @@ describe("initFromRepo", () => {
     const outputDir = makeTempDir();
     const airJsonPath = resolve(outputDir, "air.json");
 
-    const result = initFromRepo({
+    initFromRepo({
       cwd: repoDir,
       path: airJsonPath,
     });
 
-    // Verify result fields — roots.json is now written to the repo directory
-    expect(result.generatedRootName).toBe("my-project");
-    expect(result.generatedRootsPath).toBe(
-      resolve(repoDir, "roots", "roots.json")
-    );
+    // No roots.json should be created in the repo
+    expect(existsSync(resolve(repoDir, "roots", "roots.json"))).toBe(false);
 
-    // Verify roots.json file was created
-    expect(existsSync(result.generatedRootsPath)).toBe(true);
-    const rootsJson = JSON.parse(
-      readFileSync(result.generatedRootsPath, "utf-8")
-    );
-    expect(rootsJson.$schema).toBe(
-      "https://raw.githubusercontent.com/pulsemcp/air/main/schemas/roots.schema.json"
-    );
-    expect(rootsJson["my-project"]).toBeDefined();
-    expect(rootsJson["my-project"].display_name).toBe("my-project");
-    expect(rootsJson["my-project"].description).toBe(
-      "Agent root for acme/my-project."
-    );
-    expect(rootsJson["my-project"].url).toBe(
-      "https://github.com/acme/my-project.git"
-    );
-    expect(rootsJson["my-project"].default_branch).toBe("main");
-  });
-
-  it("populates root defaults from discovered artifact IDs", () => {
-    const repoDir = createGitRepo(
-      "https://github.com/acme/config.git",
-      {
-        "skills/skills.json": {
-          "deploy-staging": {
-            id: "deploy-staging",
-            description: "Deploy",
-            path: "skills/deploy-staging",
-          },
-          "review-pr": {
-            id: "review-pr",
-            description: "Review",
-            path: "skills/review-pr",
-          },
-        },
-        "mcp/mcp.json": {
-          github: { type: "stdio", command: "npx", args: ["mcp"] },
-          postgres: { type: "stdio", command: "pg" },
-        },
-        "plugins/plugins.json": {
-          "code-quality": {
-            id: "code-quality",
-            description: "Code quality plugin",
-          },
-        },
-        "hooks/hooks.json": {
-          "lint-check": {
-            id: "lint-check",
-            description: "Lint",
-            path: "hooks/lint-check",
-          },
-        },
-      }
-    );
-
-    const outputDir = makeTempDir();
-    const airJsonPath = resolve(outputDir, "air.json");
-
-    const result = initFromRepo({
-      cwd: repoDir,
-      path: airJsonPath,
-    });
-
-    const rootsJson = JSON.parse(
-      readFileSync(result.generatedRootsPath, "utf-8")
-    );
-    const root = rootsJson["config"];
-
-    expect(root.default_skills).toEqual(["deploy-staging", "review-pr"]);
-    expect(root.default_mcp_servers).toEqual(["github", "postgres"]);
-    expect(root.default_plugins).toEqual(["code-quality"]);
-    expect(root.default_hooks).toEqual(["lint-check"]);
-  });
-
-  it("omits empty default arrays from generated root", () => {
-    const repoDir = createGitRepo(
-      "https://github.com/acme/simple.git",
-      {
-        "skills/skills.json": {
-          s1: { id: "s1", description: "A skill", path: "skills/s1" },
-        },
-      }
-    );
-
-    const outputDir = makeTempDir();
-    const airJsonPath = resolve(outputDir, "air.json");
-
-    const result = initFromRepo({
-      cwd: repoDir,
-      path: airJsonPath,
-    });
-
-    const rootsJson = JSON.parse(
-      readFileSync(result.generatedRootsPath, "utf-8")
-    );
-    const root = rootsJson["simple"];
-
-    expect(root.default_skills).toEqual(["s1"]);
-    expect(root.default_mcp_servers).toBeUndefined();
-    expect(root.default_plugins).toBeUndefined();
-    expect(root.default_hooks).toBeUndefined();
+    // air.json should not include a roots property
+    const airJson = JSON.parse(readFileSync(airJsonPath, "utf-8"));
+    expect(airJson.roots).toBeUndefined();
   });
 });
 
@@ -814,21 +710,4 @@ describe("smartInit", () => {
     expect(content.name).toBe("my-config");
   });
 
-  it("cleans up stale roots.json when falling back to blank with --force", () => {
-    const dir = makeTempDir();
-    const airJsonPath = resolve(dir, "air.json");
-
-    // Simulate a previous repo-mode init that created roots.json
-    writeFileSync(airJsonPath, '{"name":"old"}');
-    const rootsDir = resolve(dir, "roots");
-    mkdirSync(rootsDir, { recursive: true });
-    const rootsPath = resolve(rootsDir, "roots.json");
-    writeFileSync(rootsPath, '{"old-root":{"name":"old-root","description":"stale"}}');
-
-    const result = smartInit({ cwd: dir, path: airJsonPath, force: true });
-
-    expect(result.mode).toBe("blank");
-    // Stale roots.json should be cleaned up
-    expect(existsSync(rootsPath)).toBe(false);
-  });
 });


### PR DESCRIPTION
## Summary

- `air init` no longer auto-generates a `roots/roots.json` file in the repo. It only discovers existing artifact index files, consistent with how all other artifact types (skills, mcp, hooks, etc.) work.
- Removed `generatedRootsPath` and `generatedRootName` from `InitFromRepoResult` and cleaned up CLI output, `smartInit` cleanup logic, and related tests.
- Updated docs (`cli.md`, `guides/roots.md`, `guides/quickstart.md`) to describe discovery-only behavior.

## Context

Previously, `air init` would create a `roots/roots.json` in the repo and reference it via a `github://` URI in `air.json`. This broke `air start claude` because the `github://` URI wasn't resolvable until the file was committed and pushed — a workflow gap with no documentation or warning. More fundamentally, if a roots index already existed elsewhere in the repo (e.g., `agents/agent-roots/roots.json`), `air init` should have discovered it rather than creating a duplicate at a hardcoded path.

The fix is simple: treat roots like every other artifact type. If a valid `roots.json` exists in the repo, `discoverArtifacts` finds it. If not, roots are omitted from `air.json`.

## Verification

- [x] CI green — all 5 checks pass (validate-schemas, e2e, test on Node 18/20/22)
- [x] Type-check clean across core, SDK, and CLI
- [x] Tests updated — removed 3 roots-generation tests, added 1 test asserting no auto-generation (37 init-from-repo tests pass)
- [x] Docs updated — `cli.md`, `guides/roots.md`, and `guides/quickstart.md` reflect discovery-only behavior
- [x] Version bumped to 0.0.17 with changelog entry
- [x] Self-review done — verified no stale references to `generatedRootsPath`, `generatedRootName`, `extractArtifactIds`, or `RootEntry` import remain
- [x] Independent subagent review completed — one finding (stale quickstart.md reference) identified and fixed

### Test evidence

```
 ✓ |@pulsemcp/air-sdk| tests/init-from-repo.test.ts (37 tests) 2314ms
 ✓ |@pulsemcp/air-sdk| tests/init.test.ts (3 tests) 11ms
 ✓ |@pulsemcp/air-core| (86 tests)

 Test Files  7 passed (7)
      Tests  126 passed (126)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)