### PR TITLE
docs: refine quickstart prerequisites and per-session config guidance

### DIFF
--- a/docs/guides/configuring-mcp-servers.md
+++ b/docs/guides/configuring-mcp-servers.md
@@ -4,7 +4,7 @@ MCP (Model Context Protocol) servers provide tools and data to AI agents. AIR ma
 
 ## User-level MCP servers and AIR
 
-AIR manages MCP server configuration per-session. If you already have user-scoped MCP servers configured in your agent (e.g., in `~/.claude/.mcp.json`), you should migrate them into AIR index files and remove the user-level config. Otherwise both will be active during sessions, leading to duplicated servers, version conflicts, and configuration that isn't shared with your team or version-controlled. See the [Quickstart](quickstart.md#how-air-manages-configuration) for more context.
+If you already have user-scoped MCP servers configured in your agent (e.g., Claude Code's `~/.claude/.mcp.json`), migrate them into AIR index files and remove the user-level config before starting sessions. See [How AIR manages configuration](quickstart.md#how-air-manages-configuration) for why this matters and how to migrate.
 
 ## Defining MCP servers
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -7,13 +7,13 @@ Get from zero to a working AIR setup in under five minutes.
 - Node.js 18 or later
 - npm
 - An AI coding agent (e.g., [Claude Code](https://docs.anthropic.com/en/docs/claude-code))
-- **A repository with at least one artifact index file.** AIR manages configuration that already exists — the CLI reads from JSON index files (e.g., `skills/skills.json`, `mcp/mcp.json`) that define your artifacts. You need at least one index file with at least one entry for any of the [artifact types](../concepts.md#artifact-types) before AIR has anything to work with. See the [examples/](../../examples/) directory for reference.
+- **A repository (recommended).** `air init` works best when run inside a git repo that already has artifact index files (e.g., `skills/skills.json`, `mcp/mcp.json`) — it discovers them automatically and generates a fully wired `air.json`. Without pre-existing artifacts, it falls back to blank scaffolding you can populate manually. See [examples/air.json](../../examples/air.json) for the expected format and [artifact types](../concepts.md#artifact-types) for what kinds of artifacts you can define.
 
 ## How AIR manages configuration
 
-AIR uses **per-session, project-level configuration**. Every time you start a session, AIR assembles the active configuration from your `air.json` and its referenced index files — nothing is persisted into the agent's own user-level config.
+AIR uses **per-session configuration**. Every time you start a session, AIR assembles the active configuration from your `air.json` and its referenced index files — nothing is persisted into the agent's own user-level config.
 
-This means you should **disable or remove any user-scoped agent configuration** you may already have (e.g., user-level MCP servers in `~/.claude/.mcp.json`, global tool settings). If left in place, user-level config will be active alongside AIR-managed config, which leads to duplication, conflicts, and config that isn't version-controlled or shared with your team. The goal is for `air.json` and its artifact indexes to be the single source of truth for every session.
+This means you should **disable or remove any user-scoped agent configuration** you may already have (e.g., user-level MCP servers such as Claude Code's `~/.claude/.mcp.json`, or global tool settings). If left in place, user-level config will be active alongside AIR-managed config, which leads to duplication, conflicts, and config that isn't version-controlled or shared with your team. To migrate, move your existing server definitions into an AIR MCP index file (see [Configuring MCP Servers](configuring-mcp-servers.md)), then remove the user-level config. The goal is for `air.json` and its artifact indexes to be the single source of truth for every session.
 
 See [Per-Session Configuration](../concepts.md#4-per-session-configuration) in the design principles for more detail.
 

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -4,7 +4,7 @@ AIR provides two commands for launching agent sessions: `air start` for interact
 
 ## Before you start
 
-AIR manages configuration **per-session** — it assembles everything from `air.json` and writes it fresh each time. To avoid conflicts and duplication, disable any user-scoped agent configuration before running sessions (e.g., user-level MCP servers in `~/.claude/.mcp.json`, global tool settings). AIR-managed config should be the single source of truth. See the [Quickstart](quickstart.md#how-air-manages-configuration) for details.
+AIR manages configuration **per-session** — it assembles everything fresh from `air.json` each time. Before your first session, ensure any user-scoped agent configuration is disabled so AIR is the single source of truth. See [How AIR manages configuration](quickstart.md#how-air-manages-configuration) for details and migration steps.
 
 ## air start — interactive sessions
 


### PR DESCRIPTION
## Summary
Follow-up to #62. Refines the prerequisite and per-session configuration guidance based on review feedback:

- **Soften prerequisite**: Changed from a hard requirement ("must have artifact index files") to a recommendation — `air init` works without pre-existing artifacts via blank scaffolding
- **Fix terminology**: Changed "per-session, project-level configuration" to "per-session configuration" to match the distinction in concepts.md (per-project and per-session are explicitly different)
- **Add migration guidance**: Added a sentence explaining how to migrate existing user-level config into AIR index files
- **Improve link target**: Changed `../../examples/` directory link to `../../examples/air.json` for a clearer landing
- **Reduce redundancy**: Made running-sessions.md and configuring-mcp-servers.md into concise cross-references to the quickstart's canonical explanation, reducing drift risk
- **Agent-agnostic framing**: Changed `~/.claude/.mcp.json` references to be framed as agent-specific examples (e.g., "Claude Code's `~/.claude/.mcp.json`") since AIR is agent-agnostic

## Verification
- [x] CI green — docs-only change, all 5 checks pass (validate-schemas, test 18/20/22, e2e)
- [x] Self-review done — all markdown links verified against real anchors/paths
- [x] Subagent PR review performed with fresh eyes; all 6 findings (1 major, 2 minor, 3 nits) addressed in this commit
- [x] Prose accuracy verified against concepts.md design principles

🤖 Generated with [Claude Code](https://claude.com/claude-code)