### PR TITLE
feat: TUI legend improvements — search-mode hints and tabs→types rename (v0.0.27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.27] - 2026-04-12
+
+### Changed
+- Rename `←→ tabs` to `←→ types` in the TUI legend since the arrow keys switch between artifact types, not browser-style tabs
+
+### Added
+- Context-sensitive key hints in the TUI legend bar: search mode displays `↑↓ navigate` / `Space toggle` (on overridable tabs) / `Enter confirm` / `Esc cancel`; normal mode shows the full legend
+
 ## [0.0.26] - 2026-04-11
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1775946369-cc49afaa",
+  "name": "air-main-1775953439-8edd592f",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -843,9 +843,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.26",
+        "@pulsemcp/air-sdk": "0.0.27",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -864,7 +864,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -880,9 +880,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.26"
+        "@pulsemcp/air-core": "0.0.27"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -895,9 +895,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.26"
+        "@pulsemcp/air-core": "0.0.27"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -910,9 +910,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.26"
+        "@pulsemcp/air-core": "0.0.27"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -925,9 +925,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.26"
+        "@pulsemcp/air-core": "0.0.27"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -940,9 +940,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.26"
+        "@pulsemcp/air-core": "0.0.27"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.26",
+    "@pulsemcp/air-sdk": "0.0.27",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/tui/render.ts
+++ b/packages/cli/src/tui/render.ts
@@ -131,23 +131,32 @@ export function render(state: TuiState, viewportHeight: number): string[] {
 
   // ── Key legend ──
   lines.push("");
-  const legendParts = [
-    `${chalk.dim("←→")} tabs`,
-    `${chalk.dim("↑↓")} navigate`,
-  ];
-  if (isOverridable) {
+  const legendParts: string[] = [];
+  if (state.searchActive) {
     legendParts.push(
-      `${chalk.dim("Space")} toggle`,
-      `${chalk.dim("a")} all`,
-      `${chalk.dim("n")} none`,
-      `${chalk.dim("o")} only`
+      `${chalk.dim("↑↓")} navigate`,
+      `${chalk.dim("Enter")} select`,
+      `${chalk.dim("Esc")} cancel`
+    );
+  } else {
+    legendParts.push(
+      `${chalk.dim("←→")} types`,
+      `${chalk.dim("↑↓")} navigate`
+    );
+    if (isOverridable) {
+      legendParts.push(
+        `${chalk.dim("Space")} toggle`,
+        `${chalk.dim("a")} all`,
+        `${chalk.dim("n")} none`,
+        `${chalk.dim("o")} only`
+      );
+    }
+    legendParts.push(
+      `${chalk.dim("/")} search`,
+      `${chalk.dim("Enter")} start`,
+      `${chalk.dim("q")} quit`
     );
   }
-  legendParts.push(
-    `${chalk.dim("/")} search`,
-    `${chalk.dim("Enter")} start`,
-    `${chalk.dim("q")} quit`
-  );
   lines.push("  " + legendParts.join("  "));
   lines.push("");
 

--- a/packages/cli/src/tui/render.ts
+++ b/packages/cli/src/tui/render.ts
@@ -133,9 +133,12 @@ export function render(state: TuiState, viewportHeight: number): string[] {
   lines.push("");
   const legendParts: string[] = [];
   if (state.searchActive) {
+    legendParts.push(`${chalk.dim("↑↓")} navigate`);
+    if (isOverridable) {
+      legendParts.push(`${chalk.dim("Space")} toggle`);
+    }
     legendParts.push(
-      `${chalk.dim("↑↓")} navigate`,
-      `${chalk.dim("Enter")} select`,
+      `${chalk.dim("Enter")} confirm`,
       `${chalk.dim("Esc")} cancel`
     );
   } else {

--- a/packages/cli/tests/tui-render.test.ts
+++ b/packages/cli/tests/tui-render.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { ResolvedArtifacts } from "@pulsemcp/air-sdk";
+import { buildInitialState } from "../src/tui/types.js";
+import { render } from "../src/tui/render.js";
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1B\[[0-9;]*[A-Za-z]/g;
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, "");
+}
+
+function makeArtifacts(
+  overrides: Partial<ResolvedArtifacts> = {}
+): ResolvedArtifacts {
+  return {
+    skills: {},
+    references: {},
+    mcp: {},
+    plugins: {},
+    roots: {},
+    hooks: {},
+    ...overrides,
+  };
+}
+
+function findLegendLine(lines: string[]): string {
+  // The legend line contains key hints like "navigate", "quit", etc.
+  const line = lines.find(
+    (l) => stripAnsi(l).includes("navigate") && stripAnsi(l).includes("quit")
+  );
+  return line ? stripAnsi(line) : "";
+}
+
+function findSearchLegendLine(lines: string[]): string {
+  // In search mode the legend contains "Esc" and "navigate"
+  const line = lines.find(
+    (l) => stripAnsi(l).includes("navigate") && stripAnsi(l).includes("Esc")
+  );
+  return line ? stripAnsi(line) : "";
+}
+
+describe("render legend", () => {
+  let origColumns: number | undefined;
+  let origRows: number | undefined;
+
+  beforeEach(() => {
+    origColumns = process.stdout.columns;
+    origRows = process.stdout.rows;
+    // Set a reasonable terminal size for tests
+    Object.defineProperty(process.stdout, "columns", {
+      value: 120,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdout, "rows", {
+      value: 40,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, "columns", {
+      value: origColumns,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdout, "rows", {
+      value: origRows,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('shows "types" instead of "tabs" in the legend', () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          server1: {
+            type: "stdio",
+            command: "node",
+            description: "A server",
+          },
+        },
+      })
+    );
+    const lines = render(state, 10);
+    const legend = findLegendLine(lines);
+    expect(legend).toContain("types");
+    expect(legend).not.toContain("tabs");
+  });
+
+  it("shows Esc hint in search mode legend", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          server1: {
+            type: "stdio",
+            command: "node",
+            description: "A server",
+          },
+        },
+      })
+    );
+    state.searchActive = true;
+    state.searchQuery = "";
+    const lines = render(state, 10);
+    const legend = findSearchLegendLine(lines);
+    expect(legend).toContain("Esc");
+    expect(legend).toContain("cancel");
+  });
+
+  it("does not show types/search/quit hints in search mode", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          server1: {
+            type: "stdio",
+            command: "node",
+            description: "A server",
+          },
+        },
+      })
+    );
+    state.searchActive = true;
+    state.searchQuery = "test";
+    const lines = render(state, 10);
+    const legend = findSearchLegendLine(lines);
+    expect(legend).toContain("Esc");
+    // Normal-mode-only hints should be absent
+    expect(legend).not.toContain("types");
+    expect(legend).not.toContain("quit");
+  });
+
+  it("shows normal legend when search is not active", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          server1: {
+            type: "stdio",
+            command: "node",
+            description: "A server",
+          },
+        },
+      })
+    );
+    const lines = render(state, 10);
+    const legend = findLegendLine(lines);
+    expect(legend).toContain("types");
+    expect(legend).toContain("search");
+    expect(legend).toContain("quit");
+    expect(legend).not.toContain("Esc");
+  });
+});

--- a/packages/cli/tests/tui-render.test.ts
+++ b/packages/cli/tests/tui-render.test.ts
@@ -90,7 +90,7 @@ describe("render legend", () => {
     expect(legend).not.toContain("tabs");
   });
 
-  it("shows Esc hint in search mode legend", () => {
+  it("shows Esc and Space toggle in search mode on overridable tab", () => {
     const state = buildInitialState(
       makeArtifacts({
         mcp: {
@@ -108,6 +108,8 @@ describe("render legend", () => {
     const legend = findSearchLegendLine(lines);
     expect(legend).toContain("Esc");
     expect(legend).toContain("cancel");
+    expect(legend).toContain("confirm");
+    expect(legend).toContain("toggle");
   });
 
   it("does not show types/search/quit hints in search mode", () => {
@@ -150,5 +152,40 @@ describe("render legend", () => {
     expect(legend).toContain("search");
     expect(legend).toContain("quit");
     expect(legend).not.toContain("Esc");
+  });
+
+  it("omits toggle/all/none/only on non-overridable tab", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        hooks: {
+          "my-hook": { description: "A hook" },
+        },
+      })
+    );
+    const lines = render(state, 10);
+    const legend = findLegendLine(lines);
+    expect(legend).toContain("types");
+    expect(legend).toContain("navigate");
+    expect(legend).not.toContain("toggle");
+    expect(legend).not.toContain("all");
+    expect(legend).not.toContain("none");
+    expect(legend).not.toContain("only");
+  });
+
+  it("omits Space toggle in search mode on non-overridable tab", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        hooks: {
+          "my-hook": { description: "A hook" },
+        },
+      })
+    );
+    state.searchActive = true;
+    state.searchQuery = "";
+    const lines = render(state, 10);
+    const legend = findSearchLegendLine(lines);
+    expect(legend).toContain("Esc");
+    expect(legend).toContain("confirm");
+    expect(legend).not.toContain("toggle");
   });
 });

--- a/packages/cli/tests/tui-render.test.ts
+++ b/packages/cli/tests/tui-render.test.ts
@@ -154,7 +154,7 @@ describe("render legend", () => {
     expect(legend).not.toContain("Esc");
   });
 
-  it("omits toggle/all/none/only on non-overridable tab", () => {
+  it("shows toggle/all/none/only on hooks tab (now overridable)", () => {
     const state = buildInitialState(
       makeArtifacts({
         hooks: {
@@ -166,13 +166,13 @@ describe("render legend", () => {
     const legend = findLegendLine(lines);
     expect(legend).toContain("types");
     expect(legend).toContain("navigate");
-    expect(legend).not.toContain("toggle");
-    expect(legend).not.toContain("all");
-    expect(legend).not.toContain("none");
-    expect(legend).not.toContain("only");
+    expect(legend).toContain("toggle");
+    expect(legend).toContain("all");
+    expect(legend).toContain("none");
+    expect(legend).toContain("only");
   });
 
-  it("omits Space toggle in search mode on non-overridable tab", () => {
+  it("shows Space toggle in search mode on hooks tab (now overridable)", () => {
     const state = buildInitialState(
       makeArtifacts({
         hooks: {
@@ -186,6 +186,6 @@ describe("render legend", () => {
     const legend = findSearchLegendLine(lines);
     expect(legend).toContain("Esc");
     expect(legend).toContain("confirm");
-    expect(legend).not.toContain("toggle");
+    expect(legend).toContain("toggle");
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.26"
+    "@pulsemcp/air-core": "0.0.27"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.26"
+    "@pulsemcp/air-core": "0.0.27"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.26"
+    "@pulsemcp/air-core": "0.0.27"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.26"
+    "@pulsemcp/air-core": "0.0.27"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.26"
+    "@pulsemcp/air-core": "0.0.27"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary
- Show context-sensitive key hints in the TUI legend bar: when in search mode, display `↑↓ navigate` / `Space toggle` (on overridable tabs) / `Enter confirm` / `Esc cancel`; in normal mode, show the full legend as before
- Rename `←→ tabs` to `←→ types` in the legend since the arrow keys switch between artifact types (MCP, Skills, Hooks, Plugins), not browser-style tabs
- Bump all packages to 0.0.27 (accounts for missing version bump on PR #78 which shipped at 0.0.26)

## Verification
- [x] CI green — all 5 checks passed (validate-schemas, test on Node 18/20/22, e2e)
- [x] Rebased cleanly onto current main (includes PRs #69–#80)
- [x] New render tests added (`tui-render.test.ts`) — 6 tests covering normal mode, search mode, overridable tabs
- [x] Tests updated to reflect hooks/plugins now being overridable (per PR #80)
- [x] All 476 tests passing across 29 test files (zero failures)
- [x] Independent subagent code review completed — no blocking issues found
- [x] Version bump verified: all 7 `package.json` files at 0.0.27, zero stale refs, lockfile regenerated, builds pass

### Proof of correctness
**Full test suite (476/476 passing):**
```
 ✓ |@pulsemcp/air-cli| tests/tui-render.test.ts (6 tests) 12ms
   ✓ shows "types" instead of "tabs" in the legend
   ✓ shows Esc and Space toggle in search mode on overridable tab
   ✓ does not show types/search/quit hints in search mode
   ✓ shows normal legend when search is not active
   ✓ shows toggle/all/none/only on hooks tab (now overridable)
   ✓ shows Space toggle in search mode on hooks tab (now overridable)

 Test Files  29 passed (29)
      Tests  476 passed (476)
```

**CI checks (all green):**
```
e2e           pass  43s
test (18)     pass  1m6s
test (20)     pass  1m0s
test (22)     pass  57s
validate-schemas  pass  19s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)