### PR TITLE
docs: clarify single-session scope and add multi-session tips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.20] - 2026-04-11
+
+### Changed
+- Clarified across documentation that AIR is a single-session configuration layer with no orchestration capabilities
+- Added practical tips for running multiple sessions using git clones or worktrees
+- Updated TUI documentation to use "types" instead of "tabs" for artifact type navigation
+
 ## [0.0.19] - 2026-04-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -215,18 +215,19 @@ Hooks are shell commands that fire at agent lifecycle events. Use them for notif
 
 ## Scope
 
-AIR is a **configuration layer** — it resolves, validates, and translates agent configs. It is not an orchestration platform.
+AIR is a **single-session configuration layer** — it resolves, validates, and translates agent configs for one session at a time. It is not an orchestration platform.
 
 | AIR handles | Orchestration platforms handle |
 |-------------|-------------------------------|
 | Config resolution & composition | Session persistence & status tracking |
 | JSON Schema validation | Subagent invocation & coordination |
 | Agent-specific translation | Job queuing, retries, scheduling |
-| Single-session setup via `air start` | Secret management & credential vaults |
+| Single-session setup (`air start` / `air prepare`) | Secret management & credential vaults |
 | `${ENV_VAR}` interpolation in configs | Git clone lifecycle & working directories |
 | | Monitoring, cost tracking, dashboards |
+| | Running multiple sessions in parallel |
 
-Teams building multi-agent systems use AIR as the config layer underneath their orchestration platform. See [Orchestration](docs/orchestration.md) for patterns and guidance.
+Each `air start` or `air prepare` call sets up exactly one agent session in one working directory. If you need to run multiple sessions concurrently, you need separate working directories and a way to manage them — see [Running Sessions](docs/guides/running-sessions.md#tips-for-running-multiple-sessions) for practical tips, or [Orchestration](docs/orchestration.md) for building a full orchestration layer on top of AIR.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ AIR solves this by:
 - **Orienting around open standards** — Agent Skills, MCP, Plugins, and more to come. The agentic ecosystem will constantly evolve, but agreed-upon standards and interfaces will be the deterministic mainstays that the ecosystem builds on top of. Everything else is just custom glue.
 - **Keeping everything in git** — All configuration is version-controlled, reviewable, and composable. No proprietary backends.
 - **Being maximally DRY** — No copy/pasting, drift, or unclear ownership. If someone in your org does the work once and catalogs it properly, nobody ever has to touch it again.
-- **Per-agent-session configs** — Not per-user or per-project (those don't scale). Each session assembles exactly what it needs from composable layers.
+- **Single-session configs** — Not per-user or per-project (those don't scale). Each session assembles exactly what it needs from composable layers.
 - **Working with any coding agent** — AIR is a common layer across the ecosystem of opinionated agent implementations. Start with one agent, switch later to the newest frontier implementation without undoing your organization's work.
 
 ## Standards Maturity
@@ -313,7 +313,7 @@ Schemas are in the [`schemas/`](schemas/) directory. Point your editor's JSON sc
 1. **Open standards are the building blocks.** Ecosystems build deterministic layers around open standards. Orient around them.
 2. **Bias towards git and files.** All data lives in git repos. Use open-source tooling or roll your own.
 3. **Maximally DRY.** Don't duplicate anything that semantically represents the same thing. Compose, don't copy.
-4. **Per-agent-session configs.** Per-user and per-project configs don't scale — they drift. Compose what each session needs from reusable layers.
+4. **Single-session configs.** Per-user and per-project configs don't scale — they drift. Each `air start` assembles what one session needs from reusable layers.
 5. **Carefully collaborate.** Treat shared configs like software other people use. Make scope crystal clear. If it's org-level, anyone in the org should understand the description.
 6. **Build for everyone.** AI agents aren't just for engineers — engineers are the early adopters. Don't build infrastructure only engineers can use.
 7. **Fork and make it your own.** Teams are encouraged to fork this framework and adapt it. The patterns matter more than the specific implementation.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -99,13 +99,13 @@ If you find yourself duplicating content, that's a signal to extract it into a r
 
 ### 4. Per-Session Configuration
 
-AIR targets per-agent-session configs, not per-user or per-project. The distinction matters:
+AIR targets **single-session** configuration, not per-user or per-project. The distinction matters:
 
 - **Per-user configs** drift between users and don't compose
 - **Per-project configs** duplicate across projects and aren't appropriate for every session
 - **Per-session configs** are assembled from composable layers at session start time
 
-Each session gets exactly what it needs, composed from org, team, project, and local layers.
+Each `air start` or `air prepare` call sets up exactly one agent session in one working directory. AIR does not coordinate multiple sessions, manage parallelism, or orchestrate agents — those are concerns for a separate orchestration layer. See [Orchestration](orchestration.md) for what belongs where.
 
 ### 5. Progressive Disclosure
 
@@ -127,6 +127,6 @@ The description is what agents (and humans) use to decide relevance. Make it cou
 
 ## What AIR Is Not
 
-AIR is a configuration layer — it resolves, validates, and translates. It does not orchestrate agent sessions, manage subagents, persist state, or handle secrets.
+AIR is a **single-session configuration layer** — it resolves, validates, and translates config for one agent session at a time. It does not orchestrate multiple sessions, coordinate agents, persist state, or handle secrets.
 
-Teams building multi-agent systems (sequential pipelines, delegated subagents, event-triggered sessions) use AIR as the config layer underneath their orchestration platform. See [Orchestration & Multi-Agent Patterns](orchestration.md) for guidance on what belongs where.
+If you need to run multiple agent sessions (sequential pipelines, delegated subagents, event-triggered sessions), you need a separate orchestration layer. AIR is the config foundation underneath it. See [Orchestration & Multi-Agent Patterns](orchestration.md) for guidance on what belongs where.

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -27,12 +27,12 @@ air start claude
 
 When run in a TTY, `air start` opens an interactive terminal UI where you can:
 
-- **Browse artifact types** — use left/right arrows to switch between MCP, Skills, Hooks, and Plugins tabs
+- **Browse artifact types** — use left/right arrows to switch between MCP, Skills, Hooks, and Plugins
 - **Select/deselect artifacts** — use up/down arrows to navigate, Space to toggle, `a` for all, `n` for none, `o` for only current
 - **Search** — press `/` to filter items by name or description, Escape to clear
 - **Launch** — press Enter to start the agent with your selections, `q` or Ctrl+C to cancel
 
-The footer shows a cross-artifact selection summary so you can see what's selected across all tabs.
+The footer shows a cross-artifact selection summary so you can see what's selected across all types.
 
 When not in a TTY (e.g., in a CI pipeline) or when `--skip-confirmation` is passed, the TUI is skipped and the agent launches with root defaults.
 
@@ -203,6 +203,54 @@ Artifacts resolved → Adapter translates → Transforms modify → Session read
 5. **Adapter** translates AIR artifacts to agent-specific format (e.g., writes `.mcp.json`, copies skills and hook directories)
 6. **Transforms** (from extensions) modify the output (e.g., inject secrets)
 7. **Validation** checks for unresolved `${VAR}` patterns
+
+## Tips for running multiple sessions
+
+AIR sets up one session per working directory. If you want to run multiple agent sessions on the same repo at the same time — for example, one agent fixing a bug while another writes docs — each session needs its own isolated copy of the repo. Two practical approaches:
+
+### Approach 1: Rotate through git clones
+
+Create a few clones of your repo upfront and rotate through them:
+
+```bash
+# One-time setup: create a few working copies
+git clone https://github.com/acme/web-app.git ~/agents/web-app-1
+git clone https://github.com/acme/web-app.git ~/agents/web-app-2
+git clone https://github.com/acme/web-app.git ~/agents/web-app-3
+
+# Start a session in each clone
+cd ~/agents/web-app-1 && air start claude
+cd ~/agents/web-app-2 && air start claude
+```
+
+This is the simplest approach. When a session finishes, merge its branch and reuse the clone for the next task.
+
+### Approach 2: Use git worktrees
+
+Git worktrees let you check out multiple branches of the same repo simultaneously without duplicating the full `.git` directory:
+
+```bash
+# From your main clone, create worktrees for each session
+cd ~/repos/web-app
+git worktree add ~/agents/web-app-bugfix feature/bugfix
+git worktree add ~/agents/web-app-docs feature/docs
+
+# Start a session in each worktree
+cd ~/agents/web-app-bugfix && air start claude
+cd ~/agents/web-app-docs && air start claude
+
+# Clean up when done
+git worktree remove ~/agents/web-app-bugfix
+```
+
+Worktrees are more disk-efficient than full clones and share git history, but require comfort with the `git worktree` command. See `git worktree --help` for details.
+
+### Which to choose?
+
+- **Clones** are simpler and fully independent — if one clone gets into a bad state, the others are unaffected. Good default choice.
+- **Worktrees** share the `.git` directory, so they use less disk space and `git fetch` in one worktree updates all of them. Better when you have many sessions on a large repo.
+
+Both approaches work identically with `air start` and `air prepare` — AIR doesn't care how the working directory was created.
 
 ## Common patterns
 

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -4,7 +4,7 @@ AIR provides two commands for launching agent sessions: `air start` for interact
 
 ## Before you start
 
-AIR manages configuration **per-session** — it assembles everything fresh from `air.json` each time. Before your first session, ensure any user-scoped agent configuration is disabled so AIR is the single source of truth. See [How AIR manages configuration](quickstart.md#how-air-manages-configuration) for details and migration steps.
+AIR assembles configuration for a **single session** from `air.json` each time you run `air start` or `air prepare`. Before your first session, ensure any user-scoped agent configuration is disabled so AIR is the single source of truth. See [How AIR manages configuration](quickstart.md#how-air-manages-configuration) for details and migration steps.
 
 ## air start — interactive sessions
 
@@ -230,10 +230,10 @@ This is the simplest approach. When a session finishes, merge its branch and reu
 Git worktrees let you check out multiple branches of the same repo simultaneously without duplicating the full `.git` directory:
 
 ```bash
-# From your main clone, create worktrees for each session
+# From your main clone, create worktrees with new branches
 cd ~/repos/web-app
-git worktree add ~/agents/web-app-bugfix feature/bugfix
-git worktree add ~/agents/web-app-docs feature/docs
+git worktree add -b feature/bugfix ~/agents/web-app-bugfix
+git worktree add -b feature/docs ~/agents/web-app-docs
 
 # Start a session in each worktree
 cd ~/agents/web-app-bugfix && air start claude
@@ -241,6 +241,7 @@ cd ~/agents/web-app-docs && air start claude
 
 # Clean up when done
 git worktree remove ~/agents/web-app-bugfix
+git worktree remove ~/agents/web-app-docs
 ```
 
 Worktrees are more disk-efficient than full clones and share git history, but require comfort with the `git worktree` command. See `git worktree --help` for details.

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -1,6 +1,6 @@
 # Orchestration & Multi-Agent Patterns
 
-AIR is a **configuration layer** — it defines what an agent session needs (skills, MCP servers, references, hooks) and translates it for the target agent. It does not manage the lifecycle of sessions, coordinate multiple agents, or persist state between runs.
+AIR is a **single-session configuration layer**. Each `air start` or `air prepare` call assembles config for exactly one agent session in one working directory. AIR does not manage session lifecycles, coordinate multiple agents, schedule work, or persist state between runs.
 
 This document clarifies what AIR handles, what it explicitly leaves to orchestration platforms, and what patterns teams should consider when building multi-agent systems on top of AIR.
 
@@ -9,7 +9,7 @@ This document clarifies what AIR handles, what it explicitly leaves to orchestra
 1. **Config resolution** — load `air.json`, merge artifact indexes, resolve a root's defaults into a concrete set of skills, MCP servers, plugins, hooks, and references.
 2. **Validation** — ensure all JSON files conform to AIR schemas.
 3. **Agent translation** — convert resolved artifacts into agent-specific formats (Claude Code `.mcp.json`, etc.).
-4. **Session setup** — `air start` assembles config and starts a single agent session.
+4. **Single-session setup** — `air start` assembles config and launches one agent session in the current working directory. `air prepare` writes config without launching.
 
 ## What AIR Does Not Do
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1775869165-90672d75",
+  "name": "air-main-1775867479-d96e9f87",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -843,9 +843,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.19",
+        "@pulsemcp/air-sdk": "0.0.20",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -864,7 +864,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -880,9 +880,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.19"
+        "@pulsemcp/air-core": "0.0.20"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -895,9 +895,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.19"
+        "@pulsemcp/air-core": "0.0.20"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -910,9 +910,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.19"
+        "@pulsemcp/air-core": "0.0.20"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -925,9 +925,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.19"
+        "@pulsemcp/air-core": "0.0.20"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -940,9 +940,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.19"
+        "@pulsemcp/air-core": "0.0.20"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.19",
+    "@pulsemcp/air-sdk": "0.0.20",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.19"
+    "@pulsemcp/air-core": "0.0.20"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.19"
+    "@pulsemcp/air-core": "0.0.20"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.19"
+    "@pulsemcp/air-core": "0.0.20"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.19"
+    "@pulsemcp/air-core": "0.0.20"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.19"
+    "@pulsemcp/air-core": "0.0.20"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary
- Clarify across README, concepts, orchestration, and running-sessions docs that AIR is a **single-session configuration layer** — it sets up one agent session per working directory with no orchestration capabilities
- Unify terminology: replace "per-agent-session" with "single-session" in README Why AIR section and Design Principles
- Add a new "Tips for running multiple sessions" section in the running-sessions guide with practical guidance on using **git clones** or **worktrees** to run parallel agent sessions
- Update "tabs" references in running-sessions TUI docs to "types" for consistency
- Bump all packages to 0.0.20

## Files changed
- `README.md` — Scope section reworded, "per-agent-session" → "single-session" in Why AIR and Design Principles, link to multi-session tips
- `docs/concepts.md` — "Per-Session Configuration" and "What AIR Is Not" sections sharpened
- `docs/orchestration.md` — Opening paragraph and "What AIR Does" list clarified
- `docs/guides/running-sessions.md` — New "Tips for running multiple sessions" section with git clone and worktree guidance; intro updated to single-session language; "tabs" → "types" in TUI description
- `CHANGELOG.md` — New 0.0.20 entry
- All `package.json` files and lockfile — version bump to 0.0.20

## Verification
- [x] CI green (confirmed via `wait-for-ci` skill after both pushes)
- [x] All CLI tests passing (33/33)
- [x] Build succeeds for core, SDK, and CLI
- [x] Version bump verified: all 7 `package.json` at 0.0.20, zero stale refs, lockfile regenerated
- [x] Independent subagent review completed — 3 substantive findings addressed: worktree `-b` flag, README terminology unification, running-sessions intro language
- [x] Rebased onto latest main (v0.0.19 from PR #69), conflicts resolved cleanly
- [x] No code changes — docs-only PR with version bump, no tests to add

### Proof of correctness
Documentation-only change verified by:
- Grepping for stale "tabs" references in docs (none remaining)
- Grepping for stale "per-agent-session" references (none remaining outside historical changelog)
- All four updated doc files consistently use "single-session" language
- Git worktree examples use correct `-b` flag for branch creation
- Build + test suite confirms version bump is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)