### PR TITLE
feat: add --no-subagent-merge to air start, fix TUI subagent pre-selection (v0.0.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.19] - 2026-04-11
+
+### Added
+- `--no-subagent-merge` flag for `air start` — parity with `air prepare` for skipping subagent root merging
+- TUI now pre-selects MCP servers and skills from subagent roots when a root declares `default_subagent_roots`
+- `getMergedDefaults` utility for computing the union of parent and subagent artifact defaults
+- `--dry-run` output for `air start` now reflects merged subagent artifacts
+
+### Changed
+- Adapter no longer merges subagent artifacts on top of explicit overrides — when `mcpServerOverrides` or `skillOverrides` are provided (e.g., from the TUI), they are treated as the final selection
+
 ## [0.0.18] - 2026-04-11
 
 ### Added

--- a/docs/guides/composition-and-overrides.md
+++ b/docs/guides/composition-and-overrides.md
@@ -173,7 +173,7 @@ Roots can declare dependencies on other roots via `default_subagent_roots`:
 }
 ```
 
-By default, `air prepare` merges the subagent roots' skills and MCP servers into the parent session. The parent's declarations take priority over subagent declarations. Opt out with `--no-subagent-merge`.
+By default, both `air start` and `air prepare` merge the subagent roots' skills and MCP servers into the parent session. The parent's declarations take priority over subagent declarations. Opt out with `--no-subagent-merge`.
 
 ## Advanced patterns
 

--- a/docs/guides/roots.md
+++ b/docs/guides/roots.md
@@ -136,11 +136,13 @@ A root can declare dependencies on other roots via `default_subagent_roots`:
 }
 ```
 
-By default, `air prepare` merges subagent roots' skills and MCP servers into the parent session and appends context about the subagent dependencies to the system prompt. This gives the parent agent awareness of its subagents' capabilities.
+By default, both `air start` and `air prepare` merge subagent roots' skills and MCP servers into the parent session and append context about the subagent dependencies to the system prompt. This gives the parent agent awareness of its subagents' capabilities.
 
 To opt out of this merging (e.g., when your orchestrator manages subagent composition externally):
 
 ```bash
+air start claude --no-subagent-merge
+# or
 air prepare claude --no-subagent-merge
 ```
 

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -45,6 +45,7 @@ Required argument: `<agent>` — the agent to start (e.g., `claude`).
 | `--root <name>` | Activate a specific root |
 | `--dry-run` | Preview configuration without starting |
 | `--skip-confirmation` | Skip the interactive TUI and launch directly |
+| `--no-subagent-merge` | Skip merging subagent roots' artifacts |
 
 ### Passing arguments to the agent
 
@@ -95,6 +96,8 @@ air start claude --root web-app
 ```
 
 This activates only the MCP servers, skills, plugins, and hooks listed in the root's defaults. Without `--root`, `air start` auto-detects the root from the current directory's git context and pre-selects the root's defaults in the TUI.
+
+When a root declares `default_subagent_roots`, the TUI pre-selects MCP servers and skills from both the parent root and its subagent roots (union). The `--dry-run` output also reflects this merged view. Use `--no-subagent-merge` to disable this behavior.
 
 ## air prepare — programmatic sessions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1775865394-780f5ded",
+  "name": "air-main-1775869165-90672d75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -843,9 +843,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.18",
+        "@pulsemcp/air-sdk": "0.0.19",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -864,7 +864,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -880,9 +880,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.18"
+        "@pulsemcp/air-core": "0.0.19"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -895,9 +895,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.18"
+        "@pulsemcp/air-core": "0.0.19"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -910,9 +910,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.18"
+        "@pulsemcp/air-core": "0.0.19"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -925,9 +925,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.18"
+        "@pulsemcp/air-core": "0.0.19"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -940,9 +940,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.18"
+        "@pulsemcp/air-core": "0.0.19"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.18",
+    "@pulsemcp/air-sdk": "0.0.19",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -8,6 +8,7 @@ import {
   type RootEntry,
 } from "@pulsemcp/air-sdk";
 import { runInteractiveSelector } from "../tui/interactive-selector.js";
+import { getMergedDefaults } from "../tui/types.js";
 
 export function startCommand(): Command {
   const cmd = new Command("start")
@@ -19,6 +20,10 @@ export function startCommand(): Command {
       "--skip-confirmation",
       "Don't prompt for confirmation before starting"
     )
+    .option(
+      "--no-subagent-merge",
+      "Skip merging subagent roots' artifacts into the parent session (for orchestrators that manage composition externally)"
+    )
     .allowUnknownOption(true)
     .action(
       async (
@@ -27,6 +32,7 @@ export function startCommand(): Command {
           root?: string;
           dryRun?: boolean;
           skipConfirmation?: boolean;
+          subagentMerge: boolean;
         },
       ) => {
         const dashDashIdx = process.argv.indexOf("--");
@@ -61,9 +67,11 @@ export function startCommand(): Command {
           }
         }
 
+        const skipSubagentMerge = !options.subagentMerge;
+
         // Dry run
         if (options.dryRun) {
-          printDryRun(agent, result.artifacts, root);
+          printDryRun(agent, result.artifacts, root, skipSubagentMerge);
           process.exit(0);
         }
 
@@ -86,7 +94,8 @@ export function startCommand(): Command {
             result.artifacts,
             root,
             rootId,
-            rootAutoDetected
+            rootAutoDetected,
+            skipSubagentMerge
           );
 
           if (!tuiResult) {
@@ -106,6 +115,7 @@ export function startCommand(): Command {
             adapter: agent,
             skills: selectedSkills,
             mcpServers: selectedMcpServers,
+            skipSubagentMerge,
           });
         } catch (err) {
           const message =
@@ -143,7 +153,8 @@ export function startCommand(): Command {
 function printDryRun(
   agent: string,
   artifacts: ResolvedArtifacts,
-  root?: RootEntry
+  root?: RootEntry,
+  skipSubagentMerge = false
 ) {
   console.log(`\n=== AIR Session Configuration ===`);
   console.log(`Agent: ${agent}`);
@@ -152,8 +163,13 @@ function printDryRun(
     console.log(`Root: ${root.display_name || root.description}`);
   }
 
-  const mcpIds = root?.default_mcp_servers || Object.keys(artifacts.mcp);
-  const skillIds = root?.default_skills || Object.keys(artifacts.skills);
+  // Compute merged defaults from subagent roots (unless merge is disabled)
+  const merged = skipSubagentMerge
+    ? { mcpServerIds: root?.default_mcp_servers ?? [], skillIds: root?.default_skills ?? [] }
+    : getMergedDefaults(root, artifacts.roots);
+
+  const mcpIds = merged.mcpServerIds.length > 0 ? merged.mcpServerIds : (root?.default_mcp_servers || Object.keys(artifacts.mcp));
+  const skillIds = merged.skillIds.length > 0 ? merged.skillIds : (root?.default_skills || Object.keys(artifacts.skills));
   const pluginIds = root?.default_plugins || Object.keys(artifacts.plugins);
   const hookIds = root?.default_hooks || Object.keys(artifacts.hooks);
 

--- a/packages/cli/src/tui/interactive-selector.ts
+++ b/packages/cli/src/tui/interactive-selector.ts
@@ -74,9 +74,10 @@ export async function runInteractiveSelector(
   artifacts: ResolvedArtifacts,
   root?: RootEntry,
   rootId?: string,
-  rootAutoDetected = false
+  rootAutoDetected = false,
+  skipSubagentMerge = false
 ): Promise<TuiResult | null> {
-  const state = buildInitialState(artifacts, root, rootId, rootAutoDetected);
+  const state = buildInitialState(artifacts, root, rootId, rootAutoDetected, skipSubagentMerge);
 
   if (state.tabs.length === 0) {
     return getSelectedIds(state);

--- a/packages/cli/src/tui/types.ts
+++ b/packages/cli/src/tui/types.ts
@@ -56,11 +56,40 @@ export function getVisibleItems(state: TuiState): ArtifactItem[] {
   );
 }
 
+/**
+ * Compute merged default IDs by unioning the parent root's defaults with
+ * all subagent roots' defaults (MCP servers and skills only).
+ */
+export function getMergedDefaults(
+  root: RootEntry | undefined,
+  allRoots: Record<string, RootEntry>
+): { mcpServerIds: string[]; skillIds: string[] } {
+  const mcpSet = new Set(root?.default_mcp_servers ?? []);
+  const skillSet = new Set(root?.default_skills ?? []);
+
+  for (const subId of root?.default_subagent_roots ?? []) {
+    const sub = allRoots[subId];
+    if (!sub) continue;
+    if (sub.default_mcp_servers) {
+      for (const id of sub.default_mcp_servers) mcpSet.add(id);
+    }
+    if (sub.default_skills) {
+      for (const id of sub.default_skills) skillSet.add(id);
+    }
+  }
+
+  return {
+    mcpServerIds: [...mcpSet],
+    skillIds: [...skillSet],
+  };
+}
+
 export function buildInitialState(
   artifacts: ResolvedArtifacts,
   root?: RootEntry,
   rootId?: string,
-  rootAutoDetected = false
+  rootAutoDetected = false,
+  skipSubagentMerge = false
 ): TuiState {
   const buildItems = (
     entries: Record<string, { description?: string; title?: string }>,
@@ -76,9 +105,17 @@ export function buildInitialState(
       .sort((a, b) => a.id.localeCompare(b.id));
   };
 
+  // Compute merged defaults from subagent roots unless merge is disabled
+  const merged = skipSubagentMerge
+    ? { mcpServerIds: root?.default_mcp_servers ?? [], skillIds: root?.default_skills ?? [] }
+    : getMergedDefaults(root, artifacts.roots);
+
+  const mcpDefaults = merged.mcpServerIds.length > 0 ? merged.mcpServerIds : root?.default_mcp_servers;
+  const skillDefaults = merged.skillIds.length > 0 ? merged.skillIds : root?.default_skills;
+
   const items: Record<ArtifactCategory, ArtifactItem[]> = {
-    mcp: buildItems(artifacts.mcp, root?.default_mcp_servers),
-    skills: buildItems(artifacts.skills, root?.default_skills),
+    mcp: buildItems(artifacts.mcp, mcpDefaults),
+    skills: buildItems(artifacts.skills, skillDefaults),
     hooks: buildItems(artifacts.hooks, root?.default_hooks),
     plugins: buildItems(artifacts.plugins, root?.default_plugins),
   };

--- a/packages/cli/tests/tui-state.test.ts
+++ b/packages/cli/tests/tui-state.test.ts
@@ -5,6 +5,7 @@ import {
   getSelectedIds,
   getVisibleItems,
   getAllSelectionSummary,
+  getMergedDefaults,
 } from "../src/tui/types.js";
 
 function makeArtifacts(
@@ -292,5 +293,165 @@ describe("getAllSelectionSummary", () => {
   it("returns empty array when no tabs exist", () => {
     const state = buildInitialState(makeArtifacts());
     expect(getAllSelectionSummary(state)).toEqual([]);
+  });
+});
+
+describe("getMergedDefaults", () => {
+  it("returns parent defaults when no subagent roots exist", () => {
+    const result = getMergedDefaults(
+      { description: "Root", default_mcp_servers: ["s1"], default_skills: ["sk1"] },
+      {}
+    );
+    expect(result.mcpServerIds).toEqual(["s1"]);
+    expect(result.skillIds).toEqual(["sk1"]);
+  });
+
+  it("returns empty arrays when root has no defaults and no subagents", () => {
+    const result = getMergedDefaults({ description: "Root" }, {});
+    expect(result.mcpServerIds).toEqual([]);
+    expect(result.skillIds).toEqual([]);
+  });
+
+  it("unions parent and subagent MCP servers and skills", () => {
+    const roots = {
+      "sub-a": {
+        description: "Sub A",
+        default_mcp_servers: ["s2", "s3"],
+        default_skills: ["sk2"],
+      },
+      "sub-b": {
+        description: "Sub B",
+        default_mcp_servers: ["s3", "s4"],
+        default_skills: ["sk3"],
+      },
+    };
+    const result = getMergedDefaults(
+      {
+        description: "Parent",
+        default_mcp_servers: ["s1"],
+        default_skills: ["sk1"],
+        default_subagent_roots: ["sub-a", "sub-b"],
+      },
+      roots
+    );
+    expect(result.mcpServerIds.sort()).toEqual(["s1", "s2", "s3", "s4"]);
+    expect(result.skillIds.sort()).toEqual(["sk1", "sk2", "sk3"]);
+  });
+
+  it("collects subagent servers when parent has no default_mcp_servers", () => {
+    const roots = {
+      "sub-a": {
+        description: "Sub A",
+        default_mcp_servers: ["s1", "s2"],
+      },
+    };
+    const result = getMergedDefaults(
+      {
+        description: "Parent",
+        default_subagent_roots: ["sub-a"],
+      },
+      roots
+    );
+    expect(result.mcpServerIds.sort()).toEqual(["s1", "s2"]);
+  });
+
+  it("skips missing subagent root IDs", () => {
+    const result = getMergedDefaults(
+      {
+        description: "Parent",
+        default_mcp_servers: ["s1"],
+        default_subagent_roots: ["nonexistent"],
+      },
+      {}
+    );
+    expect(result.mcpServerIds).toEqual(["s1"]);
+  });
+
+  it("returns empty arrays for undefined root", () => {
+    const result = getMergedDefaults(undefined, {});
+    expect(result.mcpServerIds).toEqual([]);
+    expect(result.skillIds).toEqual([]);
+  });
+});
+
+describe("buildInitialState with subagent merge", () => {
+  it("pre-selects subagent MCP servers when merge is enabled", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          "parent-server": { type: "stdio", command: "node", description: "Parent" },
+          "sub-server": { type: "stdio", command: "node", description: "Subagent" },
+        },
+        roots: {
+          "sub-root": {
+            description: "Subagent root",
+            default_mcp_servers: ["sub-server"],
+          },
+        },
+      }),
+      {
+        description: "Parent root",
+        default_mcp_servers: ["parent-server"],
+        default_subagent_roots: ["sub-root"],
+      },
+      "parent",
+      false,
+      false // skipSubagentMerge = false
+    );
+    expect(state.items.mcp.find((i) => i.id === "parent-server")?.selected).toBe(true);
+    expect(state.items.mcp.find((i) => i.id === "sub-server")?.selected).toBe(true);
+  });
+
+  it("does not pre-select subagent servers when merge is disabled", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          "parent-server": { type: "stdio", command: "node", description: "Parent" },
+          "sub-server": { type: "stdio", command: "node", description: "Subagent" },
+        },
+        roots: {
+          "sub-root": {
+            description: "Subagent root",
+            default_mcp_servers: ["sub-server"],
+          },
+        },
+      }),
+      {
+        description: "Parent root",
+        default_mcp_servers: ["parent-server"],
+        default_subagent_roots: ["sub-root"],
+      },
+      "parent",
+      false,
+      true // skipSubagentMerge = true
+    );
+    expect(state.items.mcp.find((i) => i.id === "parent-server")?.selected).toBe(true);
+    expect(state.items.mcp.find((i) => i.id === "sub-server")?.selected).toBe(false);
+  });
+
+  it("pre-selects subagent skills when parent has no default_skills", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        skills: {
+          "sub-skill": { description: "Subagent skill", path: "/skills/sub-skill" },
+          "other-skill": { description: "Other skill", path: "/skills/other" },
+        },
+        roots: {
+          "sub-root": {
+            description: "Subagent root",
+            default_skills: ["sub-skill"],
+          },
+        },
+      }),
+      {
+        description: "Parent root",
+        default_subagent_roots: ["sub-root"],
+      },
+      "parent",
+      false,
+      false
+    );
+    expect(state.items.skills.find((i) => i.id === "sub-skill")?.selected).toBe(true);
+    expect(state.items.skills.find((i) => i.id === "other-skill")?.selected).toBe(false);
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.18"
+    "@pulsemcp/air-core": "0.0.19"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/adapter-claude/src/claude-adapter.ts
+++ b/packages/extensions/adapter-claude/src/claude-adapter.ts
@@ -106,12 +106,19 @@ export class ClaudeAdapter implements AgentAdapter {
       ?? root?.default_skills
       ?? [];
 
-    // 1b. Merge subagent roots' artifacts if applicable
+    // 1b. Merge subagent roots' artifacts if applicable.
+    // Skip merge per-artifact type when explicit overrides are provided —
+    // overrides represent the caller's final selection (e.g. from the TUI)
+    // and should not be augmented by implicit merge.
     const subagentRoots = this.resolveSubagentRoots(root, artifacts, options);
     if (subagentRoots.length > 0) {
       const merged = this.mergeSubagentArtifacts(subagentRoots, mcpServerIds, skillIds);
-      mcpServerIds = merged.mcpServerIds;
-      skillIds = merged.skillIds;
+      if (!options?.mcpServerOverrides) {
+        mcpServerIds = merged.mcpServerIds;
+      }
+      if (!options?.skillOverrides) {
+        skillIds = merged.skillIds;
+      }
     }
 
     const mcpServers = mcpServerIds?.length

--- a/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
+++ b/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
@@ -825,6 +825,107 @@ describe("ClaudeAdapter", () => {
         expect(result.subagentContext).toContain("Subagent B");
       });
 
+      it("skips MCP merge when mcpServerOverrides are provided", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        artifacts.mcp["github"] = { type: "stdio", command: "gh" };
+        artifacts.mcp["postgres"] = { type: "stdio", command: "psql" };
+        artifacts.mcp["slack"] = { type: "stdio", command: "slack" };
+
+        artifacts.roots["sub-db"] = {
+          description: "DB subagent",
+          default_mcp_servers: ["postgres"],
+        };
+
+        const root: RootEntry = {
+          description: "Parent root",
+          default_mcp_servers: ["github"],
+          default_subagent_roots: ["sub-db"],
+        };
+
+        // Explicit overrides should be the final word — subagent servers not re-added
+        await adapter.prepareSession(artifacts, dir, {
+          root,
+          mcpServerOverrides: ["github", "slack"],
+        });
+
+        const mcpJson = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
+        expect(Object.keys(mcpJson.mcpServers).sort()).toEqual(["github", "slack"]);
+        // postgres from subagent should NOT be added when overrides are explicit
+        expect(mcpJson.mcpServers["postgres"]).toBeUndefined();
+      });
+
+      it("skips skill merge when skillOverrides are provided", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        // Create real skill source directories
+        const parentSkillSrc = join(dir, "..", "skills-src", "parent-skill");
+        const subSkillSrc = join(dir, "..", "skills-src", "sub-skill");
+        mkdirSync(parentSkillSrc, { recursive: true });
+        mkdirSync(subSkillSrc, { recursive: true });
+        writeFileSync(join(parentSkillSrc, "SKILL.md"), "# Parent");
+        writeFileSync(join(subSkillSrc, "SKILL.md"), "# Sub");
+
+        artifacts.skills["parent-skill"] = { description: "Parent", path: resolve(parentSkillSrc) };
+        artifacts.skills["sub-skill"] = { description: "Sub", path: resolve(subSkillSrc) };
+
+        artifacts.roots["sub-root"] = {
+          description: "Subagent",
+          default_skills: ["sub-skill"],
+        };
+
+        const root: RootEntry = {
+          description: "Parent root",
+          default_skills: ["parent-skill"],
+          default_subagent_roots: ["sub-root"],
+        };
+
+        // Explicit skill overrides — subagent skills not re-added
+        await adapter.prepareSession(artifacts, dir, {
+          root,
+          skillOverrides: ["parent-skill"],
+        });
+
+        expect(existsSync(join(dir, ".claude", "skills", "parent-skill"))).toBe(true);
+        expect(existsSync(join(dir, ".claude", "skills", "sub-skill"))).toBe(false);
+      });
+
+      it("still merges MCP servers when only skill overrides are provided", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        artifacts.mcp["github"] = { type: "stdio", command: "gh" };
+        artifacts.mcp["postgres"] = { type: "stdio", command: "psql" };
+
+        const parentSkillSrc = join(dir, "..", "skills-src2", "parent-skill");
+        mkdirSync(parentSkillSrc, { recursive: true });
+        writeFileSync(join(parentSkillSrc, "SKILL.md"), "# Parent");
+        artifacts.skills["parent-skill"] = { description: "Parent", path: resolve(parentSkillSrc) };
+
+        artifacts.roots["sub-db"] = {
+          description: "DB subagent",
+          default_mcp_servers: ["postgres"],
+        };
+
+        const root: RootEntry = {
+          description: "Parent root",
+          default_mcp_servers: ["github"],
+          default_skills: ["parent-skill"],
+          default_subagent_roots: ["sub-db"],
+        };
+
+        // Skill overrides are set, but MCP overrides are NOT — MCP merge should still happen
+        await adapter.prepareSession(artifacts, dir, {
+          root,
+          skillOverrides: ["parent-skill"],
+        });
+
+        const mcpJson = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
+        expect(Object.keys(mcpJson.mcpServers).sort()).toEqual(["github", "postgres"]);
+      });
+
       it("does not merge when root has no default_subagent_roots", async () => {
         const dir = createTempDir();
         const artifacts = emptyArtifacts();

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.18"
+    "@pulsemcp/air-core": "0.0.19"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.18"
+    "@pulsemcp/air-core": "0.0.19"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.18"
+    "@pulsemcp/air-core": "0.0.19"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.18"
+    "@pulsemcp/air-core": "0.0.19"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -409,6 +409,21 @@ describe("air start", () => {
     expect(result.stdout).toContain("deploy");
   });
 
+  it("dry-run with --no-subagent-merge excludes subagent artifacts", () => {
+    const result = tryRun(
+      "start claude --dry-run --root platform-orchestrator --no-subagent-merge",
+      fixtureEnv
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("AIR Session Configuration");
+    // Parent's servers should be listed
+    expect(result.stdout).toContain("github-server");
+    expect(result.stdout).toContain("postgres-db");
+    // Subagent servers should NOT be listed
+    expect(result.stdout).not.toContain("analytics-api");
+    expect(result.stdout).not.toContain("terraform-server");
+  });
+
   it("succeeds when claude is on PATH", () => {
     const targetDir = createTempDir();
     const stubDir = createTempDir();

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -559,6 +559,33 @@ describe("air start", () => {
     expect(existsSync(join(targetDir, ".claude", "hooks", "session-audit"))).toBe(false);
   });
 
+  it("skips subagent merge with --no-subagent-merge on start", () => {
+    const targetDir = createTempDir();
+    const stubDir = createTempDir();
+    createStubClaude(stubDir);
+
+    const result = tryRunInDir(
+      "start claude --root platform-orchestrator --skip-confirmation --no-subagent-merge",
+      targetDir,
+      {
+        ...fixtureEnv,
+        PATH: `${stubDir}:${process.env.PATH}`,
+        GITHUB_TOKEN: "ghp_test_e2e_token",
+        PG_CONNECTION_STRING: "postgresql://test:test@localhost/test",
+        ANALYTICS_SECRET: "test_analytics_key",
+      }
+    );
+    expect(result.exitCode).toBe(0);
+
+    // Only parent's MCP servers — subagent servers NOT merged
+    const mcpJson = JSON.parse(readFileSync(join(targetDir, ".mcp.json"), "utf-8"));
+    expect(mcpJson.mcpServers["github-server"]).toBeDefined();
+    expect(mcpJson.mcpServers["postgres-db"]).toBeDefined();
+    // Subagent servers should NOT be present
+    expect(mcpJson.mcpServers["analytics-api"]).toBeUndefined();
+    expect(mcpJson.mcpServers["terraform-server"]).toBeUndefined();
+  });
+
   it("completes in non-TTY mode without --skip-confirmation", () => {
     const targetDir = createTempDir();
     const stubDir = createTempDir();


### PR DESCRIPTION
## Summary
- Add `--no-subagent-merge` flag to `air start` for parity with `air prepare` — previously only `air prepare` exposed this flag
- TUI now pre-selects MCP servers and skills from subagent roots when a root declares `default_subagent_roots`, so roots with no direct `default_mcp_servers` but with subagent roots show the merged view instead of nothing selected
- Adapter skips merge per-artifact type when explicit overrides are provided (from TUI or `--mcp-servers`/`--skills` flags), ensuring the caller's selections are the final word
- `--dry-run` output for `air start` now reflects merged subagent artifacts

## Changes

### CLI (`packages/cli`)
- `start.ts`: Added `--no-subagent-merge` flag, passes `skipSubagentMerge` to `prepareSession()` and TUI
- `types.ts`: Added `getMergedDefaults()` utility; `buildInitialState()` now accepts `skipSubagentMerge` param and computes merged defaults from subagent roots
- `interactive-selector.ts`: Passes `skipSubagentMerge` through to `buildInitialState()`
- `printDryRun()`: Uses merged defaults instead of only parent root defaults

### Adapter (`packages/extensions/adapter-claude`)
- `claude-adapter.ts`: Merge is now skipped per-artifact type when explicit overrides are provided — `mcpServerOverrides` prevents MCP merge, `skillOverrides` prevents skill merge, independently

### Documentation
- `running-sessions.md`: Added `--no-subagent-merge` to `air start` options table; added subagent merge TUI behavior paragraph
- `roots.md`: Updated to show both `air start` and `air prepare` support `--no-subagent-merge`
- `composition-and-overrides.md`: Updated merge description to mention both commands

## Verification
- [x] All 405 tests pass (26 test files) — 13 new tests added
- [x] New TUI tests: `getMergedDefaults` utility (6 tests), `buildInitialState` with subagent merge (3 tests)
- [x] New adapter tests: override-skips-merge for MCP servers, skills, and independent override behavior (3 tests)
- [x] New e2e test: `air start --no-subagent-merge` skips subagent merge (1 test)
- [x] Full build succeeds across all packages
- [x] Self-review completed

### E2E test results (logic change proof)
```
 ✓ air start > writes correct artifacts with --skip-confirmation (orchestrator root)
 ✓ air start > skips subagent merge with --no-subagent-merge on start
 ✓ air start > writes correct artifacts for frontend-app root (no subagents)
 ✓ air start > completes in non-TTY mode without --skip-confirmation
 ✓ air prepare > prepares orchestrator root with subagent merging and secrets resolution
 ✓ air prepare > skips subagent merge with --no-subagent-merge

 Test Files  26 passed (26)
      Tests  405 passed (405)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)