### PR TITLE
feat: add stale cache detection and `air update` command (v0.0.21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.21] - 2026-04-11
+
+### Added
+- `air update` CLI command to refresh cached provider data (e.g., stale GitHub repository clones)
+- `checkFreshness()` and `refreshCache()` optional methods on the `CatalogProvider` interface for cache lifecycle management
+- Staleness warnings printed to stderr when `air start` or `air prepare` detects that cached GitHub clones are behind remote
+- `CacheFreshnessWarning` and `CacheRefreshResult` types exported from `@pulsemcp/air-core` and `@pulsemcp/air-sdk`
+- `updateProviderCaches()` SDK function for programmatic cache refresh
+- `checkProviderFreshness()` SDK helper for checking provider cache freshness against remote sources
+
 ## [0.0.20] - 2026-04-11
 
 ### Changed

--- a/docs/guides/extensions.md
+++ b/docs/guides/extensions.md
@@ -121,7 +121,21 @@ It does a shallow clone of the repository to `~/.air/cache/github/{owner}/{repo}
 export AIR_GITHUB_TOKEN=ghp_xxxxxxxxxxxx
 ```
 
-**Cache:** Clones are cached locally. Delete `~/.air/cache/github/` to force re-fetching.
+**Cache:** Clones are cached locally and reused on subsequent runs. When a cached clone is behind the remote, `air start` and `air prepare` print a warning to stderr:
+
+```
+Warning: github://acme/shared-config@main is behind remote. Run `air update` to refresh.
+```
+
+Immutable refs (full commit SHAs) are never checked for freshness.
+
+To refresh all cached clones:
+
+```bash
+air update
+```
+
+This fetches the latest commits for each cached mutable ref and reports what changed. You can also delete `~/.air/cache/github/` to force a full re-clone.
 
 ## Transforms
 

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -148,6 +148,7 @@ Extensions can contribute additional flags — see [Extensions System](extension
 ```bash
 # Diagnostic output (stderr)
 Auto-detected root: web-app
+Warning: github://acme/shared-config@main is behind remote. Run `air update` to refresh.
 
 # Structured output (stdout)
 {
@@ -159,6 +160,8 @@ Auto-detected root: web-app
   }
 }
 ```
+
+Staleness warnings appear when cached provider data (e.g., GitHub clones) is behind the remote. These are informational — the session still runs with cached data. Run `air update` to refresh.
 
 ### Auto-detection
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1775867479-d96e9f87",
+  "name": "air-main-1775919493-c600bd06",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -843,9 +843,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.20",
+        "@pulsemcp/air-sdk": "0.0.21",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -864,7 +864,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -880,9 +880,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.20"
+        "@pulsemcp/air-core": "0.0.21"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -895,9 +895,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.20"
+        "@pulsemcp/air-core": "0.0.21"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -910,9 +910,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.20"
+        "@pulsemcp/air-core": "0.0.21"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -925,9 +925,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.20"
+        "@pulsemcp/air-core": "0.0.21"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -940,9 +940,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.20"
+        "@pulsemcp/air-core": "0.0.21"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.20",
+    "@pulsemcp/air-sdk": "0.0.21",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -147,6 +147,13 @@ export function prepareCommand(): Command {
             console.error(`Auto-detected root: ${result.root.display_name || result.root.description}`);
           }
 
+          // Print staleness warnings to stderr
+          if (result.warnings) {
+            for (const warning of result.warnings) {
+              console.error(`Warning: ${warning}`);
+            }
+          }
+
           // Output structured JSON to stdout for orchestrator consumption
           console.log(JSON.stringify(result.session, null, 2));
         } catch (err) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -52,6 +52,13 @@ export function startCommand(): Command {
           process.exit(1);
         }
 
+        // Print staleness warnings to stderr
+        if (result.warnings) {
+          for (const warning of result.warnings) {
+            console.error(`Warning: ${warning}`);
+          }
+        }
+
         // Resolve root: use explicit option, fall back to auto-detection
         let root = result.root;
         let rootId = options.root;

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,0 +1,45 @@
+import { Command } from "commander";
+import { updateProviderCaches } from "@pulsemcp/air-sdk";
+
+export function updateCommand(): Command {
+  const cmd = new Command("update")
+    .description(
+      "Refresh cached provider data (e.g., GitHub repository clones)"
+    )
+    .option(
+      "--config <path>",
+      "Path to air.json (defaults to AIR_CONFIG env or ~/.air/air.json)"
+    )
+    .action(async (options: { config?: string }) => {
+      try {
+        const { results } = await updateProviderCaches({
+          config: options.config,
+        });
+
+        const schemes = Object.keys(results);
+        if (schemes.length === 0) {
+          console.log("No providers with cached data found.");
+          return;
+        }
+
+        for (const scheme of schemes) {
+          const entries = results[scheme];
+          if (entries.length === 0) {
+            console.log(`${scheme}:// — no cached entries`);
+            continue;
+          }
+
+          for (const entry of entries) {
+            const icon = entry.updated ? "\u2713" : "\u00b7";
+            console.log(`  ${icon} ${entry.label} — ${entry.message}`);
+          }
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        console.error(`Error: ${message}`);
+        process.exit(1);
+      }
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ import { prepareCommand } from "./commands/prepare.js";
 import { listCommand } from "./commands/list.js";
 import { initCommand } from "./commands/init.js";
 import { installCommand } from "./commands/install.js";
+import { updateCommand } from "./commands/update.js";
 import { upgradeCommand } from "./commands/upgrade.js";
 
 const require = createRequire(import.meta.url);
@@ -26,6 +27,7 @@ program.addCommand(prepareCommand());
 program.addCommand(listCommand());
 program.addCommand(initCommand());
 program.addCommand(installCommand());
+program.addCommand(updateCommand());
 program.addCommand(upgradeCommand());
 
 program.parseAsync();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,8 @@ export type {
 export type {
   AgentAdapter,
   CatalogProvider,
+  CacheFreshnessWarning,
+  CacheRefreshResult,
   AirExtension,
   PrepareTransform,
   McpConfig,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -207,6 +207,40 @@ export interface CatalogProvider {
    * to absolute paths. Returns undefined if the source isn't locally available.
    */
   resolveSourceDir?(uri: string): string | undefined;
+  /**
+   * Check freshness of cached data for the given URIs.
+   * Returns warnings for any entries whose local cache is behind the remote.
+   * Providers that don't cache can omit this method.
+   */
+  checkFreshness?(uris: string[]): Promise<CacheFreshnessWarning[]>;
+  /**
+   * Refresh all cached data managed by this provider.
+   * Returns a result for each cached entry describing what happened.
+   */
+  refreshCache?(): Promise<CacheRefreshResult[]>;
+}
+
+/**
+ * Warning returned by CatalogProvider.checkFreshness() when a cached
+ * entry is behind the remote source.
+ */
+export interface CacheFreshnessWarning {
+  /** The URI that was checked (e.g., "github://owner/repo@main/path") */
+  uri: string;
+  /** Human-readable warning message */
+  message: string;
+}
+
+/**
+ * Result of refreshing a single cached entry via CatalogProvider.refreshCache().
+ */
+export interface CacheRefreshResult {
+  /** Human-readable label for the cached entry (e.g., "owner/repo@main") */
+  label: string;
+  /** Whether the entry was updated (false if already up-to-date or skipped) */
+  updated: boolean;
+  /** Human-readable status message */
+  message: string;
 }
 
 /**

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.20"
+    "@pulsemcp/air-core": "0.0.21"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.20"
+    "@pulsemcp/air-core": "0.0.21"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/src/github-provider.ts
+++ b/packages/extensions/provider-github/src/github-provider.ts
@@ -1,7 +1,11 @@
 import { execFileSync } from "child_process";
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, readdirSync } from "fs";
 import { resolve, dirname } from "path";
-import type { CatalogProvider } from "@pulsemcp/air-core";
+import type {
+  CatalogProvider,
+  CacheFreshnessWarning,
+  CacheRefreshResult,
+} from "@pulsemcp/air-core";
 
 export interface GitHubUri {
   owner: string;
@@ -145,6 +149,14 @@ function redactToken(text: string, token?: string): string {
 }
 
 /**
+ * Check whether a ref looks like a full commit SHA (40 hex chars).
+ * Full SHAs are immutable and never need freshness checking.
+ */
+function isImmutableRef(ref: string): boolean {
+  return /^[0-9a-f]{40}$/i.test(ref);
+}
+
+/**
  * GitHub catalog provider — resolves github:// URIs by cloning the
  * repository locally (shallow clone) and reading files from the clone.
  *
@@ -201,6 +213,179 @@ export class GitHubCatalogProvider implements CatalogProvider {
       return sourceDir;
     }
     return undefined;
+  }
+
+  /**
+   * Check freshness of cached clones for the given URIs.
+   * Compares local HEAD SHA against remote for mutable refs.
+   * Skips URIs with no local clone or immutable refs (full SHAs).
+   */
+  async checkFreshness(uris: string[]): Promise<CacheFreshnessWarning[]> {
+    // De-duplicate by owner/repo/ref so we only check each clone once
+    const seen = new Map<string, string>(); // cacheKey → first URI
+    const toCheck: { owner: string; repo: string; ref: string; uri: string }[] = [];
+
+    for (const uri of uris) {
+      const parsed = parseGitHubUri(uri);
+      const ref = parsed.ref || "HEAD";
+      const key = `${parsed.owner}/${parsed.repo}/${ref}`;
+      if (seen.has(key)) continue;
+      seen.set(key, uri);
+      toCheck.push({ owner: parsed.owner, repo: parsed.repo, ref, uri });
+    }
+
+    const warnings: CacheFreshnessWarning[] = [];
+
+    for (const { owner, repo, ref, uri } of toCheck) {
+      if (isImmutableRef(ref)) continue;
+
+      const cloneDir = getClonePath(owner, repo, ref);
+      if (!existsSync(resolve(cloneDir, ".git"))) continue;
+
+      try {
+        const localSha = execFileSync("git", ["rev-parse", "HEAD"], {
+          cwd: cloneDir,
+          encoding: "utf-8",
+          stdio: "pipe",
+          timeout: 10000,
+        }).trim();
+
+        const lsRemoteArgs = ref === "HEAD"
+          ? ["ls-remote", "origin", "HEAD"]
+          : ["ls-remote", "origin", ref];
+        const lsOutput = execFileSync("git", lsRemoteArgs, {
+          cwd: cloneDir,
+          encoding: "utf-8",
+          stdio: "pipe",
+          timeout: 15000,
+        }).trim();
+
+        if (!lsOutput) continue;
+
+        // ls-remote output: "<sha>\t<refname>" — take first line's SHA
+        const remoteSha = lsOutput.split("\n")[0].split("\t")[0];
+        if (remoteSha && remoteSha !== localSha) {
+          warnings.push({
+            uri,
+            message:
+              `github://${owner}/${repo}@${ref} is behind remote. ` +
+              `Run \`air update\` to refresh.`,
+          });
+        }
+      } catch {
+        // Network failure, auth issue, etc. — skip silently
+      }
+    }
+
+    return warnings;
+  }
+
+  /**
+   * Refresh all cached GitHub clones.
+   * Walks ~/.air/cache/github/ and updates each mutable-ref clone.
+   */
+  async refreshCache(): Promise<CacheRefreshResult[]> {
+    const cacheDir = getCacheDir();
+    if (!existsSync(cacheDir)) return [];
+
+    const results: CacheRefreshResult[] = [];
+
+    // Walk owner/repo/ref directories
+    let owners: string[];
+    try {
+      owners = readdirSync(cacheDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name);
+    } catch {
+      return [];
+    }
+
+    for (const owner of owners) {
+      const ownerDir = resolve(cacheDir, owner);
+      let repos: string[];
+      try {
+        repos = readdirSync(ownerDir, { withFileTypes: true })
+          .filter((d) => d.isDirectory())
+          .map((d) => d.name);
+      } catch {
+        continue;
+      }
+
+      for (const repo of repos) {
+        const repoDir = resolve(ownerDir, repo);
+        let refs: string[];
+        try {
+          refs = readdirSync(repoDir, { withFileTypes: true })
+            .filter((d) => d.isDirectory())
+            .map((d) => d.name);
+        } catch {
+          continue;
+        }
+
+        for (const ref of refs) {
+          const label = `${owner}/${repo}@${ref}`;
+          const cloneDir = resolve(repoDir, ref);
+
+          if (!existsSync(resolve(cloneDir, ".git"))) continue;
+
+          if (isImmutableRef(ref)) {
+            results.push({ label, updated: false, message: "skipped (immutable ref)" });
+            continue;
+          }
+
+          try {
+            // Get current SHA before fetch
+            const beforeSha = execFileSync("git", ["rev-parse", "HEAD"], {
+              cwd: cloneDir,
+              encoding: "utf-8",
+              stdio: "pipe",
+              timeout: 10000,
+            }).trim();
+
+            // Fetch latest
+            const fetchArgs = ref === "HEAD"
+              ? ["fetch", "--depth", "1", "origin"]
+              : ["fetch", "--depth", "1", "origin", ref];
+            execFileSync("git", fetchArgs, {
+              cwd: cloneDir,
+              stdio: "pipe",
+              timeout: 60000,
+            });
+
+            // Reset to fetched commit
+            const resetRef = ref === "HEAD" ? "origin/HEAD" : "FETCH_HEAD";
+            execFileSync("git", ["reset", "--hard", resetRef], {
+              cwd: cloneDir,
+              stdio: "pipe",
+              timeout: 10000,
+            });
+
+            const afterSha = execFileSync("git", ["rev-parse", "HEAD"], {
+              cwd: cloneDir,
+              encoding: "utf-8",
+              stdio: "pipe",
+              timeout: 10000,
+            }).trim();
+
+            if (afterSha !== beforeSha) {
+              results.push({
+                label,
+                updated: true,
+                message: `updated ${beforeSha.slice(0, 7)} → ${afterSha.slice(0, 7)}`,
+              });
+            } else {
+              results.push({ label, updated: false, message: "already up-to-date" });
+            }
+          } catch (err) {
+            const rawMsg = err instanceof Error ? err.message : String(err);
+            const msg = redactToken(rawMsg, this.token);
+            results.push({ label, updated: false, message: `failed: ${msg}` });
+          }
+        }
+      }
+    }
+
+    return results;
   }
 
   /**

--- a/packages/extensions/provider-github/tests/github-provider.test.ts
+++ b/packages/extensions/provider-github/tests/github-provider.test.ts
@@ -287,4 +287,98 @@ describe("GitHubCatalogProvider", () => {
       )
     ).rejects.toThrow("File not found in cloned repository");
   }, 30000);
+
+  // --- checkFreshness ---
+
+  it("checkFreshness returns empty array for URIs with no local clone", async () => {
+    const warnings = await provider.checkFreshness([
+      "github://nonexistent-owner-xyz/nonexistent-repo-xyz/file.json",
+    ]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("checkFreshness skips immutable refs (full SHA)", async () => {
+    const sha = "a".repeat(40);
+    const warnings = await provider.checkFreshness([
+      `github://pulsemcp/air@${sha}/examples/skills/skills.json`,
+    ]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("checkFreshness checks a cached clone against remote", async () => {
+    // Ensure clone exists
+    const cloneDir = getClonePath("pulsemcp", "air", "HEAD");
+    if (!existsSync(resolve(cloneDir, ".git"))) {
+      await provider.resolve(
+        "github://pulsemcp/air/examples/skills/skills.json",
+        "/tmp"
+      );
+    }
+
+    // Should return either empty (up-to-date) or a warning (behind)
+    const warnings = await provider.checkFreshness([
+      "github://pulsemcp/air/examples/skills/skills.json",
+    ]);
+    expect(Array.isArray(warnings)).toBe(true);
+
+    // If there are warnings, they should have the expected shape
+    for (const w of warnings) {
+      expect(w.uri).toBe("github://pulsemcp/air/examples/skills/skills.json");
+      expect(w.message).toContain("air update");
+    }
+  }, 30000);
+
+  it("checkFreshness de-duplicates by owner/repo/ref", async () => {
+    // Ensure clone exists
+    const cloneDir = getClonePath("pulsemcp", "air", "HEAD");
+    if (!existsSync(resolve(cloneDir, ".git"))) {
+      await provider.resolve(
+        "github://pulsemcp/air/examples/skills/skills.json",
+        "/tmp"
+      );
+    }
+
+    // Two URIs pointing to the same repo/ref should produce at most one warning
+    const warnings = await provider.checkFreshness([
+      "github://pulsemcp/air/examples/skills/skills.json",
+      "github://pulsemcp/air/examples/mcp/mcp.json",
+    ]);
+    // At most 1 warning for the single repo/ref
+    expect(warnings.length).toBeLessThanOrEqual(1);
+  }, 30000);
+
+  // --- refreshCache ---
+
+  it("refreshCache returns results for cached clones", async () => {
+    // Ensure at least one clone exists
+    const cloneDir = getClonePath("pulsemcp", "air", "HEAD");
+    if (!existsSync(resolve(cloneDir, ".git"))) {
+      await provider.resolve(
+        "github://pulsemcp/air/examples/skills/skills.json",
+        "/tmp"
+      );
+    }
+
+    const results = await provider.refreshCache();
+    expect(Array.isArray(results)).toBe(true);
+
+    // Should include the pulsemcp/air@HEAD clone
+    const airResult = results.find((r) => r.label.includes("pulsemcp/air"));
+    expect(airResult).toBeDefined();
+    expect(typeof airResult!.updated).toBe("boolean");
+    expect(typeof airResult!.message).toBe("string");
+  }, 60000);
+
+  it("refreshCache returns empty array when no cache exists", async () => {
+    // Create a provider that uses a non-existent cache dir by mocking HOME
+    const origHome = process.env.HOME;
+    process.env.HOME = "/tmp/air-test-no-cache-" + Date.now();
+    try {
+      const freshProvider = new GitHubCatalogProvider();
+      const results = await freshProvider.refreshCache();
+      expect(results).toEqual([]);
+    } finally {
+      process.env.HOME = origHome;
+    }
+  });
 });

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.20"
+    "@pulsemcp/air-core": "0.0.21"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.20"
+    "@pulsemcp/air-core": "0.0.21"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.20"
+    "@pulsemcp/air-core": "0.0.21"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/cache-freshness.ts
+++ b/packages/sdk/src/cache-freshness.ts
@@ -1,0 +1,54 @@
+import type { AirConfig, CatalogProvider } from "@pulsemcp/air-core";
+
+/**
+ * Collect all URI paths from an air.json config and check their freshness
+ * against the providers that handle them. Returns warning strings.
+ *
+ * This is best-effort: network failures or missing checkFreshness
+ * implementations are silently ignored.
+ */
+export async function checkProviderFreshness(
+  airConfig: AirConfig,
+  providers: CatalogProvider[]
+): Promise<string[]> {
+  // Collect all paths from artifact arrays
+  const allPaths = [
+    ...(airConfig.skills || []),
+    ...(airConfig.references || []),
+    ...(airConfig.mcp || []),
+    ...(airConfig.plugins || []),
+    ...(airConfig.roots || []),
+    ...(airConfig.hooks || []),
+  ];
+
+  // Group URIs by provider scheme
+  const urisByScheme = new Map<string, string[]>();
+  for (const p of allPaths) {
+    const match = p.match(/^([a-zA-Z][a-zA-Z0-9+\-.]*):\/\//);
+    if (!match) continue;
+    const scheme = match[1].toLowerCase();
+    if (scheme === "file") continue;
+    const list = urisByScheme.get(scheme) || [];
+    list.push(p);
+    urisByScheme.set(scheme, list);
+  }
+
+  const warnings: string[] = [];
+
+  for (const provider of providers) {
+    if (!provider.checkFreshness) continue;
+    const uris = urisByScheme.get(provider.scheme);
+    if (!uris || uris.length === 0) continue;
+
+    try {
+      const freshnessWarnings = await provider.checkFreshness(uris);
+      for (const w of freshnessWarnings) {
+        warnings.push(w.message);
+      }
+    } catch {
+      // Freshness check is best-effort — never block on failure
+    }
+  }
+
+  return warnings;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -36,6 +36,8 @@ export type {
   // Extension interfaces
   AgentAdapter,
   CatalogProvider,
+  CacheFreshnessWarning,
+  CacheRefreshResult,
   AirExtension,
   PrepareTransform,
   McpConfig,
@@ -106,6 +108,16 @@ export type { LoadedExtensions } from "./extension-loader.js";
 // Transform runner
 export { runTransforms } from "./transform-runner.js";
 export type { RunTransformsOptions } from "./transform-runner.js";
+
+// Provider cache management
+export { updateProviderCaches } from "./update.js";
+export type {
+  UpdateProviderCachesOptions,
+  UpdateProviderCachesResult,
+} from "./update.js";
+
+// Cache freshness checking
+export { checkProviderFreshness } from "./cache-freshness.js";
 
 // Config validation
 export {

--- a/packages/sdk/src/prepare.ts
+++ b/packages/sdk/src/prepare.ts
@@ -5,13 +5,14 @@ import {
   resolveArtifacts,
   type RootEntry,
   type PreparedSession,
+  type McpConfig,
 } from "@pulsemcp/air-core";
 import { findAdapter, listAvailableAdapters } from "./adapter-registry.js";
 import { detectRoot } from "./root-detection.js";
 import { loadExtensions, type LoadedExtensions } from "./extension-loader.js";
 import { runTransforms } from "./transform-runner.js";
+import { checkProviderFreshness } from "./cache-freshness.js";
 import { readFileSync } from "fs";
-import type { McpConfig } from "@pulsemcp/air-core";
 import {
   findUnresolvedVars,
   unresolvedVarsMessage,
@@ -65,6 +66,8 @@ export interface PrepareSessionResult {
   root?: RootEntry;
   /** Whether the root was auto-detected (true) or explicitly specified (false/undefined). */
   rootAutoDetected?: boolean;
+  /** Warnings from provider cache freshness checks (e.g., stale GitHub clones). */
+  warnings?: string[];
 }
 
 /**
@@ -89,12 +92,14 @@ export async function prepareSession(
   const airJsonDir = dirname(resolve(airJsonPath));
   const searchDirs = [airJsonDir];
 
+  // Load air.json config (needed for extensions and freshness checks)
+  const airConfig = loadAirConfig(airJsonPath);
+
   // Use pre-loaded extensions or load from air.json
   let loaded: LoadedExtensions;
   if (options.extensions) {
     loaded = options.extensions;
   } else {
-    const airConfig = loadAirConfig(airJsonPath);
     loaded = await loadExtensions(airConfig.extensions || [], airJsonDir);
   }
 
@@ -122,6 +127,9 @@ export async function prepareSession(
     .map((ext) => ext.provider!)
     .filter(Boolean);
   const artifacts = await resolveArtifacts(airJsonPath, { providers });
+
+  // Check freshness of provider caches (non-blocking — warnings only)
+  const warnings = await checkProviderFreshness(airConfig, providers);
 
   // Detect or validate root
   let root: RootEntry | undefined;
@@ -183,5 +191,10 @@ export async function prepareSession(
     }
   }
 
-  return { session, root, rootAutoDetected };
+  return {
+    session,
+    root,
+    rootAutoDetected,
+    warnings: warnings.length > 0 ? warnings : undefined,
+  };
 }

--- a/packages/sdk/src/start.ts
+++ b/packages/sdk/src/start.ts
@@ -11,6 +11,7 @@ import {
 } from "@pulsemcp/air-core";
 import { findAdapter, listAvailableAdapters } from "./adapter-registry.js";
 import { loadExtensions } from "./extension-loader.js";
+import { checkProviderFreshness } from "./cache-freshness.js";
 
 export interface StartSessionOptions {
   /** Root to activate by name. */
@@ -34,6 +35,8 @@ export interface StartSessionResult {
   startCommand: StartCommand;
   /** The agent adapter display name. */
   adapterDisplayName: string;
+  /** Warnings from provider cache freshness checks (e.g., stale GitHub clones). */
+  warnings?: string[];
 }
 
 /**
@@ -56,6 +59,8 @@ export async function startSession(
   let artifacts: ResolvedArtifacts;
   let adapter = null;
 
+  let warnings: string[] = [];
+
   if (airJsonPath) {
     const airConfig = loadAirConfig(airJsonPath);
     const loaded = await loadExtensions(
@@ -72,6 +77,9 @@ export async function startSession(
       .map((ext) => ext.provider!)
       .filter(Boolean);
     artifacts = await resolveArtifacts(airJsonPath, { providers });
+
+    // Check freshness of provider caches (non-blocking — warnings only)
+    warnings = await checkProviderFreshness(airConfig, providers);
   } else {
     artifacts = emptyArtifacts();
   }
@@ -115,5 +123,6 @@ export async function startSession(
     agentAvailable,
     startCommand,
     adapterDisplayName: adapter.displayName,
+    warnings: warnings.length > 0 ? warnings : undefined,
   };
 }

--- a/packages/sdk/src/update.ts
+++ b/packages/sdk/src/update.ts
@@ -1,0 +1,51 @@
+import { dirname, resolve } from "path";
+import {
+  loadAirConfig,
+  getAirJsonPath,
+  type CacheRefreshResult,
+} from "@pulsemcp/air-core";
+import { loadExtensions } from "./extension-loader.js";
+
+export interface UpdateProviderCachesOptions {
+  /** Path to air.json. Uses AIR_CONFIG env or ~/.air/air.json if not set. */
+  config?: string;
+}
+
+export interface UpdateProviderCachesResult {
+  /** Results from each provider, keyed by provider scheme. */
+  results: Record<string, CacheRefreshResult[]>;
+}
+
+/**
+ * Refresh all provider caches.
+ *
+ * Loads extensions from air.json, finds providers that implement
+ * refreshCache(), and calls them. Returns structured results.
+ *
+ * @throws Error if air.json is not found.
+ */
+export async function updateProviderCaches(
+  options?: UpdateProviderCachesOptions
+): Promise<UpdateProviderCachesResult> {
+  const airJsonPath = options?.config ?? getAirJsonPath();
+  if (!airJsonPath) {
+    throw new Error(
+      "No air.json found. Specify a config path or set AIR_CONFIG env var."
+    );
+  }
+
+  const airJsonDir = dirname(resolve(airJsonPath));
+  const airConfig = loadAirConfig(airJsonPath);
+  const loaded = await loadExtensions(airConfig.extensions || [], airJsonDir);
+
+  const results: Record<string, CacheRefreshResult[]> = {};
+
+  for (const ext of loaded.providers) {
+    const provider = ext.provider!;
+    if (!provider.refreshCache) continue;
+
+    results[provider.scheme] = await provider.refreshCache();
+  }
+
+  return { results };
+}

--- a/packages/sdk/tests/cache-freshness.test.ts
+++ b/packages/sdk/tests/cache-freshness.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { checkProviderFreshness } from "../src/cache-freshness.js";
+import type { AirConfig, CatalogProvider, CacheFreshnessWarning } from "@pulsemcp/air-core";
+
+describe("checkProviderFreshness", () => {
+  it("returns empty array when no providers have checkFreshness", async () => {
+    const config: AirConfig = {
+      name: "test",
+      skills: ["github://acme/repo/skills.json"],
+    };
+    const provider: CatalogProvider = {
+      scheme: "github",
+      resolve: async () => ({}),
+    };
+
+    const warnings = await checkProviderFreshness(config, [provider]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("returns empty array when no URIs match any provider", async () => {
+    const config: AirConfig = {
+      name: "test",
+      skills: ["./local/skills.json"],
+    };
+    const provider: CatalogProvider = {
+      scheme: "github",
+      resolve: async () => ({}),
+      checkFreshness: async () => [],
+    };
+
+    const warnings = await checkProviderFreshness(config, [provider]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("collects warnings from providers", async () => {
+    const config: AirConfig = {
+      name: "test",
+      skills: ["github://acme/repo@main/skills.json"],
+      mcp: ["github://acme/repo@main/mcp.json"],
+    };
+    const provider: CatalogProvider = {
+      scheme: "github",
+      resolve: async () => ({}),
+      checkFreshness: async (uris: string[]): Promise<CacheFreshnessWarning[]> => {
+        return uris.map((uri) => ({
+          uri,
+          message: `${uri} is stale`,
+        }));
+      },
+    };
+
+    const warnings = await checkProviderFreshness(config, [provider]);
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain("is stale");
+  });
+
+  it("skips file:// URIs", async () => {
+    const config: AirConfig = {
+      name: "test",
+      skills: ["file:///absolute/path/skills.json"],
+    };
+    const provider: CatalogProvider = {
+      scheme: "file",
+      resolve: async () => ({}),
+      checkFreshness: async () => [{ uri: "x", message: "should not be called" }],
+    };
+
+    const warnings = await checkProviderFreshness(config, [provider]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("handles checkFreshness errors gracefully", async () => {
+    const config: AirConfig = {
+      name: "test",
+      skills: ["github://acme/repo/skills.json"],
+    };
+    const provider: CatalogProvider = {
+      scheme: "github",
+      resolve: async () => ({}),
+      checkFreshness: async () => {
+        throw new Error("network failure");
+      },
+    };
+
+    const warnings = await checkProviderFreshness(config, [provider]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("routes URIs to the correct provider by scheme", async () => {
+    const config: AirConfig = {
+      name: "test",
+      skills: ["github://acme/repo/skills.json"],
+      mcp: ["s3://bucket/mcp.json"],
+    };
+
+    const githubUris: string[] = [];
+    const s3Uris: string[] = [];
+
+    const githubProvider: CatalogProvider = {
+      scheme: "github",
+      resolve: async () => ({}),
+      checkFreshness: async (uris) => {
+        githubUris.push(...uris);
+        return [];
+      },
+    };
+
+    const s3Provider: CatalogProvider = {
+      scheme: "s3",
+      resolve: async () => ({}),
+      checkFreshness: async (uris) => {
+        s3Uris.push(...uris);
+        return [];
+      },
+    };
+
+    await checkProviderFreshness(config, [githubProvider, s3Provider]);
+
+    expect(githubUris).toEqual(["github://acme/repo/skills.json"]);
+    expect(s3Uris).toEqual(["s3://bucket/mcp.json"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `checkFreshness()` and `refreshCache()` optional methods to the `CatalogProvider` interface in core, enabling providers to report stale caches and refresh them
- Implements both methods in the GitHub provider: `checkFreshness` does a lightweight `git ls-remote` to compare local vs remote SHAs (skipping immutable refs like full commit SHAs), and `refreshCache` walks `~/.air/cache/github/` and fetches latest for each mutable-ref clone
- `air start` and `air prepare` now print staleness warnings to stderr when cached GitHub clones are behind remote (e.g., `Warning: github://acme/repo@main is behind remote. Run 'air update' to refresh.`)
- New `air update` CLI command refreshes all provider caches and reports what changed
- New SDK functions: `updateProviderCaches()` for programmatic cache refresh, `checkProviderFreshness()` for checking freshness

## Architecture

The implementation follows the existing extension layering:

| Layer | Staleness warning | `air update` |
|---|---|---|
| **Core** | Defines `checkFreshness?()` on `CatalogProvider` | Defines `refreshCache?()` on `CatalogProvider` |
| **Provider** | Implements: `git ls-remote` vs local SHA | Implements: `git fetch + reset` per clone |
| **SDK** | Calls `checkFreshness` after `resolveArtifacts`, returns warnings | New `updateProviderCaches()` function |
| **CLI** | Prints warnings to stderr | New `air update` command |

Both methods are optional on `CatalogProvider`, so existing and future providers that don't cache data can simply omit them.

## Test plan
- [x] New unit tests for `checkProviderFreshness` SDK helper (6 tests)
- [x] New integration tests for `checkFreshness()` on GitHub provider (4 tests covering: no clone, immutable refs, cached clone, deduplication)
- [x] New integration tests for `refreshCache()` on GitHub provider (2 tests covering: existing cache, no cache)
- [x] All 127 tests in affected packages pass
- [x] All packages build cleanly (core → sdk → cli → provider-github)
- [ ] Manual: run `air start claude` with a stale GitHub clone and verify warning appears
- [ ] Manual: run `air update` and verify it refreshes cached clones

🤖 Generated with [Claude Code](https://claude.com/claude-code)