### PR TITLE
fix: discover cached providers in `air update` without requiring air.json extensions (v0.0.24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.24] - 2026-04-11
+
+### Fixed
+- `air update` now discovers cached providers by scanning `~/.air/cache/` even when providers aren't listed in `air.json` extensions — previously reported "No providers with cached data found" despite cached clones existing on disk
+- `air update` no longer requires `air.json` to exist — it can refresh cached data based on the cache directory structure alone
+
+### Added
+- Known provider auto-discovery in `updateProviderCaches()` — matches cache directory scheme names (e.g., `github/`) to known provider packages
+- SDK test suite for the `air update` flow covering provider discovery, cache refresh, stale clone detection, and immutable ref handling
+
 ## [0.0.23] - 2026-04-11
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -843,9 +843,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.23",
+        "@pulsemcp/air-sdk": "0.0.24",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -864,7 +864,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -880,9 +880,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.23"
+        "@pulsemcp/air-core": "0.0.24"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -895,9 +895,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.23"
+        "@pulsemcp/air-core": "0.0.24"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -910,9 +910,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.23"
+        "@pulsemcp/air-core": "0.0.24"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -925,9 +925,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.23"
+        "@pulsemcp/air-core": "0.0.24"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -940,9 +940,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.23"
+        "@pulsemcp/air-core": "0.0.24"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.23",
+    "@pulsemcp/air-sdk": "0.0.24",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.23"
+    "@pulsemcp/air-core": "0.0.24"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.23"
+    "@pulsemcp/air-core": "0.0.24"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.23"
+    "@pulsemcp/air-core": "0.0.24"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.23"
+    "@pulsemcp/air-core": "0.0.24"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.23"
+    "@pulsemcp/air-core": "0.0.24"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/update.ts
+++ b/packages/sdk/src/update.ts
@@ -1,10 +1,25 @@
-import { dirname, resolve } from "path";
+import { createRequire } from "module";
+import { existsSync, readdirSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { pathToFileURL } from "url";
 import {
   loadAirConfig,
   getAirJsonPath,
+  getDefaultAirJsonPath,
   type CacheRefreshResult,
+  type CatalogProvider,
+  type AirExtension,
 } from "@pulsemcp/air-core";
 import { loadExtensions } from "./extension-loader.js";
+import { resolveEsmEntry } from "./esm-resolve.js";
+
+/**
+ * Known provider packages, keyed by their cache directory name (scheme).
+ * Used to auto-discover providers when air.json doesn't list them.
+ */
+const KNOWN_PROVIDERS: Record<string, string> = {
+  github: "@pulsemcp/air-provider-github",
+};
 
 export interface UpdateProviderCachesOptions {
   /** Path to air.json. Uses AIR_CONFIG env or ~/.air/air.json if not set. */
@@ -17,34 +32,125 @@ export interface UpdateProviderCachesResult {
 }
 
 /**
+ * Get the AIR cache root directory (~/.air/cache).
+ */
+function getCacheRoot(): string {
+  const home = process.env.HOME || process.env.USERPROFILE || "~";
+  return resolve(home, ".air", "cache");
+}
+
+/**
+ * Scan ~/.air/cache/ for subdirectories, each representing a provider scheme
+ * that has cached data on disk.
+ */
+function discoverCachedSchemes(): string[] {
+  const cacheRoot = getCacheRoot();
+  if (!existsSync(cacheRoot)) return [];
+
+  try {
+    return readdirSync(cacheRoot, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Try to load a provider extension by package name, searching the given
+ * directories for the installed package. Handles CJS, ESM-only, and
+ * standard Node resolution.
+ */
+async function tryLoadProvider(
+  packageName: string,
+  searchDirs: string[]
+): Promise<CatalogProvider | null> {
+  for (const dir of searchDirs) {
+    try {
+      const req = createRequire(join(dir, "__placeholder.js"));
+      const resolved = req.resolve(packageName);
+      const mod = await import(pathToFileURL(resolved).href);
+      return (mod.default as AirExtension)?.provider ?? null;
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code === "ERR_PACKAGE_PATH_NOT_EXPORTED") {
+        const esmEntry = resolveEsmEntry(packageName, dir);
+        if (esmEntry) {
+          try {
+            const mod = await import(pathToFileURL(esmEntry).href);
+            return (mod.default as AirExtension)?.provider ?? null;
+          } catch {
+            // Fall through to next directory
+          }
+        }
+      }
+      // Not found in this directory, try next
+    }
+  }
+
+  // Fall back to standard Node resolution
+  try {
+    const mod = await import(packageName);
+    return (mod.default as AirExtension)?.provider ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Refresh all provider caches.
  *
- * Loads extensions from air.json, finds providers that implement
- * refreshCache(), and calls them. Returns structured results.
+ * Discovers providers in two ways:
+ * 1. From air.json extensions (if air.json exists)
+ * 2. By scanning ~/.air/cache/ for known provider cache directories
  *
- * @throws Error if air.json is not found.
+ * This ensures cached data is refreshed even when the provider isn't
+ * explicitly listed in air.json's extensions array.
  */
 export async function updateProviderCaches(
   options?: UpdateProviderCachesOptions
 ): Promise<UpdateProviderCachesResult> {
   const airJsonPath = options?.config ?? getAirJsonPath();
-  if (!airJsonPath) {
-    throw new Error(
-      "No air.json found. Specify a config path or set AIR_CONFIG env var."
-    );
+
+  const providers = new Map<string, CatalogProvider>();
+  let airJsonDir: string | null = null;
+
+  // Load providers from air.json extensions if available
+  if (airJsonPath) {
+    airJsonDir = dirname(resolve(airJsonPath));
+    const airConfig = loadAirConfig(airJsonPath);
+    const loaded = await loadExtensions(airConfig.extensions || [], airJsonDir);
+
+    for (const ext of loaded.providers) {
+      const provider = ext.provider!;
+      providers.set(provider.scheme, provider);
+    }
   }
 
-  const airJsonDir = dirname(resolve(airJsonPath));
-  const airConfig = loadAirConfig(airJsonPath);
-  const loaded = await loadExtensions(airConfig.extensions || [], airJsonDir);
+  // Discover additional providers from cache directory
+  const cachedSchemes = discoverCachedSchemes();
+  for (const scheme of cachedSchemes) {
+    if (providers.has(scheme)) continue;
+
+    const packageName = KNOWN_PROVIDERS[scheme];
+    if (!packageName) continue;
+
+    const searchDirs: string[] = [];
+    if (airJsonDir) searchDirs.push(airJsonDir);
+    const defaultAirDir = dirname(getDefaultAirJsonPath());
+    if (defaultAirDir !== airJsonDir) searchDirs.push(defaultAirDir);
+
+    const provider = await tryLoadProvider(packageName, searchDirs);
+    if (provider?.refreshCache) {
+      providers.set(scheme, provider);
+    }
+  }
 
   const results: Record<string, CacheRefreshResult[]> = {};
 
-  for (const ext of loaded.providers) {
-    const provider = ext.provider!;
+  for (const [scheme, provider] of providers) {
     if (!provider.refreshCache) continue;
-
-    results[provider.scheme] = await provider.refreshCache();
+    results[scheme] = await provider.refreshCache();
   }
 
   return { results };

--- a/packages/sdk/src/update.ts
+++ b/packages/sdk/src/update.ts
@@ -33,10 +33,11 @@ export interface UpdateProviderCachesResult {
 
 /**
  * Get the AIR cache root directory (~/.air/cache).
+ * Derived from getDefaultAirJsonPath() to stay in sync with core's
+ * notion of the AIR home directory.
  */
 function getCacheRoot(): string {
-  const home = process.env.HOME || process.env.USERPROFILE || "~";
-  return resolve(home, ".air", "cache");
+  return resolve(dirname(getDefaultAirJsonPath()), "cache");
 }
 
 /**

--- a/packages/sdk/tests/update.test.ts
+++ b/packages/sdk/tests/update.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { resolve, join } from "path";
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+} from "fs";
+import { execFileSync } from "child_process";
+import { tmpdir } from "os";
+import { updateProviderCaches } from "../src/update.js";
+
+const tempDirs: string[] = [];
+let origHome: string | undefined;
+
+afterEach(() => {
+  if (origHome !== undefined) {
+    process.env.HOME = origHome;
+    origHome = undefined;
+  }
+  for (const dir of tempDirs) {
+    if (existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  tempDirs.length = 0;
+});
+
+function createTempDir(): string {
+  const dir = resolve(
+    tmpdir(),
+    `air-sdk-update-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  tempDirs.push(dir);
+  return dir;
+}
+
+/**
+ * Create a bare git repo and a shallow clone of it in the cache directory.
+ * This simulates a cached GitHub clone at ~/.air/cache/github/{owner}/{repo}/{ref}.
+ */
+function createCachedClone(
+  fakeHome: string,
+  owner: string,
+  repo: string,
+  ref: string
+): string {
+  const gitEnv = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "test",
+    GIT_AUTHOR_EMAIL: "test@test.com",
+    GIT_COMMITTER_NAME: "test",
+    GIT_COMMITTER_EMAIL: "test@test.com",
+  };
+
+  // Create a "remote" repo with the desired branch name and one commit
+  const remoteDir = join(fakeHome, ".air-remotes", owner, repo);
+  mkdirSync(remoteDir, { recursive: true });
+  execFileSync("git", ["init", "--initial-branch", ref], { cwd: remoteDir, stdio: "pipe", env: gitEnv });
+  writeFileSync(join(remoteDir, "README.md"), "test");
+  execFileSync("git", ["add", "."], { cwd: remoteDir, stdio: "pipe", env: gitEnv });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: remoteDir, stdio: "pipe", env: gitEnv });
+
+  // Clone into the cache directory structure
+  const cacheDir = join(fakeHome, ".air", "cache", "github", owner, repo, ref);
+  mkdirSync(join(fakeHome, ".air", "cache", "github", owner, repo), { recursive: true });
+  execFileSync("git", ["clone", "--depth", "1", "--branch", ref, remoteDir, cacheDir], { stdio: "pipe", env: gitEnv });
+
+  return cacheDir;
+}
+
+function setFakeHome(dir: string): void {
+  origHome = process.env.HOME;
+  process.env.HOME = dir;
+}
+
+describe("updateProviderCaches", () => {
+  it("discovers providers from cache directory when air.json has no extensions", async () => {
+    const fakeHome = createTempDir();
+    setFakeHome(fakeHome);
+
+    // Create air.json with empty extensions
+    const airDir = join(fakeHome, ".air");
+    mkdirSync(airDir, { recursive: true });
+    writeFileSync(
+      join(airDir, "air.json"),
+      JSON.stringify({ name: "test", extensions: [] })
+    );
+
+    // Create a cached clone
+    createCachedClone(fakeHome, "test-owner", "test-repo", "main");
+
+    const { results } = await updateProviderCaches({
+      config: join(airDir, "air.json"),
+    });
+
+    // Provider should be discovered from cache directory
+    expect(results).toHaveProperty("github");
+    expect(results.github.length).toBeGreaterThan(0);
+
+    const entry = results.github.find((r) =>
+      r.label.includes("test-owner/test-repo@main")
+    );
+    expect(entry).toBeDefined();
+    expect(typeof entry!.updated).toBe("boolean");
+  }, 30000);
+
+  it("discovers providers from cache directory when air.json does not exist", async () => {
+    const fakeHome = createTempDir();
+    setFakeHome(fakeHome);
+
+    // Create a cached clone but no air.json
+    createCachedClone(fakeHome, "test-owner", "test-repo", "main");
+
+    const { results } = await updateProviderCaches();
+
+    // Provider should be discovered from cache directory even without air.json
+    expect(results).toHaveProperty("github");
+    expect(results.github.length).toBeGreaterThan(0);
+  }, 30000);
+
+  it("returns empty results when no cache directory exists", async () => {
+    const fakeHome = createTempDir();
+    setFakeHome(fakeHome);
+
+    // No cache directory and no air.json
+    const { results } = await updateProviderCaches();
+
+    expect(Object.keys(results)).toEqual([]);
+  });
+
+  it("returns empty results when cache directory has no known provider schemes", async () => {
+    const fakeHome = createTempDir();
+    setFakeHome(fakeHome);
+
+    // Create a cache directory with an unknown scheme
+    mkdirSync(join(fakeHome, ".air", "cache", "unknown-provider"), { recursive: true });
+
+    const { results } = await updateProviderCaches();
+
+    expect(Object.keys(results)).toEqual([]);
+  });
+
+  it("refreshes cached clone and reports update status", async () => {
+    const fakeHome = createTempDir();
+    setFakeHome(fakeHome);
+
+    const owner = "test-owner";
+    const repo = "test-repo";
+    const ref = "main";
+
+    // Create a cached clone
+    createCachedClone(fakeHome, owner, repo, ref);
+
+    // Push a new commit to the remote so the clone is stale
+    const remoteDir = join(fakeHome, ".air-remotes", owner, repo);
+    const gitEnv = {
+      ...process.env,
+      HOME: fakeHome,
+      GIT_AUTHOR_NAME: "test",
+      GIT_AUTHOR_EMAIL: "test@test.com",
+      GIT_COMMITTER_NAME: "test",
+      GIT_COMMITTER_EMAIL: "test@test.com",
+    };
+    writeFileSync(join(remoteDir, "new-file.txt"), "new content");
+    execFileSync("git", ["add", "."], { cwd: remoteDir, stdio: "pipe", env: gitEnv });
+    execFileSync("git", ["commit", "-m", "update"], { cwd: remoteDir, stdio: "pipe", env: gitEnv });
+
+    const { results } = await updateProviderCaches();
+
+    expect(results).toHaveProperty("github");
+    const entry = results.github.find((r) =>
+      r.label.includes(`${owner}/${repo}@${ref}`)
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.updated).toBe(true);
+    expect(entry!.message).toContain("→");
+  }, 30000);
+
+  it("reports already up-to-date when clone matches remote", async () => {
+    const fakeHome = createTempDir();
+    setFakeHome(fakeHome);
+
+    // Create a cached clone (no new commits pushed)
+    createCachedClone(fakeHome, "test-owner", "test-repo", "main");
+
+    const { results } = await updateProviderCaches();
+
+    expect(results).toHaveProperty("github");
+    const entry = results.github.find((r) =>
+      r.label.includes("test-owner/test-repo@main")
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.updated).toBe(false);
+    expect(entry!.message).toContain("up-to-date");
+  }, 30000);
+
+  it("skips immutable refs (full SHA)", async () => {
+    const fakeHome = createTempDir();
+    setFakeHome(fakeHome);
+
+    // Use a 40-char hex string as the ref (simulates a commit SHA)
+    const sha = "a".repeat(40);
+    createCachedClone(fakeHome, "test-owner", "test-repo", sha);
+
+    const { results } = await updateProviderCaches();
+
+    expect(results).toHaveProperty("github");
+    const entry = results.github.find((r) =>
+      r.label.includes(`test-owner/test-repo@${sha}`)
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.updated).toBe(false);
+    expect(entry!.message).toContain("immutable");
+  }, 30000);
+});

--- a/packages/sdk/tests/update.test.ts
+++ b/packages/sdk/tests/update.test.ts
@@ -12,11 +12,20 @@ import { updateProviderCaches } from "../src/update.js";
 
 const tempDirs: string[] = [];
 let origHome: string | undefined;
+let origAirConfig: string | undefined;
 
 afterEach(() => {
   if (origHome !== undefined) {
     process.env.HOME = origHome;
     origHome = undefined;
+  }
+  if (origAirConfig !== undefined) {
+    if (origAirConfig === "") {
+      delete process.env.AIR_CONFIG;
+    } else {
+      process.env.AIR_CONFIG = origAirConfig;
+    }
+    origAirConfig = undefined;
   }
   for (const dir of tempDirs) {
     if (existsSync(dir)) {
@@ -72,7 +81,9 @@ function createCachedClone(
 
 function setFakeHome(dir: string): void {
   origHome = process.env.HOME;
+  origAirConfig = process.env.AIR_CONFIG ?? "";
   process.env.HOME = dir;
+  delete process.env.AIR_CONFIG;
 }
 
 describe("updateProviderCaches", () => {
@@ -96,6 +107,39 @@ describe("updateProviderCaches", () => {
     });
 
     // Provider should be discovered from cache directory
+    expect(results).toHaveProperty("github");
+    expect(results.github.length).toBeGreaterThan(0);
+
+    const entry = results.github.find((r) =>
+      r.label.includes("test-owner/test-repo@main")
+    );
+    expect(entry).toBeDefined();
+    expect(typeof entry!.updated).toBe("boolean");
+  }, 30000);
+
+  it("loads provider from air.json extensions (regression)", async () => {
+    const fakeHome = createTempDir();
+    setFakeHome(fakeHome);
+
+    // Create air.json that lists the GitHub provider in extensions
+    const airDir = join(fakeHome, ".air");
+    mkdirSync(airDir, { recursive: true });
+    writeFileSync(
+      join(airDir, "air.json"),
+      JSON.stringify({
+        name: "test",
+        extensions: ["@pulsemcp/air-provider-github"],
+      })
+    );
+
+    // Create a cached clone
+    createCachedClone(fakeHome, "test-owner", "test-repo", "main");
+
+    const { results } = await updateProviderCaches({
+      config: join(airDir, "air.json"),
+    });
+
+    // Provider should be loaded from air.json extensions
     expect(results).toHaveProperty("github");
     expect(results.github.length).toBeGreaterThan(0);
 


### PR DESCRIPTION
## Summary

- `air update` now discovers cached providers by scanning `~/.air/cache/` for known provider cache directories, instead of relying solely on `air.json` extensions
- Makes `air.json` optional for the update command — cached data is refreshed based on filesystem presence
- Adds a `KNOWN_PROVIDERS` registry (similar to `KNOWN_ADAPTERS` in the adapter registry) that maps cache directory scheme names to provider packages

## Problem

When a user ran `air update`, the command loaded providers exclusively from `air.json`'s `extensions` array. If the provider wasn't listed there (or air.json didn't exist), the function returned empty results and the CLI reported "No providers with cached data found" — even when stale cached clones existed at `~/.air/cache/github/`.

The `refreshCache()` method on `GitHubCatalogProvider` is entirely filesystem-based (it walks `~/.air/cache/github/`), so it doesn't need config to work. The bug was that `updateProviderCaches()` couldn't call it without first loading the provider from air.json.

## Changes

**`packages/sdk/src/update.ts`** — Rewrote `updateProviderCaches()` to:
1. Load providers from air.json extensions (if available) — existing behavior, preserved
2. Scan `~/.air/cache/` for subdirectories matching known provider schemes
3. For each discovered scheme not already loaded, try to import the provider package
4. Call `refreshCache()` on all discovered providers

**`packages/sdk/tests/update.test.ts`** — New test suite (8 tests) covering:
- Provider discovery from cache directory when air.json has no extensions
- Provider discovery from air.json extensions (regression test)
- Provider discovery when air.json doesn't exist at all
- Empty results when no cache directory exists
- Unknown provider schemes are skipped
- Stale clone refresh with update detection
- Already up-to-date clone detection
- Immutable ref (full SHA) skipping

## Verification

- [x] CI green (all new tests pass, no regressions introduced)
- [x] 8 new tests added covering provider discovery and refresh logic
- [x] TypeScript compilation passes (`npx tsc --noEmit -p packages/sdk/tsconfig.json`)
- [x] Subagent PR review completed and feedback addressed

### Test results

```
 ✓ |@pulsemcp/air-sdk| tests/update.test.ts (8 tests) 525ms
   ✓ discovers providers from cache directory when air.json has no extensions
   ✓ loads provider from air.json extensions (regression)
   ✓ discovers providers from cache directory when air.json does not exist
   ✓ returns empty results when no cache directory exists
   ✓ returns empty results when cache directory has no known provider schemes
   ✓ refreshes cached clone and reports update status
   ✓ reports already up-to-date when clone matches remote
   ✓ skips immutable refs (full SHA)
```

### Manual E2E test

To verify the fix end-to-end:

1. Ensure a stale GitHub cache exists: `ls ~/.air/cache/github/` (should show owner/repo/ref dirs)
2. Run `air update` — should now list cached repos and their refresh status instead of "No providers with cached data found"
3. Run `air start claude` — the previously missing file should now be found in the refreshed clone

Expected output after fix:
```
  ✓ pulsemcp/pulsemcp@main — updated abc1234 → def5678
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)