### PR TITLE
fix: `air update` self-heals stale provider extensions

### DIFF
--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -4,16 +4,22 @@ import { updateProviderCaches } from "@pulsemcp/air-sdk";
 export function updateCommand(): Command {
   const cmd = new Command("update")
     .description(
-      "Refresh cached provider data (e.g., GitHub repository clones)"
+      "Refresh cached provider data (e.g., GitHub repository clones). " +
+        "Auto-upgrades stale provider extensions when needed."
     )
     .option(
       "--config <path>",
       "Path to air.json (defaults to AIR_CONFIG env or ~/.air/air.json)"
     )
-    .action(async (options: { config?: string }) => {
+    .option(
+      "--no-auto-heal",
+      "Do not auto-upgrade provider extensions that are too old to refresh their cache"
+    )
+    .action(async (options: { config?: string; autoHeal?: boolean }) => {
       try {
         const { results } = await updateProviderCaches({
           config: options.config,
+          autoHeal: options.autoHeal,
         });
 
         const schemes = Object.keys(results);

--- a/packages/sdk/src/update.ts
+++ b/packages/sdk/src/update.ts
@@ -142,15 +142,39 @@ export async function updateProviderCaches(
     if (defaultAirDir !== airJsonDir) searchDirs.push(defaultAirDir);
 
     const provider = await tryLoadProvider(packageName, searchDirs);
-    if (provider?.refreshCache) {
+    // Add the provider even if it lacks refreshCache — the main loop
+    // below will surface a diagnostic result so users see why the
+    // refresh did not run, instead of the command silently reporting
+    // "no providers with cached data found".
+    if (provider) {
       providers.set(scheme, provider);
     }
   }
 
+  // Only schemes with actual cached data on disk are worth reporting.
+  // A provider may be listed in air.json extensions without having been
+  // used yet, in which case there is nothing to refresh.
+  const cachedSchemeSet = new Set(cachedSchemes);
+
+  const installPrefix = airJsonDir ?? dirname(getDefaultAirJsonPath());
   const results: Record<string, CacheRefreshResult[]> = {};
 
   for (const [scheme, provider] of providers) {
-    if (!provider.refreshCache) continue;
+    if (!cachedSchemeSet.has(scheme)) continue;
+    if (!provider.refreshCache) {
+      const packageName =
+        KNOWN_PROVIDERS[scheme] ?? `@pulsemcp/air-provider-${scheme}`;
+      results[scheme] = [
+        {
+          label: scheme,
+          updated: false,
+          message:
+            `installed provider is too old to refresh its cache. ` +
+            `Upgrade with: npm install --prefix ${installPrefix} ${packageName}@latest`,
+        },
+      ];
+      continue;
+    }
     results[scheme] = await provider.refreshCache();
   }
 

--- a/packages/sdk/src/update.ts
+++ b/packages/sdk/src/update.ts
@@ -1,7 +1,8 @@
-import { createRequire } from "module";
-import { existsSync, readdirSync } from "fs";
+import { execFile } from "child_process";
+import { existsSync, readFileSync, readdirSync } from "fs";
 import { dirname, join, resolve } from "path";
 import { pathToFileURL } from "url";
+import { createRequire } from "module";
 import {
   loadAirConfig,
   getAirJsonPath,
@@ -15,20 +16,67 @@ import { resolveEsmEntry } from "./esm-resolve.js";
 
 /**
  * Known provider packages, keyed by their cache directory name (scheme).
- * Used to auto-discover providers when air.json doesn't list them.
+ * Used to auto-discover providers when air.json doesn't list them and to
+ * auto-upgrade providers that are too old to support cache refresh.
  */
 const KNOWN_PROVIDERS: Record<string, string> = {
   github: "@pulsemcp/air-provider-github",
 };
 
+/**
+ * Minimum version of each known provider package required to support
+ * `refreshCache()`. When the installed version is older than this, the
+ * pre-flight upgrade step in {@link updateProviderCaches} will run
+ * `npm install <pkg>@latest` so the freshly loaded module exposes
+ * cache refresh.
+ *
+ * Bump these when raising the SDK's expectations of providers.
+ */
+const PROVIDER_MIN_VERSIONS: Record<string, string> = {
+  "@pulsemcp/air-provider-github": "0.0.21",
+};
+
 export interface UpdateProviderCachesOptions {
   /** Path to air.json. Uses AIR_CONFIG env or ~/.air/air.json if not set. */
   config?: string;
+  /**
+   * When true (default), automatically upgrade provider extensions that
+   * are installed at a version too old to expose `refreshCache()` before
+   * loading them. Disable in tests or when running offline.
+   */
+  autoHeal?: boolean;
+  /**
+   * Override for the npm install command used by auto-heal. Tests pass a
+   * stub here to simulate upgrade outcomes without touching the network.
+   */
+  runNpmInstallLatest?: NpmInstallLatest;
 }
 
 export interface UpdateProviderCachesResult {
   /** Results from each provider, keyed by provider scheme. */
   results: Record<string, CacheRefreshResult[]>;
+}
+
+/**
+ * Hook used by tests to stub out the real `npm install` invocation.
+ * The default implementation shells out to `npm install <pkg>@latest`.
+ */
+export type NpmInstallLatest = (
+  packageName: string,
+  prefix: string
+) => Promise<{ ok: boolean; stderr: string }>;
+
+/**
+ * Result of a single pre-flight upgrade attempt.
+ */
+interface UpgradeOutcome {
+  packageName: string;
+  scheme: string;
+  attempted: boolean;
+  ok: boolean;
+  beforeVersion: string | null;
+  afterVersion: string | null;
+  stderr?: string;
 }
 
 /**
@@ -56,6 +104,101 @@ function discoverCachedSchemes(): string[] {
     return [];
   }
 }
+
+/**
+ * Read the installed version of an npm package from its package.json,
+ * looking under `<prefix>/node_modules/<packageName>`.
+ */
+function readInstalledVersion(
+  packageName: string,
+  prefix: string
+): string | null {
+  try {
+    const pkgPath = join(prefix, "node_modules", packageName, "package.json");
+    if (!existsSync(pkgPath)) return null;
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    return typeof pkg.version === "string" ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compare two semver-ish version strings of the form `MAJOR.MINOR.PATCH`.
+ * Returns a negative number if `a < b`, 0 if equal, positive if `a > b`.
+ * Pre-release suffixes are ignored — we only need ordering for known
+ * provider versions like `0.0.13` vs `0.0.21`.
+ */
+function compareVersions(a: string, b: string): number {
+  const parse = (v: string): number[] =>
+    v
+      .split("-")[0]
+      .split(".")
+      .map((n) => Number.parseInt(n, 10) || 0);
+  const av = parse(a);
+  const bv = parse(b);
+  const len = Math.max(av.length, bv.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (av[i] ?? 0) - (bv[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Strip a version suffix from an npm specifier so we can compare against
+ * known package names. Mirrors the helper in `install.ts`.
+ */
+function stripVersion(specifier: string): string {
+  if (specifier.startsWith("@")) {
+    const slashIdx = specifier.indexOf("/");
+    if (slashIdx !== -1) {
+      const afterSlash = specifier.slice(slashIdx + 1);
+      const atIdx = afterSlash.indexOf("@");
+      if (atIdx !== -1) {
+        return specifier.slice(0, slashIdx + 1 + atIdx);
+      }
+    }
+    return specifier;
+  }
+  const atIdx = specifier.indexOf("@");
+  if (atIdx > 0) {
+    return specifier.slice(0, atIdx);
+  }
+  return specifier;
+}
+
+/**
+ * Default implementation of {@link NpmInstallLatest} — runs
+ * `npm install --prefix <prefix> --prefer-offline <pkg>@latest`.
+ */
+const defaultNpmInstallLatest: NpmInstallLatest = (packageName, prefix) =>
+  new Promise((resolveResult) => {
+    execFile(
+      "npm",
+      [
+        "install",
+        "--prefix",
+        prefix,
+        "--prefer-offline",
+        "--no-audit",
+        "--no-fund",
+        "--silent",
+        `${packageName}@latest`,
+      ],
+      { stdio: "pipe" } as Parameters<typeof execFile>[2],
+      (err, _stdout, stderr) => {
+        if (err) {
+          resolveResult({
+            ok: false,
+            stderr: stderr?.toString() ?? String(err),
+          });
+        } else {
+          resolveResult({ ok: true, stderr: "" });
+        }
+      }
+    );
+  });
 
 /**
  * Try to load a provider extension by package name, searching the given
@@ -99,29 +242,166 @@ async function tryLoadProvider(
 }
 
 /**
+ * Build the list of directories to search when resolving a provider
+ * package by name.
+ */
+function buildSearchDirs(airJsonDir: string | null): string[] {
+  const dirs: string[] = [];
+  if (airJsonDir) dirs.push(airJsonDir);
+  const defaultAirDir = dirname(getDefaultAirJsonPath());
+  if (defaultAirDir !== airJsonDir) dirs.push(defaultAirDir);
+  return dirs;
+}
+
+/**
+ * Pre-flight: walk the extensions array in air.json and any cached
+ * provider schemes on disk, and `npm install <pkg>@latest` for any
+ * known provider whose installed version is below the minimum required
+ * for `refreshCache()` support.
+ *
+ * Runs BEFORE any provider modules are imported so the freshly
+ * installed package is what gets loaded — Node caches modules by URL
+ * and there is no reliable way to bust the transitive import cache once
+ * a stale version has been imported in-process.
+ */
+async function preflightUpgradeProviders(
+  extensionSpecs: string[],
+  cachedSchemes: string[],
+  installPrefix: string,
+  runNpmInstallLatest: NpmInstallLatest
+): Promise<UpgradeOutcome[]> {
+  // Collect the set of provider package names we should consider, drawn
+  // from both the air.json extensions list and any cached scheme that
+  // maps to a known provider package. We dedupe by package name.
+  const candidates = new Set<string>();
+
+  for (const spec of extensionSpecs) {
+    if (typeof spec !== "string") continue;
+    const name = stripVersion(spec);
+    // Only consider known providers — we won't auto-install arbitrary
+    // packages on the user's behalf.
+    if (Object.values(KNOWN_PROVIDERS).includes(name)) {
+      candidates.add(name);
+    }
+  }
+
+  for (const scheme of cachedSchemes) {
+    const name = KNOWN_PROVIDERS[scheme];
+    if (name) candidates.add(name);
+  }
+
+  const outcomes: UpgradeOutcome[] = [];
+
+  for (const packageName of candidates) {
+    const minVersion = PROVIDER_MIN_VERSIONS[packageName];
+    if (!minVersion) continue;
+
+    const installed = readInstalledVersion(packageName, installPrefix);
+
+    // Not installed at all under this prefix — leave alone. The
+    // extension loader will handle missing packages with its own
+    // error path; auto-installing absent packages goes beyond what
+    // `air update` is supposed to do.
+    if (!installed) continue;
+
+    if (compareVersions(installed, minVersion) >= 0) continue;
+
+    const scheme =
+      Object.entries(KNOWN_PROVIDERS).find(([, n]) => n === packageName)?.[0] ??
+      "";
+
+    const installResult = await runNpmInstallLatest(packageName, installPrefix);
+    const after = readInstalledVersion(packageName, installPrefix);
+
+    outcomes.push({
+      packageName,
+      scheme,
+      attempted: true,
+      ok: installResult.ok,
+      beforeVersion: installed,
+      afterVersion: after,
+      stderr: installResult.stderr || undefined,
+    });
+  }
+
+  return outcomes;
+}
+
+/**
+ * Build a {@link CacheRefreshResult} describing a single upgrade outcome,
+ * suitable for prepending to the per-scheme results array.
+ */
+function upgradeNotice(outcome: UpgradeOutcome): CacheRefreshResult {
+  if (outcome.ok) {
+    const before = outcome.beforeVersion ?? "(none)";
+    const after = outcome.afterVersion ?? "latest";
+    return {
+      label: outcome.packageName,
+      updated: true,
+      message: `upgraded provider package ${before} → ${after}`,
+    };
+  }
+  return {
+    label: outcome.packageName,
+    updated: false,
+    message:
+      `failed to auto-upgrade provider package` +
+      (outcome.stderr ? `: ${outcome.stderr.trim().split("\n")[0]}` : ""),
+  };
+}
+
+/**
  * Refresh all provider caches.
  *
  * Discovers providers in two ways:
  * 1. From air.json extensions (if air.json exists)
  * 2. By scanning ~/.air/cache/ for known provider cache directories
  *
- * This ensures cached data is refreshed even when the provider isn't
- * explicitly listed in air.json's extensions array.
+ * Before loading any provider modules, runs a pre-flight check that
+ * compares the installed version of each known provider package against
+ * the minimum required for `refreshCache()` support. Outdated packages
+ * are upgraded with `npm install <pkg>@latest` so the freshly loaded
+ * module exposes cache refresh — making `air update` self-healing
+ * across CLI upgrades that outpace the extension packages installed
+ * under `~/.air/`.
  */
 export async function updateProviderCaches(
   options?: UpdateProviderCachesOptions
 ): Promise<UpdateProviderCachesResult> {
   const airJsonPath = options?.config ?? getAirJsonPath();
+  const autoHeal = options?.autoHeal ?? true;
+  const runNpmInstallLatest =
+    options?.runNpmInstallLatest ?? defaultNpmInstallLatest;
 
-  const providers = new Map<string, CatalogProvider>();
   let airJsonDir: string | null = null;
-
-  // Load providers from air.json extensions if available
+  let extensionSpecs: string[] = [];
   if (airJsonPath) {
     airJsonDir = dirname(resolve(airJsonPath));
     const airConfig = loadAirConfig(airJsonPath);
-    const loaded = await loadExtensions(airConfig.extensions || [], airJsonDir);
+    extensionSpecs = airConfig.extensions ?? [];
+  }
 
+  const installPrefix = airJsonDir ?? dirname(getDefaultAirJsonPath());
+  const cachedSchemes = discoverCachedSchemes();
+  const cachedSchemeSet = new Set(cachedSchemes);
+
+  // Pre-flight: upgrade any stale provider packages BEFORE loading
+  // them. We must do this before any import() of the provider runs
+  // because Node caches modules by URL and there is no reliable way to
+  // bust the transitive import cache once a stale module is loaded.
+  const upgradeOutcomes = autoHeal
+    ? await preflightUpgradeProviders(
+        extensionSpecs,
+        cachedSchemes,
+        installPrefix,
+        runNpmInstallLatest
+      )
+    : [];
+
+  // Load providers from air.json extensions if available
+  const providers = new Map<string, CatalogProvider>();
+  if (airJsonPath) {
+    const loaded = await loadExtensions(extensionSpecs, airJsonDir!);
     for (const ext of loaded.providers) {
       const provider = ext.provider!;
       providers.set(provider.scheme, provider);
@@ -129,21 +409,18 @@ export async function updateProviderCaches(
   }
 
   // Discover additional providers from cache directory
-  const cachedSchemes = discoverCachedSchemes();
   for (const scheme of cachedSchemes) {
     if (providers.has(scheme)) continue;
 
     const packageName = KNOWN_PROVIDERS[scheme];
     if (!packageName) continue;
 
-    const searchDirs: string[] = [];
-    if (airJsonDir) searchDirs.push(airJsonDir);
-    const defaultAirDir = dirname(getDefaultAirJsonPath());
-    if (defaultAirDir !== airJsonDir) searchDirs.push(defaultAirDir);
-
-    const provider = await tryLoadProvider(packageName, searchDirs);
+    const provider = await tryLoadProvider(
+      packageName,
+      buildSearchDirs(airJsonDir)
+    );
     // Add the provider even if it lacks refreshCache — the main loop
-    // below will surface a diagnostic result so users see why the
+    // below will surface a diagnostic so the user understands why the
     // refresh did not run, instead of the command silently reporting
     // "no providers with cached data found".
     if (provider) {
@@ -151,31 +428,50 @@ export async function updateProviderCaches(
     }
   }
 
+  // Index pre-flight outcomes by scheme so we can prepend the upgrade
+  // notice to that scheme's per-call results.
+  const upgradeByScheme = new Map<string, UpgradeOutcome>();
+  for (const outcome of upgradeOutcomes) {
+    if (outcome.scheme) upgradeByScheme.set(outcome.scheme, outcome);
+  }
+
   // Only schemes with actual cached data on disk are worth reporting.
   // A provider may be listed in air.json extensions without having been
   // used yet, in which case there is nothing to refresh.
-  const cachedSchemeSet = new Set(cachedSchemes);
-
-  const installPrefix = airJsonDir ?? dirname(getDefaultAirJsonPath());
   const results: Record<string, CacheRefreshResult[]> = {};
 
-  for (const [scheme, provider] of providers) {
-    if (!cachedSchemeSet.has(scheme)) continue;
-    if (!provider.refreshCache) {
-      const packageName =
-        KNOWN_PROVIDERS[scheme] ?? `@pulsemcp/air-provider-${scheme}`;
-      results[scheme] = [
-        {
-          label: scheme,
-          updated: false,
-          message:
-            `installed provider is too old to refresh its cache. ` +
-            `Upgrade with: npm install --prefix ${installPrefix} ${packageName}@latest`,
-        },
-      ];
+  for (const scheme of cachedSchemeSet) {
+    const provider = providers.get(scheme);
+
+    // Schemes with no loaded provider AND no known package mapping
+    // can't be helped — preserve the historical "silently ignore
+    // unknown schemes" behavior.
+    if (!provider && !KNOWN_PROVIDERS[scheme]) continue;
+
+    const outcome = upgradeByScheme.get(scheme);
+    const notice = outcome ? upgradeNotice(outcome) : null;
+    const packageName =
+      KNOWN_PROVIDERS[scheme] ?? `@pulsemcp/air-provider-${scheme}`;
+
+    if (!provider?.refreshCache) {
+      // Either no provider exists for this scheme, or auto-heal could
+      // not produce one with refreshCache support. Surface a single
+      // diagnostic entry so the user knows what to do next.
+      const diagnostic: CacheRefreshResult = {
+        label: scheme,
+        updated: false,
+        message: provider
+          ? `installed provider does not support cache refresh. ` +
+            `Try manually: npm install --prefix ${installPrefix} ${packageName}@latest`
+          : `no provider installed for "${scheme}://" cached data. ` +
+            `Try manually: npm install --prefix ${installPrefix} ${packageName}@latest`,
+      };
+      results[scheme] = notice ? [notice, diagnostic] : [diagnostic];
       continue;
     }
-    results[scheme] = await provider.refreshCache();
+
+    const refreshResults = await provider.refreshCache();
+    results[scheme] = notice ? [notice, ...refreshResults] : refreshResults;
   }
 
   return { results };

--- a/packages/sdk/tests/update.test.ts
+++ b/packages/sdk/tests/update.test.ts
@@ -240,6 +240,92 @@ describe("updateProviderCaches", () => {
     expect(entry!.message).toContain("up-to-date");
   }, 30000);
 
+  it("surfaces a diagnostic when the installed provider lacks refreshCache", async () => {
+    const fakeHome = createTempDir();
+    setFakeHome(fakeHome);
+
+    // Create a "stale" provider extension — has scheme but no refreshCache
+    // method, simulating an older version of @pulsemcp/air-provider-github
+    // installed alongside a newer CLI.
+    const airDir = join(fakeHome, ".air");
+    mkdirSync(airDir, { recursive: true });
+
+    const extDir = join(airDir, "fake-provider");
+    mkdirSync(extDir, { recursive: true });
+    writeFileSync(
+      join(extDir, "index.mjs"),
+      `export default {
+  name: "stale-github-provider",
+  provider: {
+    scheme: "github",
+    async resolve() { return { type: "raw", data: {} }; },
+  },
+};
+`
+    );
+
+    writeFileSync(
+      join(airDir, "air.json"),
+      JSON.stringify({
+        name: "test",
+        extensions: ["./fake-provider/index.mjs"],
+      })
+    );
+
+    // Cached data must exist on disk — otherwise there's nothing to refresh
+    // and the command should remain silent.
+    createCachedClone(fakeHome, "test-owner", "test-repo", "main");
+
+    const { results } = await updateProviderCaches({
+      config: join(airDir, "air.json"),
+    });
+
+    expect(results).toHaveProperty("github");
+    expect(results.github).toHaveLength(1);
+    const entry = results.github[0];
+    expect(entry.updated).toBe(false);
+    expect(entry.message).toMatch(/too old/);
+    expect(entry.message).toMatch(/@pulsemcp\/air-provider-github@latest/);
+  }, 30000);
+
+  it("does not emit diagnostics for providers without cached data on disk", async () => {
+    const fakeHome = createTempDir();
+    setFakeHome(fakeHome);
+
+    // Provider listed in air.json, stale (no refreshCache), but no cache dir —
+    // nothing to refresh, so the command should stay silent (empty results).
+    const airDir = join(fakeHome, ".air");
+    mkdirSync(airDir, { recursive: true });
+
+    const extDir = join(airDir, "fake-provider");
+    mkdirSync(extDir, { recursive: true });
+    writeFileSync(
+      join(extDir, "index.mjs"),
+      `export default {
+  name: "stale-github-provider",
+  provider: {
+    scheme: "github",
+    async resolve() { return { type: "raw", data: {} }; },
+  },
+};
+`
+    );
+
+    writeFileSync(
+      join(airDir, "air.json"),
+      JSON.stringify({
+        name: "test",
+        extensions: ["./fake-provider/index.mjs"],
+      })
+    );
+
+    const { results } = await updateProviderCaches({
+      config: join(airDir, "air.json"),
+    });
+
+    expect(Object.keys(results)).toEqual([]);
+  });
+
   it("skips immutable refs (full SHA)", async () => {
     const fakeHome = createTempDir();
     setFakeHome(fakeHome);

--- a/packages/sdk/tests/update.test.ts
+++ b/packages/sdk/tests/update.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { resolve, join } from "path";
+import { resolve, join, dirname } from "path";
 import {
   mkdirSync,
   writeFileSync,
@@ -240,20 +240,32 @@ describe("updateProviderCaches", () => {
     expect(entry!.message).toContain("up-to-date");
   }, 30000);
 
-  it("surfaces a diagnostic when the installed provider lacks refreshCache", async () => {
+  it("auto-heals a stale provider via pre-flight upgrade then refreshes the cache", async () => {
     const fakeHome = createTempDir();
     setFakeHome(fakeHome);
 
-    // Create a "stale" provider extension — has scheme but no refreshCache
-    // method, simulating an older version of @pulsemcp/air-provider-github
-    // installed alongside a newer CLI.
+    // Set up <airDir>/node_modules/@pulsemcp/air-provider-github at an
+    // older version that lacks refreshCache, mirroring a user whose
+    // ~/.air install hasn't kept up with the CLI.
     const airDir = join(fakeHome, ".air");
-    mkdirSync(airDir, { recursive: true });
-
-    const extDir = join(airDir, "fake-provider");
-    mkdirSync(extDir, { recursive: true });
+    const pkgDir = join(
+      airDir,
+      "node_modules",
+      "@pulsemcp",
+      "air-provider-github"
+    );
+    mkdirSync(pkgDir, { recursive: true });
     writeFileSync(
-      join(extDir, "index.mjs"),
+      join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "@pulsemcp/air-provider-github",
+        version: "0.0.13",
+        type: "module",
+        main: "./index.mjs",
+      })
+    );
+    writeFileSync(
+      join(pkgDir, "index.mjs"),
       `export default {
   name: "stale-github-provider",
   provider: {
@@ -268,39 +280,213 @@ describe("updateProviderCaches", () => {
       join(airDir, "air.json"),
       JSON.stringify({
         name: "test",
-        extensions: ["./fake-provider/index.mjs"],
+        extensions: ["@pulsemcp/air-provider-github"],
       })
     );
 
-    // Cached data must exist on disk — otherwise there's nothing to refresh
-    // and the command should remain silent.
+    // Cached data must exist on disk so the upgrade path is reached.
+    createCachedClone(fakeHome, "test-owner", "test-repo", "main");
+
+    // Stub `npm install` — instead of touching the network, overwrite
+    // the on-disk package with a fresh "upgraded" version that exposes
+    // a working refreshCache method. The pre-flight upgrade runs BEFORE
+    // any provider module is loaded, so the SDK loads this version.
+    const runNpmInstallLatest = async (
+      packageName: string,
+      prefix: string
+    ): Promise<{ ok: boolean; stderr: string }> => {
+      expect(packageName).toBe("@pulsemcp/air-provider-github");
+      expect(prefix).toBe(airDir);
+
+      writeFileSync(
+        join(pkgDir, "package.json"),
+        JSON.stringify({
+          name: packageName,
+          version: "9.9.9",
+          type: "module",
+          main: "./index.mjs",
+        })
+      );
+      writeFileSync(
+        join(pkgDir, "index.mjs"),
+        `export default {
+  name: "fresh-github-provider",
+  provider: {
+    scheme: "github",
+    async resolve() { return { type: "raw", data: {} }; },
+    async refreshCache() {
+      return [{ label: "stub/refresh@main", updated: true, message: "stub-refreshed" }];
+    },
+  },
+};
+`
+      );
+      return { ok: true, stderr: "" };
+    };
+
+    const { results } = await updateProviderCaches({
+      config: join(airDir, "air.json"),
+      runNpmInstallLatest,
+    });
+
+    expect(results).toHaveProperty("github");
+    const entries = results.github;
+    // First entry is the upgrade notice, then the refreshCache results.
+    expect(entries.length).toBeGreaterThanOrEqual(2);
+
+    const upgrade = entries[0];
+    expect(upgrade.updated).toBe(true);
+    expect(upgrade.label).toBe("@pulsemcp/air-provider-github");
+    expect(upgrade.message).toMatch(/upgraded provider package 0\.0\.13 → 9\.9\.9/);
+
+    const refreshed = entries.find((e) => e.label === "stub/refresh@main");
+    expect(refreshed).toBeDefined();
+    expect(refreshed!.updated).toBe(true);
+    expect(refreshed!.message).toBe("stub-refreshed");
+  }, 30000);
+
+  it("does not run pre-flight upgrade when installed provider already meets the minimum version", async () => {
+    const fakeHome = createTempDir();
+    setFakeHome(fakeHome);
+
+    const airDir = join(fakeHome, ".air");
+    const pkgDir = join(
+      airDir,
+      "node_modules",
+      "@pulsemcp",
+      "air-provider-github"
+    );
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "@pulsemcp/air-provider-github",
+        version: "0.0.99",
+        type: "module",
+        main: "./index.mjs",
+      })
+    );
+    writeFileSync(
+      join(pkgDir, "index.mjs"),
+      `export default {
+  name: "fresh-github-provider",
+  provider: {
+    scheme: "github",
+    async resolve() { return { type: "raw", data: {} }; },
+    async refreshCache() {
+      return [{ label: "noop", updated: false, message: "ok" }];
+    },
+  },
+};
+`
+    );
+
+    writeFileSync(
+      join(airDir, "air.json"),
+      JSON.stringify({
+        name: "test",
+        extensions: ["@pulsemcp/air-provider-github"],
+      })
+    );
+
+    createCachedClone(fakeHome, "test-owner", "test-repo", "main");
+
+    let installCalls = 0;
+    const runNpmInstallLatest = async () => {
+      installCalls += 1;
+      return { ok: true, stderr: "" };
+    };
+
+    const { results } = await updateProviderCaches({
+      config: join(airDir, "air.json"),
+      runNpmInstallLatest,
+    });
+
+    expect(installCalls).toBe(0);
+    expect(results.github).toBeDefined();
+    // No upgrade notice — first entry should be the refreshCache result.
+    expect(results.github[0].label).toBe("noop");
+  }, 30000);
+
+  it("emits a diagnostic when auto-heal is disabled and the provider lacks refreshCache", async () => {
+    const fakeHome = createTempDir();
+    setFakeHome(fakeHome);
+
+    const airDir = join(fakeHome, ".air");
+    const pkgDir = join(
+      airDir,
+      "node_modules",
+      "@pulsemcp",
+      "air-provider-github"
+    );
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "@pulsemcp/air-provider-github",
+        version: "0.0.13",
+        type: "module",
+        main: "./index.mjs",
+      })
+    );
+    writeFileSync(
+      join(pkgDir, "index.mjs"),
+      `export default {
+  name: "stale-github-provider",
+  provider: {
+    scheme: "github",
+    async resolve() { return { type: "raw", data: {} }; },
+  },
+};
+`
+    );
+
+    writeFileSync(
+      join(airDir, "air.json"),
+      JSON.stringify({
+        name: "test",
+        extensions: ["@pulsemcp/air-provider-github"],
+      })
+    );
+
     createCachedClone(fakeHome, "test-owner", "test-repo", "main");
 
     const { results } = await updateProviderCaches({
       config: join(airDir, "air.json"),
+      autoHeal: false,
     });
 
     expect(results).toHaveProperty("github");
     expect(results.github).toHaveLength(1);
     const entry = results.github[0];
     expect(entry.updated).toBe(false);
-    expect(entry.message).toMatch(/too old/);
+    expect(entry.message).toMatch(/does not support cache refresh/);
     expect(entry.message).toMatch(/@pulsemcp\/air-provider-github@latest/);
   }, 30000);
 
-  it("does not emit diagnostics for providers without cached data on disk", async () => {
+  it("surfaces failure details when pre-flight upgrade fails", async () => {
     const fakeHome = createTempDir();
     setFakeHome(fakeHome);
 
-    // Provider listed in air.json, stale (no refreshCache), but no cache dir —
-    // nothing to refresh, so the command should stay silent (empty results).
     const airDir = join(fakeHome, ".air");
-    mkdirSync(airDir, { recursive: true });
-
-    const extDir = join(airDir, "fake-provider");
-    mkdirSync(extDir, { recursive: true });
+    const pkgDir = join(
+      airDir,
+      "node_modules",
+      "@pulsemcp",
+      "air-provider-github"
+    );
+    mkdirSync(pkgDir, { recursive: true });
     writeFileSync(
-      join(extDir, "index.mjs"),
+      join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "@pulsemcp/air-provider-github",
+        version: "0.0.13",
+        type: "module",
+        main: "./index.mjs",
+      })
+    );
+    writeFileSync(
+      join(pkgDir, "index.mjs"),
       `export default {
   name: "stale-github-provider",
   provider: {
@@ -315,12 +501,82 @@ describe("updateProviderCaches", () => {
       join(airDir, "air.json"),
       JSON.stringify({
         name: "test",
-        extensions: ["./fake-provider/index.mjs"],
+        extensions: ["@pulsemcp/air-provider-github"],
+      })
+    );
+
+    createCachedClone(fakeHome, "test-owner", "test-repo", "main");
+
+    const runNpmInstallLatest = async () => ({
+      ok: false,
+      stderr: "EACCES: permission denied",
+    });
+
+    const { results } = await updateProviderCaches({
+      config: join(airDir, "air.json"),
+      runNpmInstallLatest,
+    });
+
+    expect(results).toHaveProperty("github");
+    expect(results.github.length).toBeGreaterThanOrEqual(2);
+
+    const failureNotice = results.github[0];
+    expect(failureNotice.updated).toBe(false);
+    expect(failureNotice.label).toBe("@pulsemcp/air-provider-github");
+    expect(failureNotice.message).toMatch(/failed to auto-upgrade/);
+    expect(failureNotice.message).toMatch(/EACCES/);
+
+    const diagnostic = results.github[1];
+    expect(diagnostic.updated).toBe(false);
+    expect(diagnostic.message).toMatch(/does not support cache refresh/);
+  }, 30000);
+
+  it("does not emit diagnostics for providers without cached data on disk", async () => {
+    const fakeHome = createTempDir();
+    setFakeHome(fakeHome);
+
+    // Provider listed in air.json (stale), but no cache dir — nothing
+    // to refresh, so the command should stay silent (empty results).
+    const airDir = join(fakeHome, ".air");
+    const pkgDir = join(
+      airDir,
+      "node_modules",
+      "@pulsemcp",
+      "air-provider-github"
+    );
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "@pulsemcp/air-provider-github",
+        version: "0.0.13",
+        type: "module",
+        main: "./index.mjs",
+      })
+    );
+    writeFileSync(
+      join(pkgDir, "index.mjs"),
+      `export default {
+  name: "stale-github-provider",
+  provider: {
+    scheme: "github",
+    async resolve() { return { type: "raw", data: {} }; },
+  },
+};
+`
+    );
+
+    writeFileSync(
+      join(airDir, "air.json"),
+      JSON.stringify({
+        name: "test",
+        extensions: ["@pulsemcp/air-provider-github"],
       })
     );
 
     const { results } = await updateProviderCaches({
       config: join(airDir, "air.json"),
+      runNpmInstallLatest: async () => ({ ok: true, stderr: "" }),
     });
 
     expect(Object.keys(results)).toEqual([]);


### PR DESCRIPTION
## Summary

When a user upgrades the air CLI but their `~/.air/node_modules` still holds an older provider extension (e.g. `@pulsemcp/air-provider-github@^0.0.13`, where the `^0.0.x` pin blocks any upgrade), `air update` previously silently printed:

```
No providers with cached data found.
```

…even though stale cache directories existed on disk and the provider was successfully loaded. The misleading output sent users chasing the wrong root cause — including assuming #75 should have fixed it.

This PR makes `air update` guarantee freshness: the user runs the command, the command makes everything correct, full stop.

## Approach

Self-heal stale providers via a pre-flight upgrade pass that runs **before** any provider module is imported:

1. Walk the air.json extensions list and the cached provider scheme directories on disk.
2. For each known provider package (currently `@pulsemcp/air-provider-github`) whose installed version is below the minimum required for `refreshCache()` support (`PROVIDER_MIN_VERSIONS`), run `npm install --prefer-offline <pkg>@latest --prefix <prefix>`.
3. Then load extensions normally — the freshly installed module is what gets imported, so the upgraded `refreshCache` is reachable.
4. Refresh the caches as before, prepending an upgrade notice to the per-scheme results so the user sees what was healed.

## Why pre-flight, not in-process reload

The first attempt of this fix tried to reload the provider in-process after `npm install`, using a cache-busting query string on the dynamic `import()` URL. That works for the top-level `index.js` but **not** for its transitive imports — Node caches ESM modules by URL, and after the parent imports the cached `github-provider.js`, no amount of busting the index URL surfaces the new class. The only reliable fix is to never load the stale version in the first place.

## Behavior

**Before — broken state, output:**
```
No providers with cached data found.
```

**After — broken state, single `air update` invocation:**
```
  ✓ @pulsemcp/air-provider-github — upgraded provider package 0.0.13 → 0.0.25
  ✓ pulsemcp/pulsemcp@main — updated 5f9995b → 2ef40a3
```

**After — already up-to-date, no extra cost:** the version compare short-circuits the npm call. Wall-clock unchanged.

**After — upgrade fails (no npm, EACCES, etc.):** the existing diagnostic with the manual upgrade command is still surfaced.

## CLI surface

- `air update` — auto-heals by default
- `air update --no-auto-heal` — opts out (kept for users who want to control upgrades themselves)

The SDK exposes the same via `updateProviderCaches({ autoHeal: false })` and accepts a `runNpmInstallLatest` test stub for injection.

## Test plan

- [x] New unit tests in `update.test.ts`:
  - `auto-heals a stale provider via pre-flight upgrade then refreshes the cache` — stubs `npm install` to overwrite the on-disk package, then asserts the upgraded module is loaded and refreshCache is invoked.
  - `does not run pre-flight upgrade when installed provider already meets the minimum version` — verifies the fast path.
  - `emits a diagnostic when auto-heal is disabled and the provider lacks refreshCache` — covers the opt-out path.
  - `surfaces failure details when pre-flight upgrade fails` — covers the npm-install-failed path.
  - `does not emit diagnostics for providers without cached data on disk` — guards against noise for unused providers.
- [x] All 159 existing SDK tests pass.
- [x] Reproduced manually in `/Users/admin/github-projects/pulsemcp/agents/plugins` with `@pulsemcp/air-provider-github@0.0.13` pinned. Single `air update` invocation upgrades the package and refreshes the cache cleanly. Re-run is fast (no upgrade needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)