### PR TITLE
feat: enable hooks and plugins override in air start TUI (v0.0.26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.26] - 2026-04-11
+
+### Added
+- Hooks and plugins are now selectable in the `air start` TUI — previously displayed as read-only, they can now be toggled like MCP servers and skills
+- `getMergedDefaults()` unions hook and plugin defaults from subagent roots (in addition to MCP servers and skills)
+- `TuiResult` includes `hooks` and `plugins` arrays, passed through to `prepareSession()` as override arrays
+
 ## [0.0.25] - 2026-04-11
 
 ### Changed

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -97,7 +97,7 @@ air start claude --root web-app
 
 This activates only the MCP servers, skills, plugins, and hooks listed in the root's defaults. Without `--root`, `air start` auto-detects the root from the current directory's git context and pre-selects the root's defaults in the TUI.
 
-When a root declares `default_subagent_roots`, the TUI pre-selects MCP servers and skills from both the parent root and its subagent roots (union). The `--dry-run` output also reflects this merged view. Use `--no-subagent-merge` to disable this behavior.
+When a root declares `default_subagent_roots`, the TUI pre-selects MCP servers, skills, hooks, and plugins from both the parent root and its subagent roots (union). The `--dry-run` output also reflects this merged view. Use `--no-subagent-merge` to disable this behavior.
 
 ## air prepare — programmatic sessions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1775941052-878fed61",
+  "name": "air-main-1775946369-cc49afaa",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -843,9 +843,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.25",
+        "@pulsemcp/air-sdk": "0.0.26",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -864,7 +864,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -880,9 +880,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.25"
+        "@pulsemcp/air-core": "0.0.26"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -895,9 +895,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.25"
+        "@pulsemcp/air-core": "0.0.26"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -910,9 +910,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.25"
+        "@pulsemcp/air-core": "0.0.26"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -925,9 +925,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.25"
+        "@pulsemcp/air-core": "0.0.26"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -940,9 +940,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.25"
+        "@pulsemcp/air-core": "0.0.26"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.25",
+    "@pulsemcp/air-sdk": "0.0.26",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -93,6 +93,8 @@ export function startCommand(): Command {
         // Interactive TUI or skip
         let selectedSkills: string[] | undefined;
         let selectedMcpServers: string[] | undefined;
+        let selectedHooks: string[] | undefined;
+        let selectedPlugins: string[] | undefined;
 
         const isTTY = process.stdout.isTTY && process.stdin.isTTY;
 
@@ -111,6 +113,8 @@ export function startCommand(): Command {
 
           selectedSkills = tuiResult.skills;
           selectedMcpServers = tuiResult.mcpServers;
+          selectedHooks = tuiResult.hooks;
+          selectedPlugins = tuiResult.plugins;
         }
 
         // Prepare session (write .mcp.json, inject skills, etc.)
@@ -122,6 +126,8 @@ export function startCommand(): Command {
             adapter: agent,
             skills: selectedSkills,
             mcpServers: selectedMcpServers,
+            hooks: selectedHooks,
+            plugins: selectedPlugins,
             skipSubagentMerge,
           });
         } catch (err) {
@@ -172,13 +178,18 @@ function printDryRun(
 
   // Compute merged defaults from subagent roots (unless merge is disabled)
   const merged = skipSubagentMerge
-    ? { mcpServerIds: root?.default_mcp_servers ?? [], skillIds: root?.default_skills ?? [] }
+    ? {
+        mcpServerIds: root?.default_mcp_servers ?? [],
+        skillIds: root?.default_skills ?? [],
+        hookIds: root?.default_hooks ?? [],
+        pluginIds: root?.default_plugins ?? [],
+      }
     : getMergedDefaults(root, artifacts.roots);
 
   const mcpIds = merged.mcpServerIds.length > 0 ? merged.mcpServerIds : (root?.default_mcp_servers || Object.keys(artifacts.mcp));
   const skillIds = merged.skillIds.length > 0 ? merged.skillIds : (root?.default_skills || Object.keys(artifacts.skills));
-  const pluginIds = root?.default_plugins || Object.keys(artifacts.plugins);
-  const hookIds = root?.default_hooks || Object.keys(artifacts.hooks);
+  const pluginIds = merged.pluginIds.length > 0 ? merged.pluginIds : (root?.default_plugins || Object.keys(artifacts.plugins));
+  const hookIds = merged.hookIds.length > 0 ? merged.hookIds : (root?.default_hooks || Object.keys(artifacts.hooks));
 
   console.log(`\nMCP Servers (${mcpIds.length}):`);
   for (const id of mcpIds) {

--- a/packages/cli/src/tui/types.ts
+++ b/packages/cli/src/tui/types.ts
@@ -27,12 +27,16 @@ export interface TuiState {
 export interface TuiResult {
   mcpServers: string[];
   skills: string[];
+  hooks: string[];
+  plugins: string[];
 }
 
 /** Categories where prepareSession supports override arrays */
 export const OVERRIDABLE_CATEGORIES: Set<ArtifactCategory> = new Set([
   "mcp",
   "skills",
+  "hooks",
+  "plugins",
 ]);
 
 export const CATEGORY_LABELS: Record<ArtifactCategory, string> = {
@@ -58,14 +62,16 @@ export function getVisibleItems(state: TuiState): ArtifactItem[] {
 
 /**
  * Compute merged default IDs by unioning the parent root's defaults with
- * all subagent roots' defaults (MCP servers and skills only).
+ * all subagent roots' defaults.
  */
 export function getMergedDefaults(
   root: RootEntry | undefined,
   allRoots: Record<string, RootEntry>
-): { mcpServerIds: string[]; skillIds: string[] } {
+): { mcpServerIds: string[]; skillIds: string[]; hookIds: string[]; pluginIds: string[] } {
   const mcpSet = new Set(root?.default_mcp_servers ?? []);
   const skillSet = new Set(root?.default_skills ?? []);
+  const hookSet = new Set(root?.default_hooks ?? []);
+  const pluginSet = new Set(root?.default_plugins ?? []);
 
   for (const subId of root?.default_subagent_roots ?? []) {
     const sub = allRoots[subId];
@@ -76,11 +82,19 @@ export function getMergedDefaults(
     if (sub.default_skills) {
       for (const id of sub.default_skills) skillSet.add(id);
     }
+    if (sub.default_hooks) {
+      for (const id of sub.default_hooks) hookSet.add(id);
+    }
+    if (sub.default_plugins) {
+      for (const id of sub.default_plugins) pluginSet.add(id);
+    }
   }
 
   return {
     mcpServerIds: [...mcpSet],
     skillIds: [...skillSet],
+    hookIds: [...hookSet],
+    pluginIds: [...pluginSet],
   };
 }
 
@@ -107,17 +121,24 @@ export function buildInitialState(
 
   // Compute merged defaults from subagent roots unless merge is disabled
   const merged = skipSubagentMerge
-    ? { mcpServerIds: root?.default_mcp_servers ?? [], skillIds: root?.default_skills ?? [] }
+    ? {
+        mcpServerIds: root?.default_mcp_servers ?? [],
+        skillIds: root?.default_skills ?? [],
+        hookIds: root?.default_hooks ?? [],
+        pluginIds: root?.default_plugins ?? [],
+      }
     : getMergedDefaults(root, artifacts.roots);
 
   const mcpDefaults = merged.mcpServerIds.length > 0 ? merged.mcpServerIds : root?.default_mcp_servers;
   const skillDefaults = merged.skillIds.length > 0 ? merged.skillIds : root?.default_skills;
+  const hookDefaults = merged.hookIds.length > 0 ? merged.hookIds : root?.default_hooks;
+  const pluginDefaults = merged.pluginIds.length > 0 ? merged.pluginIds : root?.default_plugins;
 
   const items: Record<ArtifactCategory, ArtifactItem[]> = {
     mcp: buildItems(artifacts.mcp, mcpDefaults),
     skills: buildItems(artifacts.skills, skillDefaults),
-    hooks: buildItems(artifacts.hooks, root?.default_hooks),
-    plugins: buildItems(artifacts.plugins, root?.default_plugins),
+    hooks: buildItems(artifacts.hooks, hookDefaults),
+    plugins: buildItems(artifacts.plugins, pluginDefaults),
   };
 
   const tabs = (
@@ -147,6 +168,12 @@ export function getSelectedIds(state: TuiState): TuiResult {
       .filter((i) => i.selected)
       .map((i) => i.id),
     skills: state.items.skills
+      .filter((i) => i.selected)
+      .map((i) => i.id),
+    hooks: state.items.hooks
+      .filter((i) => i.selected)
+      .map((i) => i.id),
+    plugins: state.items.plugins
       .filter((i) => i.selected)
       .map((i) => i.id),
   };

--- a/packages/cli/tests/tui-state.test.ts
+++ b/packages/cli/tests/tui-state.test.ts
@@ -50,6 +50,26 @@ describe("buildInitialState", () => {
     expect(state.items.plugins).toEqual([]);
   });
 
+  it("includes hooks and plugins tabs when they have items", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        mcp: {
+          server1: { type: "stdio", command: "node", description: "A server" },
+        },
+        skills: {
+          skill1: { description: "A skill", path: "/skills/skill1" },
+        },
+        hooks: {
+          hook1: { description: "A hook", path: "/hooks/hook1" },
+        },
+        plugins: {
+          plugin1: { description: "A plugin", path: "/plugins/plugin1" },
+        },
+      })
+    );
+    expect(state.tabs).toEqual(["mcp", "skills", "hooks", "plugins"]);
+  });
+
   it("selects items matching root defaults", () => {
     const state = buildInitialState(
       makeArtifacts({
@@ -205,7 +225,7 @@ describe("getVisibleItems", () => {
 });
 
 describe("getSelectedIds", () => {
-  it("returns only selected MCP servers and skills", () => {
+  it("returns selected IDs for all artifact categories", () => {
     const state = buildInitialState(
       makeArtifacts({
         mcp: {
@@ -224,16 +244,27 @@ describe("getSelectedIds", () => {
           skill1: { description: "Skill 1", path: "/skills/skill1" },
           skill2: { description: "Skill 2", path: "/skills/skill2" },
         },
+        hooks: {
+          hook1: { description: "Hook 1", path: "/hooks/hook1" },
+          hook2: { description: "Hook 2", path: "/hooks/hook2" },
+        },
+        plugins: {
+          plugin1: { description: "Plugin 1", path: "/plugins/plugin1" },
+        },
       }),
       {
         description: "Root",
         default_mcp_servers: ["server1"],
         default_skills: ["skill2"],
+        default_hooks: ["hook1"],
+        default_plugins: ["plugin1"],
       }
     );
     const result = getSelectedIds(state);
     expect(result.mcpServers).toEqual(["server1"]);
     expect(result.skills).toEqual(["skill2"]);
+    expect(result.hooks).toEqual(["hook1"]);
+    expect(result.plugins).toEqual(["plugin1"]);
   });
 
   it("returns empty arrays when nothing is selected", () => {
@@ -251,6 +282,8 @@ describe("getSelectedIds", () => {
     const result = getSelectedIds(state);
     expect(result.mcpServers).toEqual([]);
     expect(result.skills).toEqual([]);
+    expect(result.hooks).toEqual([]);
+    expect(result.plugins).toEqual([]);
   });
 });
 
@@ -299,30 +332,44 @@ describe("getAllSelectionSummary", () => {
 describe("getMergedDefaults", () => {
   it("returns parent defaults when no subagent roots exist", () => {
     const result = getMergedDefaults(
-      { description: "Root", default_mcp_servers: ["s1"], default_skills: ["sk1"] },
+      {
+        description: "Root",
+        default_mcp_servers: ["s1"],
+        default_skills: ["sk1"],
+        default_hooks: ["h1"],
+        default_plugins: ["p1"],
+      },
       {}
     );
     expect(result.mcpServerIds).toEqual(["s1"]);
     expect(result.skillIds).toEqual(["sk1"]);
+    expect(result.hookIds).toEqual(["h1"]);
+    expect(result.pluginIds).toEqual(["p1"]);
   });
 
   it("returns empty arrays when root has no defaults and no subagents", () => {
     const result = getMergedDefaults({ description: "Root" }, {});
     expect(result.mcpServerIds).toEqual([]);
     expect(result.skillIds).toEqual([]);
+    expect(result.hookIds).toEqual([]);
+    expect(result.pluginIds).toEqual([]);
   });
 
-  it("unions parent and subagent MCP servers and skills", () => {
+  it("unions parent and subagent defaults across all categories", () => {
     const roots = {
       "sub-a": {
         description: "Sub A",
         default_mcp_servers: ["s2", "s3"],
         default_skills: ["sk2"],
+        default_hooks: ["h2"],
+        default_plugins: ["p2"],
       },
       "sub-b": {
         description: "Sub B",
         default_mcp_servers: ["s3", "s4"],
         default_skills: ["sk3"],
+        default_hooks: ["h2", "h3"],
+        default_plugins: ["p3"],
       },
     };
     const result = getMergedDefaults(
@@ -330,12 +377,16 @@ describe("getMergedDefaults", () => {
         description: "Parent",
         default_mcp_servers: ["s1"],
         default_skills: ["sk1"],
+        default_hooks: ["h1"],
+        default_plugins: ["p1"],
         default_subagent_roots: ["sub-a", "sub-b"],
       },
       roots
     );
     expect(result.mcpServerIds.sort()).toEqual(["s1", "s2", "s3", "s4"]);
     expect(result.skillIds.sort()).toEqual(["sk1", "sk2", "sk3"]);
+    expect(result.hookIds.sort()).toEqual(["h1", "h2", "h3"]);
+    expect(result.pluginIds.sort()).toEqual(["p1", "p2", "p3"]);
   });
 
   it("collects subagent servers when parent has no default_mcp_servers", () => {
@@ -355,6 +406,23 @@ describe("getMergedDefaults", () => {
     expect(result.mcpServerIds.sort()).toEqual(["s1", "s2"]);
   });
 
+  it("collects subagent hooks when parent has no default_hooks", () => {
+    const roots = {
+      "sub-a": {
+        description: "Sub A",
+        default_hooks: ["h1", "h2"],
+      },
+    };
+    const result = getMergedDefaults(
+      {
+        description: "Parent",
+        default_subagent_roots: ["sub-a"],
+      },
+      roots
+    );
+    expect(result.hookIds.sort()).toEqual(["h1", "h2"]);
+  });
+
   it("skips missing subagent root IDs", () => {
     const result = getMergedDefaults(
       {
@@ -371,6 +439,8 @@ describe("getMergedDefaults", () => {
     const result = getMergedDefaults(undefined, {});
     expect(result.mcpServerIds).toEqual([]);
     expect(result.skillIds).toEqual([]);
+    expect(result.hookIds).toEqual([]);
+    expect(result.pluginIds).toEqual([]);
   });
 });
 
@@ -453,5 +523,86 @@ describe("buildInitialState with subagent merge", () => {
     );
     expect(state.items.skills.find((i) => i.id === "sub-skill")?.selected).toBe(true);
     expect(state.items.skills.find((i) => i.id === "other-skill")?.selected).toBe(false);
+  });
+
+  it("pre-selects subagent hooks when merge is enabled", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        hooks: {
+          "parent-hook": { description: "Parent hook", path: "/hooks/parent" },
+          "sub-hook": { description: "Subagent hook", path: "/hooks/sub" },
+        },
+        roots: {
+          "sub-root": {
+            description: "Subagent root",
+            default_hooks: ["sub-hook"],
+          },
+        },
+      }),
+      {
+        description: "Parent root",
+        default_hooks: ["parent-hook"],
+        default_subagent_roots: ["sub-root"],
+      },
+      "parent",
+      false,
+      false
+    );
+    expect(state.items.hooks.find((i) => i.id === "parent-hook")?.selected).toBe(true);
+    expect(state.items.hooks.find((i) => i.id === "sub-hook")?.selected).toBe(true);
+  });
+
+  it("does not pre-select subagent hooks when merge is disabled", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        hooks: {
+          "parent-hook": { description: "Parent hook", path: "/hooks/parent" },
+          "sub-hook": { description: "Subagent hook", path: "/hooks/sub" },
+        },
+        roots: {
+          "sub-root": {
+            description: "Subagent root",
+            default_hooks: ["sub-hook"],
+          },
+        },
+      }),
+      {
+        description: "Parent root",
+        default_hooks: ["parent-hook"],
+        default_subagent_roots: ["sub-root"],
+      },
+      "parent",
+      false,
+      true
+    );
+    expect(state.items.hooks.find((i) => i.id === "parent-hook")?.selected).toBe(true);
+    expect(state.items.hooks.find((i) => i.id === "sub-hook")?.selected).toBe(false);
+  });
+
+  it("pre-selects subagent plugins when merge is enabled", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        plugins: {
+          "parent-plugin": { description: "Parent plugin", path: "/plugins/parent" },
+          "sub-plugin": { description: "Subagent plugin", path: "/plugins/sub" },
+        },
+        roots: {
+          "sub-root": {
+            description: "Subagent root",
+            default_plugins: ["sub-plugin"],
+          },
+        },
+      }),
+      {
+        description: "Parent root",
+        default_plugins: ["parent-plugin"],
+        default_subagent_roots: ["sub-root"],
+      },
+      "parent",
+      false,
+      false
+    );
+    expect(state.items.plugins.find((i) => i.id === "parent-plugin")?.selected).toBe(true);
+    expect(state.items.plugins.find((i) => i.id === "sub-plugin")?.selected).toBe(true);
   });
 });

--- a/packages/cli/tests/tui-state.test.ts
+++ b/packages/cli/tests/tui-state.test.ts
@@ -423,6 +423,23 @@ describe("getMergedDefaults", () => {
     expect(result.hookIds.sort()).toEqual(["h1", "h2"]);
   });
 
+  it("collects subagent plugins when parent has no default_plugins", () => {
+    const roots = {
+      "sub-a": {
+        description: "Sub A",
+        default_plugins: ["p1", "p2"],
+      },
+    };
+    const result = getMergedDefaults(
+      {
+        description: "Parent",
+        default_subagent_roots: ["sub-a"],
+      },
+      roots
+    );
+    expect(result.pluginIds.sort()).toEqual(["p1", "p2"]);
+  });
+
   it("skips missing subagent root IDs", () => {
     const result = getMergedDefaults(
       {
@@ -604,5 +621,32 @@ describe("buildInitialState with subagent merge", () => {
     );
     expect(state.items.plugins.find((i) => i.id === "parent-plugin")?.selected).toBe(true);
     expect(state.items.plugins.find((i) => i.id === "sub-plugin")?.selected).toBe(true);
+  });
+
+  it("does not pre-select subagent plugins when merge is disabled", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        plugins: {
+          "parent-plugin": { description: "Parent plugin", path: "/plugins/parent" },
+          "sub-plugin": { description: "Subagent plugin", path: "/plugins/sub" },
+        },
+        roots: {
+          "sub-root": {
+            description: "Subagent root",
+            default_plugins: ["sub-plugin"],
+          },
+        },
+      }),
+      {
+        description: "Parent root",
+        default_plugins: ["parent-plugin"],
+        default_subagent_roots: ["sub-root"],
+      },
+      "parent",
+      false,
+      true
+    );
+    expect(state.items.plugins.find((i) => i.id === "parent-plugin")?.selected).toBe(true);
+    expect(state.items.plugins.find((i) => i.id === "sub-plugin")?.selected).toBe(false);
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.25"
+    "@pulsemcp/air-core": "0.0.26"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.25"
+    "@pulsemcp/air-core": "0.0.26"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.25"
+    "@pulsemcp/air-core": "0.0.26"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.25"
+    "@pulsemcp/air-core": "0.0.26"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.25"
+    "@pulsemcp/air-core": "0.0.26"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary
- Hooks and plugins are now fully selectable in the `air start` interactive TUI — previously displayed as read-only with "override not yet supported"
- `getMergedDefaults()` now unions hook and plugin defaults from subagent roots (previously only MCP servers and skills)
- `TuiResult` includes `hooks` and `plugins` arrays, passed through to `prepareSession()` as override arrays
- Updated docs and dry-run output to reflect all four artifact categories in subagent merge

## Context
The SDK (`PrepareSessionOptions.hooks/plugins`) and the Claude adapter (`hookOverrides/pluginOverrides`) already fully supported overrides for all four artifact types. The gap was only in the CLI's TUI layer, which hardcoded `OVERRIDABLE_CATEGORIES` to just `mcp` and `skills`.

## Changes
- **`packages/cli/src/tui/types.ts`** — Added `hooks` and `plugins` to `OVERRIDABLE_CATEGORIES`, extended `TuiResult` and `getSelectedIds()`, expanded `getMergedDefaults()` to include hooks/plugins
- **`packages/cli/src/commands/start.ts`** — Pass `hooks`/`plugins` from TUI result to `prepareSession()`; updated dry-run merged defaults
- **`packages/cli/tests/tui-state.test.ts`** — Updated existing tests and added new tests for hook/plugin selection, merged defaults, and subagent merge (31 tests total)
- **`docs/guides/running-sessions.md`** — Updated subagent merge description to include hooks and plugins

## Known limitation
The Claude adapter's internal `mergeSubagentArtifacts()` only merges MCP servers and skills from subagent roots — not hooks or plugins. This is a pre-existing gap unrelated to this PR. When the TUI is used, this doesn't matter because explicit override arrays are passed. In `--skip-confirmation` / non-TTY mode, subagent hooks/plugins fall back to only the parent root's defaults. A follow-up PR can extend the adapter's merge logic.

## Verification
- [x] CI green — all 5 checks pass (e2e, test x3, validate-schemas)
- [x] Type-check clean (`npx tsc --noEmit -p packages/cli/tsconfig.json`)
- [x] Build succeeds for core, sdk, and cli
- [x] 31 TUI tests pass (6 new tests added for hooks/plugins selection, merged defaults, and subagent merge)
- [x] Independent subagent code review performed and all feedback addressed
- [x] Version bumped to 0.0.26 with CHANGELOG entry
- [x] Docs updated in `running-sessions.md`
- [x] e2e test output confirms hooks/plugins override plumbing works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)