### PR TITLE
fix: exclude *.schema.json and use word-boundary matching in detectSchemaType (v0.0.27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.27] - 2026-04-12
+
+### Fixed
+- `air init` no longer misclassifies `*.schema.json` files or unrelated filenames containing artifact keywords as catalogs — `detectSchemaType` now excludes `*.schema.json` and uses word-boundary matching instead of substring matching
+
 ## [0.0.26] - 2026-04-11
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1775946369-cc49afaa",
+  "name": "air-main-1775953516-857ec2b3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -843,9 +843,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.26",
+        "@pulsemcp/air-sdk": "0.0.27",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -864,7 +864,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -880,9 +880,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.26"
+        "@pulsemcp/air-core": "0.0.27"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -895,9 +895,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.26"
+        "@pulsemcp/air-core": "0.0.27"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -910,9 +910,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.26"
+        "@pulsemcp/air-core": "0.0.27"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -925,9 +925,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.26"
+        "@pulsemcp/air-core": "0.0.27"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -940,9 +940,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.26"
+        "@pulsemcp/air-core": "0.0.27"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.26",
+    "@pulsemcp/air-sdk": "0.0.27",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -49,15 +49,17 @@ const SCHEMA_FILES: Record<SchemaType, string> = {
   hooks: "hooks.schema.json",
 };
 
-// Substrings to match against filenames (checked in order, longest first to avoid false matches)
-const SCHEMA_SUBSTRINGS: [string, SchemaType][] = [
-  ["references", "references"],
-  ["plugins", "plugins"],
-  ["skills", "skills"],
-  ["roots", "roots"],
-  ["hooks", "hooks"],
-  ["mcp", "mcp"],
-  ["air", "air"],
+// Patterns to match against the basename stem (filename without .json extension).
+// Each keyword must appear as a whole word delimited by start/end or a separator (. - _).
+// Checked longest-first to avoid shorter prefixes shadowing longer ones.
+const SCHEMA_PATTERNS: [RegExp, SchemaType][] = [
+  [/(?:^|[._-])references(?:[._-]|$)/, "references"],
+  [/(?:^|[._-])plugins(?:[._-]|$)/, "plugins"],
+  [/(?:^|[._-])skills(?:[._-]|$)/, "skills"],
+  [/(?:^|[._-])roots(?:[._-]|$)/, "roots"],
+  [/(?:^|[._-])hooks(?:[._-]|$)/, "hooks"],
+  [/(?:^|[._-])mcp(?:[._-]|$)/, "mcp"],
+  [/(?:^|[._-])air(?:[._-]|$)/, "air"],
 ];
 
 export function getSchemasDir(): string {
@@ -76,8 +78,10 @@ export function loadSchema(type: SchemaType): object {
 
 export function detectSchemaType(filename: string): SchemaType | null {
   const basename = (filename.split("/").pop() || filename).toLowerCase();
-  for (const [substring, type] of SCHEMA_SUBSTRINGS) {
-    if (basename.includes(substring)) {
+  if (basename.endsWith(".schema.json")) return null;
+  const stem = basename.replace(/\.json$/, "");
+  for (const [pattern, type] of SCHEMA_PATTERNS) {
+    if (pattern.test(stem)) {
       return type;
     }
   }

--- a/packages/core/tests/schemas.test.ts
+++ b/packages/core/tests/schemas.test.ts
@@ -47,6 +47,39 @@ describe("detectSchemaType", () => {
     expect(detectSchemaType("unknown.json")).toBeNull();
     expect(detectSchemaType("config.yaml")).toBeNull();
   });
+
+  it("returns null for *.schema.json files (JSON Schema definitions)", () => {
+    expect(detectSchemaType("mcp.schema.json")).toBeNull();
+    expect(detectSchemaType("skills.schema.json")).toBeNull();
+    expect(detectSchemaType("hooks.schema.json")).toBeNull();
+    expect(detectSchemaType("roots.schema.json")).toBeNull();
+    expect(detectSchemaType("plugins.schema.json")).toBeNull();
+    expect(detectSchemaType("references.schema.json")).toBeNull();
+    expect(detectSchemaType("air.schema.json")).toBeNull();
+    expect(detectSchemaType("schemas/mcp.schema.json")).toBeNull();
+    expect(detectSchemaType("path/to/skills.schema.json")).toBeNull();
+  });
+
+  it("still matches prefixed/suffixed catalog filenames", () => {
+    expect(detectSchemaType("team-mcp.json")).toBe("mcp");
+    expect(detectSchemaType("mcp.local.json")).toBe("mcp");
+    expect(detectSchemaType("mcp-servers.json")).toBe("mcp");
+    expect(detectSchemaType("my-skills.json")).toBe("skills");
+    expect(detectSchemaType("skills-frontend.json")).toBe("skills");
+    expect(detectSchemaType("team_hooks.json")).toBe("hooks");
+    expect(detectSchemaType("dev.air.json")).toBe("air");
+  });
+
+  it("rejects words that contain a keyword as a substring", () => {
+    expect(detectSchemaType("repair.json")).toBeNull();
+    expect(detectSchemaType("affair.json")).toBeNull();
+    expect(detectSchemaType("flair.json")).toBeNull();
+    expect(detectSchemaType("webhooks.json")).toBeNull();
+    expect(detectSchemaType("upskills.json")).toBeNull();
+    expect(detectSchemaType("grassroots.json")).toBeNull();
+    expect(detectSchemaType("mcpserver.json")).toBeNull();
+    expect(detectSchemaType("airtable.json")).toBeNull();
+  });
 });
 
 describe("detectSchemaFromValue", () => {

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.26"
+    "@pulsemcp/air-core": "0.0.27"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.26"
+    "@pulsemcp/air-core": "0.0.27"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.26"
+    "@pulsemcp/air-core": "0.0.27"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.26"
+    "@pulsemcp/air-core": "0.0.27"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.26"
+    "@pulsemcp/air-core": "0.0.27"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/tests/init-from-repo.test.ts
+++ b/packages/sdk/tests/init-from-repo.test.ts
@@ -333,6 +333,29 @@ describe("discoverArtifacts", () => {
     expect(artifacts).toHaveLength(0);
   });
 
+  it("skips *.schema.json files (JSON Schema definitions, not catalogs)", () => {
+    const dir = createGitRepo("https://github.com/acme/config.git", {
+      "schemas/mcp.schema.json": {
+        $schema: "http://json-schema.org/draft-07/schema#",
+        title: "MCP schema",
+        type: "object",
+      },
+      "schemas/skills.schema.json": {
+        $schema: "http://json-schema.org/draft-07/schema#",
+        title: "Skills schema",
+        type: "object",
+      },
+      "mcp/mcp.json": {
+        server: { type: "stdio", command: "echo" },
+      },
+    });
+
+    const artifacts = discoverArtifacts(dir, "acme/config", "main");
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].type).toBe("mcp");
+    expect(artifacts[0].repoPath).toBe("mcp/mcp.json");
+  });
+
   it("discovers multiple files of the same artifact type", () => {
     const dir = createGitRepo("https://github.com/acme/config.git", {
       "frontend/skills.json": {


### PR DESCRIPTION
## Summary

Fixes #79 — `air init` incorrectly picked up `*.schema.json` files (JSON Schema definitions) as MCP catalog artifacts.

### Root cause

`detectSchemaType` in `packages/core/src/schemas.ts` used **substring matching** (`basename.includes("mcp")`) to classify filenames. This had two problems:

1. **`*.schema.json` false positive** (the reported bug): `mcp.schema.json` contains the substring `"mcp"` and was classified as an MCP catalog
2. **Embedded-word false positives**: any filename containing a keyword as part of a larger word would match — `repair.json` contains `"air"`, `webhooks.json` contains `"hooks"`, etc.

### The fix (two layers)

1. **Exclude `*.schema.json`** — early return for filenames ending with `.schema.json` (JSON Schema naming convention)
2. **Word-boundary matching** — replaced `.includes()` with regex that requires keywords to appear as whole words delimited by separators (`.`, `-`, `_`) or start/end of the filename stem

### Before (broken) vs After (fixed)

| Filename | Before | After | Correct? |
|---|---|---|---|
| `mcp.json` | `"mcp"` ✓ | `"mcp"` ✓ | ✓ Exact match |
| `team-mcp.json` | `"mcp"` ✓ | `"mcp"` ✓ | ✓ Prefix with `-` separator |
| `mcp-servers.json` | `"mcp"` ✓ | `"mcp"` ✓ | ✓ Suffix with `-` separator |
| `mcp.local.json` | `"mcp"` ✓ | `"mcp"` ✓ | ✓ Suffix with `.` separator |
| `my_skills.json` | `"skills"` ✓ | `"skills"` ✓ | ✓ Prefix with `_` separator |
| `skills-frontend.json` | `"skills"` ✓ | `"skills"` ✓ | ✓ Suffix with `-` separator |
| `dev.air.json` | `"air"` ✓ | `"air"` ✓ | ✓ Both `.` separators |
| `mcp.schema.json` | `"mcp"` ✗ | `null` ✓ | ✓ JSON Schema definition |
| `skills.schema.json` | `"skills"` ✗ | `null` ✓ | ✓ JSON Schema definition |
| `repair.json` | `"air"` ✗ | `null` ✓ | ✓ English word, not a catalog |
| `affair.json` | `"air"` ✗ | `null` ✓ | ✓ English word, not a catalog |
| `flair.json` | `"air"` ✗ | `null` ✓ | ✓ English word, not a catalog |
| `webhooks.json` | `"hooks"` ✗ | `null` ✓ | ✓ "hooks" embedded in "webhooks" |
| `upskills.json` | `"skills"` ✗ | `null` ✓ | ✓ "skills" embedded in "upskills" |
| `grassroots.json` | `"roots"` ✗ | `null` ✓ | ✓ "roots" embedded in "grassroots" |
| `mcpserver.json` | `"mcp"` ✗ | `null` ✓ | ✓ No separator after keyword |
| `airtable.json` | `"air"` ✗ | `null` ✓ | ✓ No separator after keyword |
| `unknown.json` | `null` ✓ | `null` ✓ | ✓ No keyword present |

### What matches (catalog index files)

The keyword must appear as a **whole word** separated by `.`, `-`, `_`, or start/end of filename:
- Exact: `mcp.json`, `skills.json`, `hooks.json`, `air.json`
- Prefixed: `team-mcp.json`, `my-skills.json`, `dev.air.json`
- Suffixed: `mcp-servers.json`, `mcp.local.json`, `skills-frontend.json`
- Both: `team-mcp-v2.json`, `my_skills.local.json`

### What doesn't match

- `*.schema.json` — JSON Schema definitions (excluded by suffix guard)
- Keywords adjacent to alphanumeric chars without separator — `mcpserver.json`, `airtable.json`
- Keywords embedded in larger words — `repair.json`, `webhooks.json`, `upskills.json`, `grassroots.json`, `affair.json`, `flair.json`
- Unrelated files — `config.json`, `package.json`, `tsconfig.json`

## Verification

- [x] CI green — all 5 checks passed (validate-schemas, e2e, test on Node 18/20/22)
- [x] 60 tests pass across `schemas.test.ts` (19 tests) and `init-from-repo.test.ts` (41 tests)
- [x] Self-review completed by subagent with fresh eyes — approved, no blocking issues
- [x] Reviewer feedback addressed (added keyword-adjacent-to-alphanumeric test cases)
- [x] Version bumped to 0.0.27 across all packages + CHANGELOG updated

### Test evidence

```
 ✓ |@pulsemcp/air-core| tests/schemas.test.ts (19 tests) 13ms
 ✓ |@pulsemcp/air-sdk| tests/init-from-repo.test.ts (41 tests) 1967ms

 Test Files  2 passed (2)
      Tests  60 passed (60)
```

New test cases added:
- `*.schema.json` exclusion: all 7 schema types + path variants
- Prefixed/suffixed catalogs: `team-mcp.json`, `mcp.local.json`, `mcp-servers.json`, `my-skills.json`, `skills-frontend.json`, `team_hooks.json`, `dev.air.json`
- Embedded-word rejection: `repair.json`, `affair.json`, `flair.json`, `webhooks.json`, `upskills.json`, `grassroots.json`
- Keyword-adjacent-to-alphanumeric rejection: `mcpserver.json`, `airtable.json`
- Integration test: `discoverArtifacts` skips `schemas/mcp.schema.json` and `schemas/skills.schema.json` while discovering `mcp/mcp.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)