### PR TITLE
fix: exclude *.schema.json and use word-boundary matching in detectSchemaType (v0.0.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.28] - 2026-04-12
+
+### Fixed
+- `air init` no longer misclassifies `*.schema.json` files or unrelated filenames containing artifact keywords as catalogs — `detectSchemaType` now excludes `*.schema.json` and uses word-boundary matching instead of substring matching
+
 ## [0.0.27] - 2026-04-12
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1775953439-8edd592f",
+  "name": "air-main-1775953516-857ec2b3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -843,9 +843,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.27",
+        "@pulsemcp/air-sdk": "0.0.28",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -864,7 +864,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -880,9 +880,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.27"
+        "@pulsemcp/air-core": "0.0.28"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -895,9 +895,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.27"
+        "@pulsemcp/air-core": "0.0.28"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -910,9 +910,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.27"
+        "@pulsemcp/air-core": "0.0.28"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -925,9 +925,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.27"
+        "@pulsemcp/air-core": "0.0.28"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -940,9 +940,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.27"
+        "@pulsemcp/air-core": "0.0.28"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.27",
+    "@pulsemcp/air-sdk": "0.0.28",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -49,15 +49,17 @@ const SCHEMA_FILES: Record<SchemaType, string> = {
   hooks: "hooks.schema.json",
 };
 
-// Substrings to match against filenames (checked in order, longest first to avoid false matches)
-const SCHEMA_SUBSTRINGS: [string, SchemaType][] = [
-  ["references", "references"],
-  ["plugins", "plugins"],
-  ["skills", "skills"],
-  ["roots", "roots"],
-  ["hooks", "hooks"],
-  ["mcp", "mcp"],
-  ["air", "air"],
+// Patterns to match against the basename stem (filename without .json extension).
+// Each keyword must appear as a whole word delimited by start/end or a separator (. - _).
+// Checked longest-first to avoid shorter prefixes shadowing longer ones.
+const SCHEMA_PATTERNS: [RegExp, SchemaType][] = [
+  [/(?:^|[._-])references(?:[._-]|$)/, "references"],
+  [/(?:^|[._-])plugins(?:[._-]|$)/, "plugins"],
+  [/(?:^|[._-])skills(?:[._-]|$)/, "skills"],
+  [/(?:^|[._-])roots(?:[._-]|$)/, "roots"],
+  [/(?:^|[._-])hooks(?:[._-]|$)/, "hooks"],
+  [/(?:^|[._-])mcp(?:[._-]|$)/, "mcp"],
+  [/(?:^|[._-])air(?:[._-]|$)/, "air"],
 ];
 
 export function getSchemasDir(): string {
@@ -76,8 +78,10 @@ export function loadSchema(type: SchemaType): object {
 
 export function detectSchemaType(filename: string): SchemaType | null {
   const basename = (filename.split("/").pop() || filename).toLowerCase();
-  for (const [substring, type] of SCHEMA_SUBSTRINGS) {
-    if (basename.includes(substring)) {
+  if (basename.endsWith(".schema.json")) return null;
+  const stem = basename.replace(/\.json$/, "");
+  for (const [pattern, type] of SCHEMA_PATTERNS) {
+    if (pattern.test(stem)) {
       return type;
     }
   }

--- a/packages/core/tests/schemas.test.ts
+++ b/packages/core/tests/schemas.test.ts
@@ -47,6 +47,39 @@ describe("detectSchemaType", () => {
     expect(detectSchemaType("unknown.json")).toBeNull();
     expect(detectSchemaType("config.yaml")).toBeNull();
   });
+
+  it("returns null for *.schema.json files (JSON Schema definitions)", () => {
+    expect(detectSchemaType("mcp.schema.json")).toBeNull();
+    expect(detectSchemaType("skills.schema.json")).toBeNull();
+    expect(detectSchemaType("hooks.schema.json")).toBeNull();
+    expect(detectSchemaType("roots.schema.json")).toBeNull();
+    expect(detectSchemaType("plugins.schema.json")).toBeNull();
+    expect(detectSchemaType("references.schema.json")).toBeNull();
+    expect(detectSchemaType("air.schema.json")).toBeNull();
+    expect(detectSchemaType("schemas/mcp.schema.json")).toBeNull();
+    expect(detectSchemaType("path/to/skills.schema.json")).toBeNull();
+  });
+
+  it("still matches prefixed/suffixed catalog filenames", () => {
+    expect(detectSchemaType("team-mcp.json")).toBe("mcp");
+    expect(detectSchemaType("mcp.local.json")).toBe("mcp");
+    expect(detectSchemaType("mcp-servers.json")).toBe("mcp");
+    expect(detectSchemaType("my-skills.json")).toBe("skills");
+    expect(detectSchemaType("skills-frontend.json")).toBe("skills");
+    expect(detectSchemaType("team_hooks.json")).toBe("hooks");
+    expect(detectSchemaType("dev.air.json")).toBe("air");
+  });
+
+  it("rejects words that contain a keyword as a substring", () => {
+    expect(detectSchemaType("repair.json")).toBeNull();
+    expect(detectSchemaType("affair.json")).toBeNull();
+    expect(detectSchemaType("flair.json")).toBeNull();
+    expect(detectSchemaType("webhooks.json")).toBeNull();
+    expect(detectSchemaType("upskills.json")).toBeNull();
+    expect(detectSchemaType("grassroots.json")).toBeNull();
+    expect(detectSchemaType("mcpserver.json")).toBeNull();
+    expect(detectSchemaType("airtable.json")).toBeNull();
+  });
 });
 
 describe("detectSchemaFromValue", () => {

--- a/packages/core/tests/schemas.test.ts
+++ b/packages/core/tests/schemas.test.ts
@@ -28,7 +28,7 @@ describe("getSchemaPath / loadSchema", () => {
 });
 
 describe("detectSchemaType", () => {
-  it("detects from filename substrings", () => {
+  it("detects from word-boundary keyword matching", () => {
     expect(detectSchemaType("air.json")).toBe("air");
     expect(detectSchemaType("skills.json")).toBe("skills");
     expect(detectSchemaType("mcp.json")).toBe("mcp");

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.27"
+    "@pulsemcp/air-core": "0.0.28"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.27"
+    "@pulsemcp/air-core": "0.0.28"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.27"
+    "@pulsemcp/air-core": "0.0.28"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.27"
+    "@pulsemcp/air-core": "0.0.28"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.27"
+    "@pulsemcp/air-core": "0.0.28"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/init-from-repo.ts
+++ b/packages/sdk/src/init-from-repo.ts
@@ -10,6 +10,7 @@ import { resolve, dirname } from "path";
 import {
   getDefaultAirJsonPath,
   detectSchemaType,
+  detectSchemaFromValue,
   getAllSchemaTypes,
   type SchemaType,
 } from "@pulsemcp/air-core";
@@ -215,11 +216,12 @@ export function discoverArtifacts(
       if (typeof data !== "object" || data === null || Array.isArray(data)) {
         continue;
       }
-      // Skip JSON Schema definitions — their $schema points at a meta-schema
-      // (e.g. json-schema.org), not at an AIR schema URL.
+      // If the file declares a $schema, it must point to a known AIR schema.
+      // This rejects JSON Schema definitions, OpenAPI schemas, and any other
+      // structured JSON that happens to match an artifact keyword in its filename.
       if (
         typeof data.$schema === "string" &&
-        data.$schema.includes("json-schema.org")
+        !detectSchemaFromValue(data.$schema)
       ) {
         continue;
       }

--- a/packages/sdk/src/init-from-repo.ts
+++ b/packages/sdk/src/init-from-repo.ts
@@ -215,6 +215,14 @@ export function discoverArtifacts(
       if (typeof data !== "object" || data === null || Array.isArray(data)) {
         continue;
       }
+      // Skip JSON Schema definitions — their $schema points at a meta-schema
+      // (e.g. json-schema.org), not at an AIR schema URL.
+      if (
+        typeof data.$schema === "string" &&
+        data.$schema.includes("json-schema.org")
+      ) {
+        continue;
+      }
     } catch {
       continue;
     }

--- a/packages/sdk/tests/init-from-repo.test.ts
+++ b/packages/sdk/tests/init-from-repo.test.ts
@@ -356,21 +356,52 @@ describe("discoverArtifacts", () => {
     expect(artifacts[0].repoPath).toBe("mcp/mcp.json");
   });
 
-  it("skips files whose $schema points to a JSON Schema meta-schema", () => {
+  it("skips files whose $schema points to a non-AIR schema URL", () => {
+    const nonAirSchemas = [
+      "http://json-schema.org/draft-04/schema#",
+      "http://json-schema.org/draft-06/schema#",
+      "http://json-schema.org/draft-07/schema#",
+      "https://json-schema.org/draft/2019-09/schema",
+      "https://json-schema.org/draft/2020-12/schema",
+      "https://spec.openapis.org/oas/3.1/schema/2022-10-07",
+    ];
+
+    for (const schemaUrl of nonAirSchemas) {
+      const dir = createGitRepo("https://github.com/acme/config.git", {
+        "mcp/mcp.json": {
+          $schema: schemaUrl,
+          title: "Not an AIR catalog",
+          type: "object",
+        },
+        "skills/skills.json": {
+          "my-skill": { description: "A real skill", path: "skills/my-skill" },
+        },
+      });
+
+      const artifacts = discoverArtifacts(dir, "acme/config", "main");
+      expect(artifacts).toHaveLength(1);
+      expect(artifacts[0].type).toBe("skills");
+    }
+  });
+
+  it("discovers catalog files whose $schema points to a known AIR schema URL", () => {
     const dir = createGitRepo("https://github.com/acme/config.git", {
       "mcp/mcp.json": {
-        $schema: "http://json-schema.org/draft-07/schema#",
-        title: "This is a schema definition, not a catalog",
-        type: "object",
+        $schema:
+          "https://raw.githubusercontent.com/pulsemcp/air/main/schemas/mcp.schema.json",
+        server: { type: "stdio", command: "echo" },
       },
       "skills/skills.json": {
+        $schema:
+          "https://raw.githubusercontent.com/pulsemcp/air/main/schemas/skills.schema.json",
         "my-skill": { description: "A real skill", path: "skills/my-skill" },
       },
     });
 
     const artifacts = discoverArtifacts(dir, "acme/config", "main");
-    expect(artifacts).toHaveLength(1);
-    expect(artifacts[0].type).toBe("skills");
+    expect(artifacts).toHaveLength(2);
+    const types = artifacts.map((a) => a.type).sort();
+    expect(types).toEqual(["mcp", "skills"]);
   });
 
   it("discovers multiple files of the same artifact type", () => {

--- a/packages/sdk/tests/init-from-repo.test.ts
+++ b/packages/sdk/tests/init-from-repo.test.ts
@@ -333,6 +333,29 @@ describe("discoverArtifacts", () => {
     expect(artifacts).toHaveLength(0);
   });
 
+  it("skips *.schema.json files (JSON Schema definitions, not catalogs)", () => {
+    const dir = createGitRepo("https://github.com/acme/config.git", {
+      "schemas/mcp.schema.json": {
+        $schema: "http://json-schema.org/draft-07/schema#",
+        title: "MCP schema",
+        type: "object",
+      },
+      "schemas/skills.schema.json": {
+        $schema: "http://json-schema.org/draft-07/schema#",
+        title: "Skills schema",
+        type: "object",
+      },
+      "mcp/mcp.json": {
+        server: { type: "stdio", command: "echo" },
+      },
+    });
+
+    const artifacts = discoverArtifacts(dir, "acme/config", "main");
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].type).toBe("mcp");
+    expect(artifacts[0].repoPath).toBe("mcp/mcp.json");
+  });
+
   it("discovers multiple files of the same artifact type", () => {
     const dir = createGitRepo("https://github.com/acme/config.git", {
       "frontend/skills.json": {

--- a/packages/sdk/tests/init-from-repo.test.ts
+++ b/packages/sdk/tests/init-from-repo.test.ts
@@ -356,6 +356,23 @@ describe("discoverArtifacts", () => {
     expect(artifacts[0].repoPath).toBe("mcp/mcp.json");
   });
 
+  it("skips files whose $schema points to a JSON Schema meta-schema", () => {
+    const dir = createGitRepo("https://github.com/acme/config.git", {
+      "mcp/mcp.json": {
+        $schema: "http://json-schema.org/draft-07/schema#",
+        title: "This is a schema definition, not a catalog",
+        type: "object",
+      },
+      "skills/skills.json": {
+        "my-skill": { description: "A real skill", path: "skills/my-skill" },
+      },
+    });
+
+    const artifacts = discoverArtifacts(dir, "acme/config", "main");
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].type).toBe("skills");
+  });
+
   it("discovers multiple files of the same artifact type", () => {
     const dir = createGitRepo("https://github.com/acme/config.git", {
       "frontend/skills.json": {

--- a/packages/sdk/tests/init-from-repo.test.ts
+++ b/packages/sdk/tests/init-from-repo.test.ts
@@ -384,6 +384,19 @@ describe("discoverArtifacts", () => {
     }
   });
 
+  it("discovers catalog files when $schema is not a string", () => {
+    const dir = createGitRepo("https://github.com/acme/config.git", {
+      "mcp/mcp.json": {
+        $schema: 42,
+        server: { type: "stdio", command: "echo" },
+      },
+    });
+
+    const artifacts = discoverArtifacts(dir, "acme/config", "main");
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].type).toBe("mcp");
+  });
+
   it("discovers catalog files whose $schema points to a known AIR schema URL", () => {
     const dir = createGitRepo("https://github.com/acme/config.git", {
       "mcp/mcp.json": {


### PR DESCRIPTION
## Summary

Fixes #79 — `air init` incorrectly picked up `*.schema.json` files (JSON Schema definitions) as MCP catalog artifacts.

### Root cause
`detectSchemaType` used substring matching (`basename.includes("mcp")`), so `mcp.schema.json` matched as type `mcp`. Similarly, any file containing a keyword as a substring would match (e.g. `repair.json` → `air`).

### Fix — three defense layers

1. **Filename suffix exclusion** (`packages/core/src/schemas.ts`): `*.schema.json` files are immediately rejected — these are JSON Schema definitions, not catalogs.

2. **Word-boundary regex** (`packages/core/src/schemas.ts`): Keywords must appear as whole words delimited by start/end of stem or separators (`.`, `-`, `_`). This prevents `mcpserver.json`, `repair.json`, `webhooks.json`, etc. from matching.

3. **Content-based `$schema` allowlist** (`packages/sdk/src/init-from-repo.ts`): If a discovered file declares a `$schema` field, it must point to a known AIR schema URL (checked via `detectSchemaFromValue()`). Any non-AIR `$schema` — JSON Schema drafts 04 through 2020-12, OpenAPI specs, or anything else — causes the file to be skipped.

### What matches (true positives)
| Filename | Detected type |
|---|---|
| `mcp.json` | `mcp` |
| `team-mcp.json` | `mcp` |
| `mcp.local.json` | `mcp` |
| `mcp-servers.json` | `mcp` |
| `skills.json` | `skills` |
| `my-skills.json` | `skills` |
| `skills-frontend.json` | `skills` |
| `dev.air.json` | `air` |
| File with `$schema` pointing to AIR URL | discovered |

### What doesn't match (true negatives)
| Filename / content | Why rejected |
|---|---|
| `mcp.schema.json` | `.schema.json` suffix exclusion |
| `skills.schema.json` | `.schema.json` suffix exclusion |
| `mcpserver.json` | `mcp` not a whole word |
| `repair.json` | `air` not a whole word |
| `webhooks.json` | `hooks` not a whole word |
| `airtable.json` | `air` not a whole word |
| `grassroots.json` | `roots` not a whole word |
| File with `$schema: "http://json-schema.org/draft-07/schema#"` | Non-AIR `$schema` |
| File with `$schema: "https://spec.openapis.org/oas/3.1/..."` | Non-AIR `$schema` |

## Verification

- [x] `detectSchemaType("mcp.schema.json")` returns `null` (was `"mcp"`)
- [x] `detectSchemaType("mcp.json")` still returns `"mcp"`
- [x] `detectSchemaType("team-mcp.json")` returns `"mcp"` (word-boundary match)
- [x] `detectSchemaType("mcpserver.json")` returns `null` (no word boundary)
- [x] `detectSchemaType("repair.json")` returns `null` (no word boundary)
- [x] `discoverArtifacts` skips files with non-AIR `$schema` (JSON Schema drafts 04–2020-12, OpenAPI)
- [x] `discoverArtifacts` keeps files with AIR `$schema` URLs
- [x] `discoverArtifacts` keeps files with non-string `$schema` values
- [x] `discoverArtifacts` keeps files with no `$schema` field
- [x] All tests in `packages/core/tests/schemas.test.ts` pass (28 tests)
- [x] All tests in `packages/sdk/tests/init-from-repo.test.ts` pass (44 tests)
- [x] CI green on all checks

## Test plan

- [x] Verify `.schema.json` exclusion for all 7 artifact types + path variants
- [x] Verify word-boundary matching for prefixed/suffixed catalogs
- [x] Verify embedded-word rejection (repair, affair, webhooks, mcpserver, etc.)
- [x] Verify content-based `$schema` allowlist with parameterized non-AIR URLs
- [x] Verify positive case: catalog with AIR `$schema` URL is still discovered
- [x] Verify non-string `$schema` values don't cause errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)