### PR TITLE
fix: merge plugin-declared artifacts into session in Claude adapter

### DIFF
--- a/packages/extensions/adapter-claude/src/claude-adapter.ts
+++ b/packages/extensions/adapter-claude/src/claude-adapter.ts
@@ -161,23 +161,23 @@ export class ClaudeAdapter implements AgentAdapter {
       ? this.filterByIds(artifacts.plugins, pluginIds, "plugin")
       : {};
 
+    const mcpSet = new Set(mcpServerIds ?? []);
+    const skillSet = new Set(skillIds);
+    const hookSet = new Set(hookIds);
     for (const plugin of Object.values(plugins)) {
       if (plugin.mcp_servers) {
-        const set = new Set(mcpServerIds ?? []);
-        for (const id of plugin.mcp_servers) set.add(id);
-        mcpServerIds = [...set];
+        for (const id of plugin.mcp_servers) mcpSet.add(id);
       }
       if (plugin.skills) {
-        const set = new Set(skillIds);
-        for (const id of plugin.skills) set.add(id);
-        skillIds = [...set];
+        for (const id of plugin.skills) skillSet.add(id);
       }
       if (plugin.hooks) {
-        const set = new Set(hookIds);
-        for (const id of plugin.hooks) set.add(id);
-        hookIds = [...set];
+        for (const id of plugin.hooks) hookSet.add(id);
       }
     }
+    if (mcpSet.size > 0 || mcpServerIds !== undefined) mcpServerIds = [...mcpSet];
+    skillIds = [...skillSet];
+    hookIds = [...hookSet];
 
     const mcpServers = mcpServerIds?.length
       ? this.filterByIds(artifacts.mcp, mcpServerIds, "MCP server")

--- a/packages/extensions/adapter-claude/src/claude-adapter.ts
+++ b/packages/extensions/adapter-claude/src/claude-adapter.ts
@@ -54,12 +54,27 @@ export class ClaudeAdapter implements AgentAdapter {
     root?: RootEntry,
     _workDir?: string
   ): AgentSessionConfig {
-    const mcpServers = root?.default_mcp_servers
-      ? this.filterByIds(artifacts.mcp, root.default_mcp_servers, "MCP server")
-      : {};
-
     const plugins = root?.default_plugins
       ? this.filterByIds(artifacts.plugins, root.default_plugins, "plugin")
+      : {};
+
+    // Merge plugin-declared MCP servers and skills into root defaults (additive)
+    const mcpServerIdSet = new Set(root?.default_mcp_servers ?? []);
+    const skillIdSet = new Set(root?.default_skills ?? []);
+    for (const plugin of Object.values(plugins)) {
+      if (plugin.mcp_servers) {
+        for (const id of plugin.mcp_servers) mcpServerIdSet.add(id);
+      }
+      if (plugin.skills) {
+        for (const id of plugin.skills) skillIdSet.add(id);
+      }
+    }
+
+    const mcpServerIds = [...mcpServerIdSet];
+    const skillIds = [...skillIdSet];
+
+    const mcpServers = mcpServerIds.length
+      ? this.filterByIds(artifacts.mcp, mcpServerIds, "MCP server")
       : {};
 
     const mcpConfig = this.translateMcpServers(mcpServers);
@@ -68,8 +83,7 @@ export class ClaudeAdapter implements AgentAdapter {
       this.translatePlugin(id, p)
     );
 
-    const skillIds = root?.default_skills ?? [];
-    if (root?.default_skills) {
+    if (skillIds.length > 0) {
       this.validateIds(artifacts.skills, skillIds, "skill");
     }
     const skillPaths = skillIds.map((id) => artifacts.skills[id].path);
@@ -120,6 +134,9 @@ export class ClaudeAdapter implements AgentAdapter {
     let skillIds = options?.skillOverrides
       ?? root?.default_skills
       ?? [];
+    let hookIds = options?.hookOverrides
+      ?? root?.default_hooks
+      ?? [];
 
     // 1b. Merge subagent roots' artifacts if applicable.
     // Skip merge per-artifact type when explicit overrides are provided —
@@ -136,15 +153,34 @@ export class ClaudeAdapter implements AgentAdapter {
       }
     }
 
-    const mcpServers = mcpServerIds?.length
-      ? this.filterByIds(artifacts.mcp, mcpServerIds, "MCP server")
-      : {};
-
+    // 1c. Resolve plugins and merge their declared artifacts (additive)
     const pluginIds = options?.pluginOverrides
       ?? root?.default_plugins
       ?? undefined;
     const plugins = pluginIds?.length
       ? this.filterByIds(artifacts.plugins, pluginIds, "plugin")
+      : {};
+
+    for (const plugin of Object.values(plugins)) {
+      if (plugin.mcp_servers) {
+        const set = new Set(mcpServerIds ?? []);
+        for (const id of plugin.mcp_servers) set.add(id);
+        mcpServerIds = [...set];
+      }
+      if (plugin.skills) {
+        const set = new Set(skillIds);
+        for (const id of plugin.skills) set.add(id);
+        skillIds = [...set];
+      }
+      if (plugin.hooks) {
+        const set = new Set(hookIds);
+        for (const id of plugin.hooks) set.add(id);
+        hookIds = [...set];
+      }
+    }
+
+    const mcpServers = mcpServerIds?.length
+      ? this.filterByIds(artifacts.mcp, mcpServerIds, "MCP server")
       : {};
 
     // 2. Validate skill IDs
@@ -179,9 +215,6 @@ export class ClaudeAdapter implements AgentAdapter {
     }
 
     // 5. Validate and inject path-based hooks into .claude/hooks/
-    const hookIds = options?.hookOverrides
-      ?? root?.default_hooks
-      ?? [];
     if (hookIds.length > 0) {
       this.validateIds(artifacts.hooks, hookIds, "hook");
     }

--- a/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
+++ b/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
@@ -1816,5 +1816,265 @@ describe("ClaudeAdapter", () => {
         expect(Object.keys(settings.hooks)).toHaveLength(0);
       });
     });
+
+    describe("plugin artifact resolution", () => {
+      it("merges plugin mcp_servers into .mcp.json", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        artifacts.mcp["github"] = { type: "stdio", command: "gh" };
+        artifacts.mcp["playwright-custom"] = { type: "stdio", command: "playwright" };
+        artifacts.mcp["remote-fs"] = { type: "stdio", command: "remote-fs" };
+
+        artifacts.plugins["screenshots-videos"] = {
+          description: "Screenshot and video capture",
+          mcp_servers: ["playwright-custom", "remote-fs"],
+        };
+
+        const root: RootEntry = {
+          description: "Test root",
+          default_mcp_servers: ["github"],
+          default_plugins: ["screenshots-videos"],
+        };
+
+        await adapter.prepareSession(artifacts, dir, { root });
+
+        const mcpJson = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
+        expect(mcpJson.mcpServers["github"]).toBeDefined();
+        expect(mcpJson.mcpServers["playwright-custom"]).toBeDefined();
+        expect(mcpJson.mcpServers["remote-fs"]).toBeDefined();
+      });
+
+      it("merges plugin skills into session", async () => {
+        const dir = createTempDir();
+
+        const skillSrcDir = join(dir, "..", "skills-plugin", "lint-fix");
+        mkdirSync(skillSrcDir, { recursive: true });
+        writeFileSync(join(skillSrcDir, "SKILL.md"), "# Lint Fix");
+
+        const parentSkillSrc = join(dir, "..", "skills-plugin", "deploy");
+        mkdirSync(parentSkillSrc, { recursive: true });
+        writeFileSync(join(parentSkillSrc, "SKILL.md"), "# Deploy");
+
+        const artifacts = emptyArtifacts();
+        artifacts.skills["deploy"] = { description: "Deploy", path: resolve(parentSkillSrc) };
+        artifacts.skills["lint-fix"] = { description: "Lint fix", path: resolve(skillSrcDir) };
+
+        artifacts.plugins["code-quality"] = {
+          description: "Code quality tools",
+          skills: ["lint-fix"],
+        };
+
+        const root: RootEntry = {
+          description: "Test root",
+          default_skills: ["deploy"],
+          default_plugins: ["code-quality"],
+        };
+
+        const result = await adapter.prepareSession(artifacts, dir, { root });
+
+        expect(existsSync(join(dir, ".claude", "skills", "deploy", "SKILL.md"))).toBe(true);
+        expect(existsSync(join(dir, ".claude", "skills", "lint-fix", "SKILL.md"))).toBe(true);
+        expect(result.skillPaths).toHaveLength(2);
+      });
+
+      it("merges plugin hooks into session", async () => {
+        const dir = createTempDir();
+
+        const hookSrcDir = join(dir, "..", "hooks-plugin", "lint-pre-commit");
+        mkdirSync(hookSrcDir, { recursive: true });
+        writeFileSync(
+          join(hookSrcDir, "HOOK.json"),
+          JSON.stringify({ event: "pre_tool_call", command: "npx", args: ["lint-staged"] })
+        );
+
+        const artifacts = emptyArtifacts();
+        artifacts.hooks["lint-pre-commit"] = {
+          description: "Pre-commit lint",
+          path: resolve(hookSrcDir),
+        };
+
+        artifacts.plugins["code-quality"] = {
+          description: "Code quality tools",
+          hooks: ["lint-pre-commit"],
+        };
+
+        const root: RootEntry = {
+          description: "Test root",
+          default_plugins: ["code-quality"],
+        };
+
+        const result = await adapter.prepareSession(artifacts, dir, { root });
+
+        expect(existsSync(join(dir, ".claude", "hooks", "lint-pre-commit", "HOOK.json"))).toBe(true);
+        expect(result.hookPaths).toHaveLength(1);
+      });
+
+      it("deduplicates when plugin and root share artifact IDs", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        artifacts.mcp["github"] = { type: "stdio", command: "gh" };
+        artifacts.mcp["slack"] = { type: "stdio", command: "slack" };
+
+        artifacts.plugins["collab-tools"] = {
+          description: "Collaboration",
+          mcp_servers: ["github", "slack"],
+        };
+
+        const root: RootEntry = {
+          description: "Test root",
+          default_mcp_servers: ["github"],
+          default_plugins: ["collab-tools"],
+        };
+
+        await adapter.prepareSession(artifacts, dir, { root });
+
+        const mcpJson = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
+        expect(Object.keys(mcpJson.mcpServers).sort()).toEqual(["github", "slack"]);
+      });
+
+      it("merges artifacts from multiple plugins", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        artifacts.mcp["playwright"] = { type: "stdio", command: "playwright" };
+        artifacts.mcp["eslint-server"] = { type: "stdio", command: "eslint" };
+
+        artifacts.plugins["screenshots"] = {
+          description: "Screenshots",
+          mcp_servers: ["playwright"],
+        };
+        artifacts.plugins["linting"] = {
+          description: "Linting",
+          mcp_servers: ["eslint-server"],
+        };
+
+        const root: RootEntry = {
+          description: "Test root",
+          default_plugins: ["screenshots", "linting"],
+        };
+
+        await adapter.prepareSession(artifacts, dir, { root });
+
+        const mcpJson = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
+        expect(mcpJson.mcpServers["playwright"]).toBeDefined();
+        expect(mcpJson.mcpServers["eslint-server"]).toBeDefined();
+      });
+
+      it("plugin artifacts are additive even when explicit overrides are provided", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        artifacts.mcp["github"] = { type: "stdio", command: "gh" };
+        artifacts.mcp["playwright"] = { type: "stdio", command: "playwright" };
+
+        artifacts.plugins["screenshots"] = {
+          description: "Screenshots",
+          mcp_servers: ["playwright"],
+        };
+
+        const root: RootEntry = {
+          description: "Test root",
+          default_mcp_servers: ["github"],
+          default_plugins: ["screenshots"],
+        };
+
+        await adapter.prepareSession(artifacts, dir, {
+          root,
+          mcpServerOverrides: ["github"],
+        });
+
+        const mcpJson = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
+        expect(mcpJson.mcpServers["github"]).toBeDefined();
+        expect(mcpJson.mcpServers["playwright"]).toBeDefined();
+      });
+
+      it("plugin with no artifact arrays does not affect session", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        artifacts.mcp["github"] = { type: "stdio", command: "gh" };
+
+        artifacts.plugins["minimal"] = {
+          description: "A minimal plugin with no artifacts",
+        };
+
+        const root: RootEntry = {
+          description: "Test root",
+          default_mcp_servers: ["github"],
+          default_plugins: ["minimal"],
+        };
+
+        await adapter.prepareSession(artifacts, dir, { root });
+
+        const mcpJson = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
+        expect(Object.keys(mcpJson.mcpServers)).toEqual(["github"]);
+      });
+    });
+  });
+
+  describe("generateConfig plugin artifact resolution", () => {
+    it("merges plugin mcp_servers into config", () => {
+      const artifacts = emptyArtifacts();
+      artifacts.mcp["github"] = { type: "stdio", command: "gh" };
+      artifacts.mcp["playwright"] = { type: "stdio", command: "playwright" };
+
+      artifacts.plugins["screenshots"] = {
+        description: "Screenshots",
+        mcp_servers: ["playwright"],
+      };
+
+      const root: RootEntry = {
+        description: "Test root",
+        default_mcp_servers: ["github"],
+        default_plugins: ["screenshots"],
+      };
+
+      const config = adapter.generateConfig(artifacts, root);
+      const mcpConfig = config.mcpConfig as any;
+
+      expect(mcpConfig.mcpServers["github"]).toBeDefined();
+      expect(mcpConfig.mcpServers["playwright"]).toBeDefined();
+    });
+
+    it("merges plugin skills into config", () => {
+      const artifacts = emptyArtifacts();
+      artifacts.skills["deploy"] = { description: "Deploy", path: "skills/deploy" };
+      artifacts.skills["lint-fix"] = { description: "Lint fix", path: "skills/lint-fix" };
+
+      artifacts.plugins["code-quality"] = {
+        description: "Code quality",
+        skills: ["lint-fix"],
+      };
+
+      const root: RootEntry = {
+        description: "Test root",
+        default_skills: ["deploy"],
+        default_plugins: ["code-quality"],
+      };
+
+      const config = adapter.generateConfig(artifacts, root);
+      expect(config.skillPaths).toEqual(["skills/deploy", "skills/lint-fix"]);
+    });
+
+    it("handles plugin mcp_servers when root has no default_mcp_servers", () => {
+      const artifacts = emptyArtifacts();
+      artifacts.mcp["playwright"] = { type: "stdio", command: "playwright" };
+
+      artifacts.plugins["screenshots"] = {
+        description: "Screenshots",
+        mcp_servers: ["playwright"],
+      };
+
+      const root: RootEntry = {
+        description: "Test root",
+        default_plugins: ["screenshots"],
+      };
+
+      const config = adapter.generateConfig(artifacts, root);
+      const mcpConfig = config.mcpConfig as any;
+      expect(mcpConfig.mcpServers["playwright"]).toBeDefined();
+    });
   });
 });

--- a/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
+++ b/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
@@ -1990,6 +1990,48 @@ describe("ClaudeAdapter", () => {
         expect(mcpJson.mcpServers["playwright"]).toBeDefined();
       });
 
+      it("throws when plugin references a nonexistent MCP server", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        artifacts.plugins["bad-plugin"] = {
+          description: "References missing server",
+          mcp_servers: ["nonexistent-server"],
+        };
+
+        const root: RootEntry = {
+          description: "Test root",
+          default_plugins: ["bad-plugin"],
+        };
+
+        await expect(
+          adapter.prepareSession(artifacts, dir, { root })
+        ).rejects.toThrow(
+          /Unknown MCP server ID\(s\): nonexistent-server/
+        );
+      });
+
+      it("throws when plugin references a nonexistent skill", async () => {
+        const dir = createTempDir();
+        const artifacts = emptyArtifacts();
+
+        artifacts.plugins["bad-plugin"] = {
+          description: "References missing skill",
+          skills: ["nonexistent-skill"],
+        };
+
+        const root: RootEntry = {
+          description: "Test root",
+          default_plugins: ["bad-plugin"],
+        };
+
+        await expect(
+          adapter.prepareSession(artifacts, dir, { root })
+        ).rejects.toThrow(
+          /Unknown skill ID\(s\): nonexistent-skill/
+        );
+      });
+
       it("plugin with no artifact arrays does not affect session", async () => {
         const dir = createTempDir();
         const artifacts = emptyArtifacts();


### PR DESCRIPTION
## Summary

- Plugins that declare `mcp_servers`, `skills`, or `hooks` arrays now have those artifacts merged into the session's activated set
- Previously, resolved plugins were only used for metadata (name/description/version) — their artifact references were silently discarded, so plugins like `screenshots-videos` declaring `["playwright-custom", "remote-fs-screenshots"]` had no effect
- Fix applies to both `prepareSession` (used by `air prepare`) and `generateConfig` (used by `air start`)

## What changed

**`prepareSession`**: Plugin resolution moved before MCP server filtering. After resolving plugins, their `mcp_servers`, `skills`, and `hooks` are merged (additive union via Set) into the session's ID sets. `hookIds` declaration moved up so plugin hooks can be merged before the hook injection loop.

**`generateConfig`**: Plugin resolution moved before MCP server/skill filtering. Plugin `mcp_servers` and `skills` are merged into root defaults via Set before filtering and validation.

Plugin artifacts are always additive — they contribute additional artifacts on top of explicit selections, even when `mcpServerOverrides` or `skillOverrides` are provided. This differs from subagent merging (which is skipped when overrides are present) because plugins are explicitly activated and their artifacts are integral dependencies.

## Verification

- [x] CI green (all adapter-claude tests pass — 80/80)
- [x] Type-check clean (`tsc --noEmit`)
- [x] 12 new tests added covering plugin artifact resolution in both `prepareSession` and `generateConfig`
- [x] Subagent PR review completed and all feedback addressed
- [x] Self-review completed

### Test results

**Before (main):** Plugins resolved but artifacts discarded — a plugin with `mcp_servers: ["playwright-custom"]` produces empty `.mcp.json`.

**After (this PR):** Plugin MCP servers appear in `.mcp.json`, plugin skills are injected, plugin hooks are registered.

```
 ✓ |@pulsemcp/air-adapter-claude| tests/claude-adapter.test.ts (80 tests) 119ms

 Test Files  1 passed (1)
      Tests  80 passed (80)
```

New tests:
- `merges plugin mcp_servers into .mcp.json` — plugin-declared MCP servers appear alongside root defaults
- `merges plugin skills into session` — plugin skills are injected into `.claude/skills/`
- `merges plugin hooks into session` — plugin hooks are injected into `.claude/hooks/`
- `deduplicates when plugin and root share artifact IDs` — Set-based dedup works
- `merges artifacts from multiple plugins` — union across multiple plugins
- `plugin artifacts are additive even when explicit overrides are provided` — plugins contribute even with `mcpServerOverrides`
- `throws when plugin references a nonexistent MCP server` — clear error for invalid plugin artifact refs
- `throws when plugin references a nonexistent skill` — clear error for invalid plugin skill refs
- `plugin with no artifact arrays does not affect session` — minimal plugins are harmless
- `generateConfig: merges plugin mcp_servers into config` — `generateConfig` path works
- `generateConfig: merges plugin skills into config` — skill paths include plugin skills
- `generateConfig: handles plugin mcp_servers when root has no default_mcp_servers` — plugins work without root MCP defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)