### PR TITLE
feat: non-interactive artifact selection flags for `air start` / `air prepare` (add/remove/without-defaults)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.30] - 2026-04-17
+
+### Added
+- `air start` now accepts `--skills`, `--mcp-servers`, `--hooks`, and `--plugins` flags — each taking a comma-separated list of IDs — to select artifacts non-interactively. Any flag present suppresses the interactive TUI; unspecified categories fall back to root defaults. `--dry-run` honors these flags so scripted invocations can be previewed.
+
 ## [0.0.29] - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.30] - 2026-04-17
 
 ### Added
-- `air start` now accepts `--skills`, `--mcp-servers`, `--hooks`, and `--plugins` flags — each taking a comma-separated list of IDs — to select artifacts non-interactively. Any flag present suppresses the interactive TUI; unspecified categories fall back to root defaults. `--dry-run` honors these flags so scripted invocations can be previewed.
+- `air start` and `air prepare` now accept `--skills`, `--mcp-servers`, `--hooks`, and `--plugins` flags — each taking a comma-separated list of IDs — to **add** artifacts on top of root defaults non-interactively. Any flag present suppresses the interactive TUI in `air start`; unspecified categories are untouched. `--dry-run` honors these flags so scripted invocations can be previewed.
+- Matching `--without-skills`, `--without-mcp-servers`, `--without-hooks`, and `--without-plugins` flags remove specific IDs from the root defaults.
+- `--without-defaults` drops all root defaults (parent root + merged subagent roots) so only the artifacts explicitly added via the `--skills` / `--mcp-servers` / `--hooks` / `--plugins` flags are activated.
+- New SDK helpers: `computeMergedDefaults(root, artifacts, skipSubagentMerge?)` and `resolveCategoryOverride(explicit, defaults, add, remove, withoutDefaults)` for reusing the add/remove resolution logic from callers other than the CLI.
+
+### Changed
+- `air prepare --skills <ids>` (and `--mcp-servers` / `--hooks` / `--plugins`) now **adds** on top of root defaults instead of replacing them. This is a breaking change for callers that relied on the previous override behavior — combine with `--without-defaults` to restore the old semantic (`--without-defaults --skills <ids>`).
 
 ## [0.0.29] - 2026-04-14
 

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -38,7 +38,7 @@ When not in a TTY (e.g., in a CI pipeline) or when `--skip-confirmation` is pass
 
 ### Non-interactive selection
 
-Pass any of `--skills`, `--mcp-servers`, `--hooks`, or `--plugins` to select artifacts from the command line instead of the TUI. Each flag takes a comma-separated list of IDs and overrides the root defaults for that category. Unspecified categories fall back to root defaults.
+Pass any of `--skills`, `--mcp-servers`, `--hooks`, or `--plugins` to select artifacts from the command line instead of the TUI. Each flag takes a comma-separated list of IDs and overrides the root defaults for that category. Unspecified categories (flag omitted) fall back to root defaults; passing an empty or comma-only value (e.g. `--skills ""`) explicitly deselects everything in that category.
 
 ```bash
 air start claude --root web-app --skills deploy-staging,initial-pr-review --mcp-servers github,postgres-prod

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -38,13 +38,20 @@ When not in a TTY (e.g., in a CI pipeline) or when `--skip-confirmation` is pass
 
 ### Non-interactive selection
 
-Pass any of `--skills`, `--mcp-servers`, `--hooks`, or `--plugins` to select artifacts from the command line instead of the TUI. Each flag takes a comma-separated list of IDs and overrides the root defaults for that category. Unspecified categories (flag omitted) fall back to root defaults; passing an empty or comma-only value (e.g. `--skills ""`) explicitly deselects everything in that category.
+Pass any of `--skills`, `--mcp-servers`, `--hooks`, or `--plugins` to tweak the selection from the command line instead of the TUI. Each flag takes a comma-separated list of IDs and **adds** those artifacts on top of the root defaults (union). Use the matching `--without-*` flag to remove specific IDs from the defaults, or `--without-defaults` to opt out of all root defaults and start from an empty set.
 
 ```bash
-air start claude --root web-app --skills deploy-staging,initial-pr-review --mcp-servers github,postgres-prod
+# Add an extra skill and MCP server on top of web-app's defaults
+air start claude --root web-app --skills deploy-staging --mcp-servers postgres-prod
+
+# Drop a specific hook from the defaults
+air start claude --root web-app --without-hooks prevent-secrets-in-context
+
+# Run with only the explicitly listed artifacts (no root defaults at all)
+air start claude --root web-app --without-defaults --skills pr-review --mcp-servers github
 ```
 
-When any of these flags is provided, `air start` skips the interactive TUI even if stdin/stdout are a TTY.
+When any of these flags is provided, `air start` skips the interactive TUI even if stdin/stdout are a TTY. Flags for unspecified categories leave those categories at their root defaults.
 
 ### Options
 
@@ -55,10 +62,15 @@ Required argument: `<agent>` — the agent to start (e.g., `claude`).
 | `--root <name>` | Activate a specific root |
 | `--dry-run` | Preview configuration without starting |
 | `--skip-confirmation` | Skip the interactive TUI and launch directly |
-| `--skills <ids>` | Comma-separated skill IDs (overrides root defaults, skips the TUI) |
-| `--mcp-servers <ids>` | Comma-separated MCP server IDs (overrides root defaults, skips the TUI) |
-| `--hooks <ids>` | Comma-separated hook IDs (overrides root defaults, skips the TUI) |
-| `--plugins <ids>` | Comma-separated plugin IDs (overrides root defaults, skips the TUI) |
+| `--skills <ids>` | Comma-separated skill IDs to add on top of root defaults (skips the TUI) |
+| `--mcp-servers <ids>` | Comma-separated MCP server IDs to add on top of root defaults (skips the TUI) |
+| `--hooks <ids>` | Comma-separated hook IDs to add on top of root defaults (skips the TUI) |
+| `--plugins <ids>` | Comma-separated plugin IDs to add on top of root defaults (skips the TUI) |
+| `--without-skills <ids>` | Skill IDs to remove from the root defaults |
+| `--without-mcp-servers <ids>` | MCP server IDs to remove from the root defaults |
+| `--without-hooks <ids>` | Hook IDs to remove from the root defaults |
+| `--without-plugins <ids>` | Plugin IDs to remove from the root defaults |
+| `--without-defaults` | Ignore all root defaults — start from an empty set and activate only the artifacts added via `--skills` / `--mcp-servers` / `--hooks` / `--plugins` |
 | `--no-subagent-merge` | Skip merging subagent roots' artifacts |
 
 ### Passing arguments to the agent
@@ -82,7 +94,7 @@ air start claude --dry-run
 Dry run honors the non-interactive selection flags, so you can preview exactly what a scripted invocation would run:
 
 ```bash
-air start claude --dry-run --skills deploy-staging --mcp-servers github
+air start claude --dry-run --skills deploy-staging --without-hooks prevent-secrets-in-context
 ```
 
 Output:
@@ -153,10 +165,15 @@ Required argument: `<adapter>` — the agent adapter to use (e.g., `claude`).
 | `--config <path>` | Path to air.json (default: `~/.air/air.json` or `AIR_CONFIG`) |
 | `--root <name>` | Root to activate (auto-detected from cwd if omitted) |
 | `--target <dir>` | Directory to prepare (default: current directory) |
-| `--skills <ids>` | Comma-separated skill IDs (overrides root defaults) |
-| `--mcp-servers <ids>` | Comma-separated MCP server IDs (overrides root defaults) |
-| `--hooks <ids>` | Comma-separated hook IDs (overrides root defaults) |
-| `--plugins <ids>` | Comma-separated plugin IDs (overrides root defaults) |
+| `--skills <ids>` | Comma-separated skill IDs to add on top of root defaults |
+| `--mcp-servers <ids>` | Comma-separated MCP server IDs to add on top of root defaults |
+| `--hooks <ids>` | Comma-separated hook IDs to add on top of root defaults |
+| `--plugins <ids>` | Comma-separated plugin IDs to add on top of root defaults |
+| `--without-skills <ids>` | Skill IDs to remove from the root defaults |
+| `--without-mcp-servers <ids>` | MCP server IDs to remove from the root defaults |
+| `--without-hooks <ids>` | Hook IDs to remove from the root defaults |
+| `--without-plugins <ids>` | Plugin IDs to remove from the root defaults |
+| `--without-defaults` | Ignore all root defaults — start from an empty set |
 | `--no-subagent-merge` | Skip merging subagent roots' artifacts |
 | `--skip-validation` | Skip `${VAR}` validation |
 
@@ -198,12 +215,19 @@ Detection priority:
 3. Root-level match (root has no subdirectory specified)
 4. Any matching root as fallback
 
-### Overriding defaults
+### Adjusting the selection
 
-Override which skills, MCP servers, hooks, or plugins are activated, regardless of root defaults:
+Add artifacts on top of root defaults, remove specific IDs, or drop all defaults:
 
 ```bash
-air prepare claude --skills deploy-staging --mcp-servers github,postgres-prod --hooks lint-pre-commit --plugins code-quality
+# Add a skill and an MCP server on top of the root's defaults
+air prepare claude --skills deploy-staging --mcp-servers postgres-prod
+
+# Remove a hook from the defaults
+air prepare claude --without-hooks prevent-secrets-in-context
+
+# Start from empty and include only what you list
+air prepare claude --without-defaults --skills deploy-staging --mcp-servers github
 ```
 
 ## air export — building plugin marketplaces

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -36,6 +36,16 @@ The footer shows a cross-artifact selection summary so you can see what's select
 
 When not in a TTY (e.g., in a CI pipeline) or when `--skip-confirmation` is passed, the TUI is skipped and the agent launches with root defaults.
 
+### Non-interactive selection
+
+Pass any of `--skills`, `--mcp-servers`, `--hooks`, or `--plugins` to select artifacts from the command line instead of the TUI. Each flag takes a comma-separated list of IDs and overrides the root defaults for that category. Unspecified categories fall back to root defaults.
+
+```bash
+air start claude --root web-app --skills deploy-staging,initial-pr-review --mcp-servers github,postgres-prod
+```
+
+When any of these flags is provided, `air start` skips the interactive TUI even if stdin/stdout are a TTY.
+
 ### Options
 
 Required argument: `<agent>` — the agent to start (e.g., `claude`).
@@ -45,6 +55,10 @@ Required argument: `<agent>` — the agent to start (e.g., `claude`).
 | `--root <name>` | Activate a specific root |
 | `--dry-run` | Preview configuration without starting |
 | `--skip-confirmation` | Skip the interactive TUI and launch directly |
+| `--skills <ids>` | Comma-separated skill IDs (overrides root defaults, skips the TUI) |
+| `--mcp-servers <ids>` | Comma-separated MCP server IDs (overrides root defaults, skips the TUI) |
+| `--hooks <ids>` | Comma-separated hook IDs (overrides root defaults, skips the TUI) |
+| `--plugins <ids>` | Comma-separated plugin IDs (overrides root defaults, skips the TUI) |
 | `--no-subagent-merge` | Skip merging subagent roots' artifacts |
 
 ### Passing arguments to the agent
@@ -63,6 +77,12 @@ Preview what would be activated:
 
 ```bash
 air start claude --dry-run
+```
+
+Dry run honors the non-interactive selection flags, so you can preview exactly what a scripted invocation would run:
+
+```bash
+air start claude --dry-run --skills deploy-staging --mcp-servers github
 ```
 
 Output:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1776204185-80cfc143",
+  "name": "air-main-1776434722-826c1c4f",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -847,9 +847,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.29",
+        "@pulsemcp/air-sdk": "0.0.30",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -868,7 +868,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -884,9 +884,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.29"
+        "@pulsemcp/air-core": "0.0.30"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -899,9 +899,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.29"
+        "@pulsemcp/air-core": "0.0.30"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -914,9 +914,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.29"
+        "@pulsemcp/air-core": "0.0.30"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -929,9 +929,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.29"
+        "@pulsemcp/air-core": "0.0.30"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -944,9 +944,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.29"
+        "@pulsemcp/air-core": "0.0.30"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -959,9 +959,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.29"
+        "@pulsemcp/air-core": "0.0.30"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.29",
+    "@pulsemcp/air-sdk": "0.0.30",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -36,6 +36,11 @@ function parseArgvFlag(flagName: string): string | undefined {
   return undefined;
 }
 
+function parseIdList(value: string | undefined): string[] | undefined {
+  if (value === undefined) return undefined;
+  return value.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
 export function prepareCommand(): Command {
   const cmd = new Command("prepare")
     .description(
@@ -54,19 +59,39 @@ export function prepareCommand(): Command {
     )
     .option(
       "--skills <ids>",
-      "Comma-separated skill IDs (overrides root defaults)"
+      "Comma-separated skill IDs to ADD on top of root defaults"
     )
     .option(
       "--mcp-servers <ids>",
-      "Comma-separated MCP server IDs (overrides root defaults)"
+      "Comma-separated MCP server IDs to ADD on top of root defaults"
     )
     .option(
       "--hooks <ids>",
-      "Comma-separated hook IDs (overrides root defaults)"
+      "Comma-separated hook IDs to ADD on top of root defaults"
     )
     .option(
       "--plugins <ids>",
-      "Comma-separated plugin IDs (overrides root defaults)"
+      "Comma-separated plugin IDs to ADD on top of root defaults"
+    )
+    .option(
+      "--without-skills <ids>",
+      "Comma-separated skill IDs to remove from root defaults"
+    )
+    .option(
+      "--without-mcp-servers <ids>",
+      "Comma-separated MCP server IDs to remove from root defaults"
+    )
+    .option(
+      "--without-hooks <ids>",
+      "Comma-separated hook IDs to remove from root defaults"
+    )
+    .option(
+      "--without-plugins <ids>",
+      "Comma-separated plugin IDs to remove from root defaults"
+    )
+    .option(
+      "--without-defaults",
+      "Ignore all root defaults — start from an empty selection (only artifacts added via --skills / --mcp-servers / --hooks / --plugins will be activated)"
     )
     .option(
       "--no-subagent-merge",
@@ -86,6 +111,11 @@ export function prepareCommand(): Command {
         mcpServers?: string;
         hooks?: string;
         plugins?: string;
+        withoutSkills?: string;
+        withoutMcpServers?: string;
+        withoutHooks?: string;
+        withoutPlugins?: string;
+        withoutDefaults?: boolean;
         subagentMerge: boolean;
         skipValidation?: boolean;
       }) => {
@@ -125,18 +155,15 @@ export function prepareCommand(): Command {
             root: options.root,
             target: options.target,
             adapter,
-            skills: options.skills
-              ? options.skills.split(",").map((s) => s.trim())
-              : undefined,
-            mcpServers: options.mcpServers
-              ? options.mcpServers.split(",").map((s) => s.trim())
-              : undefined,
-            hooks: options.hooks
-              ? options.hooks.split(",").map((s) => s.trim())
-              : undefined,
-            plugins: options.plugins
-              ? options.plugins.split(",").map((s) => s.trim())
-              : undefined,
+            addSkills: parseIdList(options.skills),
+            addMcpServers: parseIdList(options.mcpServers),
+            addHooks: parseIdList(options.hooks),
+            addPlugins: parseIdList(options.plugins),
+            removeSkills: parseIdList(options.withoutSkills),
+            removeMcpServers: parseIdList(options.withoutMcpServers),
+            removeHooks: parseIdList(options.withoutHooks),
+            removePlugins: parseIdList(options.withoutPlugins),
+            withoutDefaults: options.withoutDefaults,
             skipSubagentMerge: !options.subagentMerge,
             skipValidation: options.skipValidation,
             extensionOptions,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -21,6 +21,22 @@ export function startCommand(): Command {
       "Don't prompt for confirmation before starting"
     )
     .option(
+      "--skills <ids>",
+      "Comma-separated skill IDs (overrides root defaults, skips interactive TUI)"
+    )
+    .option(
+      "--mcp-servers <ids>",
+      "Comma-separated MCP server IDs (overrides root defaults, skips interactive TUI)"
+    )
+    .option(
+      "--hooks <ids>",
+      "Comma-separated hook IDs (overrides root defaults, skips interactive TUI)"
+    )
+    .option(
+      "--plugins <ids>",
+      "Comma-separated plugin IDs (overrides root defaults, skips interactive TUI)"
+    )
+    .option(
       "--no-subagent-merge",
       "Skip merging subagent roots' artifacts into the parent session (for orchestrators that manage composition externally)"
     )
@@ -32,6 +48,10 @@ export function startCommand(): Command {
           root?: string;
           dryRun?: boolean;
           skipConfirmation?: boolean;
+          skills?: string;
+          mcpServers?: string;
+          hooks?: string;
+          plugins?: string;
           subagentMerge: boolean;
         },
       ) => {
@@ -76,9 +96,31 @@ export function startCommand(): Command {
 
         const skipSubagentMerge = !options.subagentMerge;
 
+        // Parse CLI artifact flags (CSV of IDs). Any flag present implies
+        // non-interactive mode and suppresses the TUI; unspecified categories
+        // fall back to root defaults via prepareSession's default handling.
+        const parseIdList = (value: string | undefined): string[] | undefined =>
+          value ? value.split(",").map((s) => s.trim()).filter(Boolean) : undefined;
+
+        let selectedSkills = parseIdList(options.skills);
+        let selectedMcpServers = parseIdList(options.mcpServers);
+        let selectedHooks = parseIdList(options.hooks);
+        let selectedPlugins = parseIdList(options.plugins);
+
+        const hasArtifactFlags =
+          selectedSkills !== undefined ||
+          selectedMcpServers !== undefined ||
+          selectedHooks !== undefined ||
+          selectedPlugins !== undefined;
+
         // Dry run
         if (options.dryRun) {
-          printDryRun(agent, result.artifacts, root, skipSubagentMerge);
+          printDryRun(agent, result.artifacts, root, skipSubagentMerge, {
+            skills: selectedSkills,
+            mcpServers: selectedMcpServers,
+            hooks: selectedHooks,
+            plugins: selectedPlugins,
+          });
           process.exit(0);
         }
 
@@ -90,15 +132,9 @@ export function startCommand(): Command {
           process.exit(1);
         }
 
-        // Interactive TUI or skip
-        let selectedSkills: string[] | undefined;
-        let selectedMcpServers: string[] | undefined;
-        let selectedHooks: string[] | undefined;
-        let selectedPlugins: string[] | undefined;
-
         const isTTY = process.stdout.isTTY && process.stdin.isTTY;
 
-        if (isTTY && !options.skipConfirmation) {
+        if (isTTY && !options.skipConfirmation && !hasArtifactFlags) {
           const tuiResult = await runInteractiveSelector(
             result.artifacts,
             root,
@@ -167,7 +203,13 @@ function printDryRun(
   agent: string,
   artifacts: ResolvedArtifacts,
   root?: RootEntry,
-  skipSubagentMerge = false
+  skipSubagentMerge = false,
+  overrides: {
+    skills?: string[];
+    mcpServers?: string[];
+    hooks?: string[];
+    plugins?: string[];
+  } = {}
 ) {
   console.log(`\n=== AIR Session Configuration ===`);
   console.log(`Agent: ${agent}`);
@@ -186,10 +228,11 @@ function printDryRun(
       }
     : getMergedDefaults(root, artifacts.roots);
 
-  const mcpIds = merged.mcpServerIds.length > 0 ? merged.mcpServerIds : (root?.default_mcp_servers || Object.keys(artifacts.mcp));
-  const skillIds = merged.skillIds.length > 0 ? merged.skillIds : (root?.default_skills || Object.keys(artifacts.skills));
-  const pluginIds = merged.pluginIds.length > 0 ? merged.pluginIds : (root?.default_plugins || Object.keys(artifacts.plugins));
-  const hookIds = merged.hookIds.length > 0 ? merged.hookIds : (root?.default_hooks || Object.keys(artifacts.hooks));
+  // CLI overrides take precedence over merged defaults for each category
+  const mcpIds = overrides.mcpServers ?? (merged.mcpServerIds.length > 0 ? merged.mcpServerIds : (root?.default_mcp_servers || Object.keys(artifacts.mcp)));
+  const skillIds = overrides.skills ?? (merged.skillIds.length > 0 ? merged.skillIds : (root?.default_skills || Object.keys(artifacts.skills)));
+  const pluginIds = overrides.plugins ?? (merged.pluginIds.length > 0 ? merged.pluginIds : (root?.default_plugins || Object.keys(artifacts.plugins)));
+  const hookIds = overrides.hooks ?? (merged.hookIds.length > 0 ? merged.hookIds : (root?.default_hooks || Object.keys(artifacts.hooks)));
 
   console.log(`\nMCP Servers (${mcpIds.length}):`);
   for (const id of mcpIds) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -96,11 +96,15 @@ export function startCommand(): Command {
 
         const skipSubagentMerge = !options.subagentMerge;
 
-        // Parse CLI artifact flags (CSV of IDs). Any flag present implies
-        // non-interactive mode and suppresses the TUI; unspecified categories
+        // Parse CLI artifact flags (CSV of IDs). Any flag present (including
+        // an empty or comma-only value) implies non-interactive mode, suppresses
+        // the TUI, and produces an explicit list — an empty string means "no
+        // artifacts of this category". Unspecified categories (flag omitted)
         // fall back to root defaults via prepareSession's default handling.
-        const parseIdList = (value: string | undefined): string[] | undefined =>
-          value ? value.split(",").map((s) => s.trim()).filter(Boolean) : undefined;
+        const parseIdList = (value: string | undefined): string[] | undefined => {
+          if (value === undefined) return undefined;
+          return value.split(",").map((s) => s.trim()).filter(Boolean);
+        };
 
         let selectedSkills = parseIdList(options.skills);
         let selectedMcpServers = parseIdList(options.mcpServers);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -4,11 +4,12 @@ import {
   startSession,
   prepareSession,
   detectRoot,
+  computeMergedDefaults,
+  resolveCategoryOverride,
   type ResolvedArtifacts,
   type RootEntry,
 } from "@pulsemcp/air-sdk";
 import { runInteractiveSelector } from "../tui/interactive-selector.js";
-import { getMergedDefaults } from "../tui/types.js";
 
 export function startCommand(): Command {
   const cmd = new Command("start")
@@ -22,19 +23,39 @@ export function startCommand(): Command {
     )
     .option(
       "--skills <ids>",
-      "Comma-separated skill IDs (overrides root defaults, skips interactive TUI)"
+      "Comma-separated skill IDs to ADD on top of root defaults (skips interactive TUI)"
     )
     .option(
       "--mcp-servers <ids>",
-      "Comma-separated MCP server IDs (overrides root defaults, skips interactive TUI)"
+      "Comma-separated MCP server IDs to ADD on top of root defaults (skips interactive TUI)"
     )
     .option(
       "--hooks <ids>",
-      "Comma-separated hook IDs (overrides root defaults, skips interactive TUI)"
+      "Comma-separated hook IDs to ADD on top of root defaults (skips interactive TUI)"
     )
     .option(
       "--plugins <ids>",
-      "Comma-separated plugin IDs (overrides root defaults, skips interactive TUI)"
+      "Comma-separated plugin IDs to ADD on top of root defaults (skips interactive TUI)"
+    )
+    .option(
+      "--without-skills <ids>",
+      "Comma-separated skill IDs to remove from root defaults"
+    )
+    .option(
+      "--without-mcp-servers <ids>",
+      "Comma-separated MCP server IDs to remove from root defaults"
+    )
+    .option(
+      "--without-hooks <ids>",
+      "Comma-separated hook IDs to remove from root defaults"
+    )
+    .option(
+      "--without-plugins <ids>",
+      "Comma-separated plugin IDs to remove from root defaults"
+    )
+    .option(
+      "--without-defaults",
+      "Ignore all root defaults — start from an empty selection (only artifacts added via --skills / --mcp-servers / --hooks / --plugins will be activated)"
     )
     .option(
       "--no-subagent-merge",
@@ -52,6 +73,11 @@ export function startCommand(): Command {
           mcpServers?: string;
           hooks?: string;
           plugins?: string;
+          withoutSkills?: string;
+          withoutMcpServers?: string;
+          withoutHooks?: string;
+          withoutPlugins?: string;
+          withoutDefaults?: boolean;
           subagentMerge: boolean;
         },
       ) => {
@@ -96,26 +122,65 @@ export function startCommand(): Command {
 
         const skipSubagentMerge = !options.subagentMerge;
 
-        // Parse CLI artifact flags (CSV of IDs). Any flag present (including
-        // an empty or comma-only value) implies non-interactive mode, suppresses
-        // the TUI, and produces an explicit list — an empty string means "no
-        // artifacts of this category". Unspecified categories (flag omitted)
-        // fall back to root defaults via prepareSession's default handling.
+        // Parse CLI artifact flags. Values are comma-separated ID lists with
+        // whitespace trimmed and empty entries filtered. `undefined` means the
+        // flag was not passed.
         const parseIdList = (value: string | undefined): string[] | undefined => {
           if (value === undefined) return undefined;
           return value.split(",").map((s) => s.trim()).filter(Boolean);
         };
 
-        let selectedSkills = parseIdList(options.skills);
-        let selectedMcpServers = parseIdList(options.mcpServers);
-        let selectedHooks = parseIdList(options.hooks);
-        let selectedPlugins = parseIdList(options.plugins);
+        const addSkills = parseIdList(options.skills);
+        const addMcpServers = parseIdList(options.mcpServers);
+        const addHooks = parseIdList(options.hooks);
+        const addPlugins = parseIdList(options.plugins);
+        const removeSkills = parseIdList(options.withoutSkills);
+        const removeMcpServers = parseIdList(options.withoutMcpServers);
+        const removeHooks = parseIdList(options.withoutHooks);
+        const removePlugins = parseIdList(options.withoutPlugins);
+        const withoutDefaults = options.withoutDefaults ?? false;
 
         const hasArtifactFlags =
-          selectedSkills !== undefined ||
-          selectedMcpServers !== undefined ||
-          selectedHooks !== undefined ||
-          selectedPlugins !== undefined;
+          addSkills !== undefined ||
+          addMcpServers !== undefined ||
+          addHooks !== undefined ||
+          addPlugins !== undefined ||
+          removeSkills !== undefined ||
+          removeMcpServers !== undefined ||
+          removeHooks !== undefined ||
+          removePlugins !== undefined ||
+          withoutDefaults;
+
+        // Resolve final per-category overrides using the SDK helper
+        const merged = computeMergedDefaults(root, result.artifacts, skipSubagentMerge);
+        const selectedSkills = resolveCategoryOverride(
+          undefined,
+          merged.skillIds,
+          addSkills,
+          removeSkills,
+          withoutDefaults
+        );
+        const selectedMcpServers = resolveCategoryOverride(
+          undefined,
+          merged.mcpServerIds,
+          addMcpServers,
+          removeMcpServers,
+          withoutDefaults
+        );
+        const selectedHooks = resolveCategoryOverride(
+          undefined,
+          merged.hookIds,
+          addHooks,
+          removeHooks,
+          withoutDefaults
+        );
+        const selectedPlugins = resolveCategoryOverride(
+          undefined,
+          merged.pluginIds,
+          addPlugins,
+          removePlugins,
+          withoutDefaults
+        );
 
         // Dry run
         if (options.dryRun) {
@@ -138,6 +203,11 @@ export function startCommand(): Command {
 
         const isTTY = process.stdout.isTTY && process.stdin.isTTY;
 
+        let tuiSkills = selectedSkills;
+        let tuiMcpServers = selectedMcpServers;
+        let tuiHooks = selectedHooks;
+        let tuiPlugins = selectedPlugins;
+
         if (isTTY && !options.skipConfirmation && !hasArtifactFlags) {
           const tuiResult = await runInteractiveSelector(
             result.artifacts,
@@ -151,10 +221,10 @@ export function startCommand(): Command {
             process.exit(0);
           }
 
-          selectedSkills = tuiResult.skills;
-          selectedMcpServers = tuiResult.mcpServers;
-          selectedHooks = tuiResult.hooks;
-          selectedPlugins = tuiResult.plugins;
+          tuiSkills = tuiResult.skills;
+          tuiMcpServers = tuiResult.mcpServers;
+          tuiHooks = tuiResult.hooks;
+          tuiPlugins = tuiResult.plugins;
         }
 
         // Prepare session (write .mcp.json, inject skills, etc.)
@@ -164,10 +234,10 @@ export function startCommand(): Command {
             root: rootId,
             target: process.cwd(),
             adapter: agent,
-            skills: selectedSkills,
-            mcpServers: selectedMcpServers,
-            hooks: selectedHooks,
-            plugins: selectedPlugins,
+            skills: tuiSkills,
+            mcpServers: tuiMcpServers,
+            hooks: tuiHooks,
+            plugins: tuiPlugins,
             skipSubagentMerge,
           });
         } catch (err) {
@@ -222,15 +292,7 @@ function printDryRun(
     console.log(`Root: ${root.display_name || root.description}`);
   }
 
-  // Compute merged defaults from subagent roots (unless merge is disabled)
-  const merged = skipSubagentMerge
-    ? {
-        mcpServerIds: root?.default_mcp_servers ?? [],
-        skillIds: root?.default_skills ?? [],
-        hookIds: root?.default_hooks ?? [],
-        pluginIds: root?.default_plugins ?? [],
-      }
-    : getMergedDefaults(root, artifacts.roots);
+  const merged = computeMergedDefaults(root, artifacts, skipSubagentMerge);
 
   // CLI overrides take precedence over merged defaults for each category
   const mcpIds = overrides.mcpServers ?? (merged.mcpServerIds.length > 0 ? merged.mcpServerIds : (root?.default_mcp_servers || Object.keys(artifacts.mcp)));

--- a/packages/cli/tests/prepare-command.test.ts
+++ b/packages/cli/tests/prepare-command.test.ts
@@ -213,7 +213,7 @@ describe("prepare command", () => {
     expect(mcpJson.mcpServers.slack).toBeUndefined();
   });
 
-  it("supports --skills override", () => {
+  it("--skills adds on top of root defaults (union)", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -247,24 +247,110 @@ describe("prepare command", () => {
 
     const target = createTemp({});
 
-    // Override to only use skill-c (ignoring root defaults)
+    // Add skill-c on top of the root's default skills
     const result = tryRun(
       `prepare claude --config ${join(catalog, "air.json")} --root myroot --skills skill-c --target ${target}`
     );
     expect(result.exitCode).toBe(0);
 
+    // All three skills should now be injected
+    expect(
+      existsSync(join(target, ".claude", "skills", "skill-a", "SKILL.md"))
+    ).toBe(true);
+    expect(
+      existsSync(join(target, ".claude", "skills", "skill-b", "SKILL.md"))
+    ).toBe(true);
     expect(
       existsSync(join(target, ".claude", "skills", "skill-c", "SKILL.md"))
     ).toBe(true);
+  });
+
+  it("--without-skills removes specific skills from root defaults", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        roots: ["./roots.json"],
+      },
+      "skills.json": {
+        "skill-a": { description: "Skill A", path: "skills/skill-a" },
+        "skill-b": { description: "Skill B", path: "skills/skill-b" },
+      },
+      "skills/skill-a/SKILL.md": "# A",
+      "skills/skill-b/SKILL.md": "# B",
+      "roots.json": {
+        myroot: {
+          description: "Test",
+          default_skills: ["skill-a", "skill-b"],
+        },
+      },
+    });
+
+    const target = createTemp({});
+
+    const result = tryRun(
+      `prepare claude --config ${join(catalog, "air.json")} --root myroot --without-skills skill-a --target ${target}`
+    );
+    expect(result.exitCode).toBe(0);
+
+    // skill-a removed, skill-b kept
     expect(
       existsSync(join(target, ".claude", "skills", "skill-a"))
     ).toBe(false);
     expect(
-      existsSync(join(target, ".claude", "skills", "skill-b"))
-    ).toBe(false);
+      existsSync(join(target, ".claude", "skills", "skill-b", "SKILL.md"))
+    ).toBe(true);
   });
 
-  it("supports --mcp-servers override", () => {
+  it("--without-defaults drops all root defaults and only activates additions", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        mcp: ["./mcp.json"],
+        roots: ["./roots.json"],
+      },
+      "skills.json": {
+        "skill-a": { description: "Skill A", path: "skills/skill-a" },
+        "skill-b": { description: "Skill B", path: "skills/skill-b" },
+      },
+      "skills/skill-a/SKILL.md": "# A",
+      "skills/skill-b/SKILL.md": "# B",
+      "mcp.json": {
+        github: { type: "stdio", command: "npx", args: ["gh"] },
+      },
+      "roots.json": {
+        myroot: {
+          description: "Test",
+          default_skills: ["skill-a"],
+          default_mcp_servers: ["github"],
+        },
+      },
+    });
+
+    const target = createTemp({});
+
+    const result = tryRun(
+      `prepare claude --config ${join(catalog, "air.json")} --root myroot --without-defaults --skills skill-b --target ${target}`
+    );
+    expect(result.exitCode).toBe(0);
+
+    // Only skill-b activated
+    expect(
+      existsSync(join(target, ".claude", "skills", "skill-a"))
+    ).toBe(false);
+    expect(
+      existsSync(join(target, ".claude", "skills", "skill-b", "SKILL.md"))
+    ).toBe(true);
+
+    // No MCP servers: root's github default dropped, nothing added
+    const mcpJson = JSON.parse(
+      readFileSync(join(target, ".mcp.json"), "utf-8")
+    );
+    expect(mcpJson.mcpServers ?? {}).toEqual({});
+  });
+
+  it("--mcp-servers adds on top of root defaults (union)", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -285,7 +371,7 @@ describe("prepare command", () => {
 
     const target = createTemp({});
 
-    // Override to only use slack (ignoring root's default of github)
+    // Add slack alongside the root's github default
     const result = tryRun(
       `prepare claude --config ${join(catalog, "air.json")} --root myroot --mcp-servers slack --target ${target}`
     );
@@ -294,8 +380,8 @@ describe("prepare command", () => {
     const mcpJson = JSON.parse(
       readFileSync(join(target, ".mcp.json"), "utf-8")
     );
+    expect(mcpJson.mcpServers.github).toBeDefined();
     expect(mcpJson.mcpServers.slack).toBeDefined();
-    expect(mcpJson.mcpServers.github).toBeUndefined();
   });
 
   it("injects skill references", () => {

--- a/packages/cli/tests/start-command.test.ts
+++ b/packages/cli/tests/start-command.test.ts
@@ -190,6 +190,59 @@ describe("start command — CLI artifact selection flags", () => {
     expect(result.stdout).toContain("github");
   });
 
+  it("treats an empty --skills value as explicit deselect (no skills)", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        roots: ["./roots.json"],
+      },
+      "skills.json": {
+        "skill-a": { description: "Skill A", path: "skills/skill-a" },
+      },
+      "skills/skill-a/SKILL.md": "# A",
+      "roots.json": {
+        myroot: { description: "Test", default_skills: ["skill-a"] },
+      },
+    });
+
+    const result = tryRun(
+      `start claude --root myroot --dry-run --skills ""`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    // Empty flag means no skills; root default skill-a should not appear
+    expect(result.stdout).toContain("Skills (0)");
+    expect(result.stdout).not.toContain("skill-a");
+  });
+
+  it("treats a comma-only --skills value as explicit deselect", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        roots: ["./roots.json"],
+      },
+      "skills.json": {
+        "skill-a": { description: "Skill A", path: "skills/skill-a" },
+      },
+      "skills/skill-a/SKILL.md": "# A",
+      "roots.json": {
+        myroot: { description: "Test", default_skills: ["skill-a"] },
+      },
+    });
+
+    const result = tryRun(
+      `start claude --root myroot --dry-run --skills ",, ,"`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Skills (0)");
+    expect(result.stdout).not.toContain("skill-a");
+  });
+
   it("supports --hooks and --plugins overrides", () => {
     const catalog = createTemp({
       "air.json": {

--- a/packages/cli/tests/start-command.test.ts
+++ b/packages/cli/tests/start-command.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { execSync } from "child_process";
+import { resolve } from "path";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+
+const CLI = resolve(__dirname, "../src/index.ts");
+
+const tryRun = (args: string, env?: Record<string, string>) => {
+  try {
+    const stdout = execSync(`npx tsx ${CLI} ${args}`, {
+      encoding: "utf-8",
+      cwd: resolve(__dirname, "../../.."),
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, ...env },
+    });
+    return { stdout, stderr: "", exitCode: 0 };
+  } catch (err: any) {
+    return {
+      stdout: err.stdout?.toString() || "",
+      stderr: err.stderr?.toString() || "",
+      exitCode: err.status ?? 1,
+    };
+  }
+};
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    if (existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  tempDirs.length = 0;
+});
+
+function createTemp(files: Record<string, unknown>): string {
+  const dir = resolve(
+    tmpdir(),
+    `air-start-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  tempDirs.push(dir);
+  for (const [name, content] of Object.entries(files)) {
+    const path = resolve(dir, name);
+    mkdirSync(resolve(path, ".."), { recursive: true });
+    writeFileSync(
+      path,
+      typeof content === "string" ? content : JSON.stringify(content, null, 2)
+    );
+  }
+  return dir;
+}
+
+// These tests use --dry-run so we don't actually spawn the agent. Dry run
+// respects the CLI artifact flags, which is what we want to verify.
+describe("start command — CLI artifact selection flags", () => {
+  it("--skills overrides root defaults in dry-run output", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        roots: ["./roots.json"],
+      },
+      "skills.json": {
+        "skill-a": { description: "Skill A", path: "skills/skill-a" },
+        "skill-b": { description: "Skill B", path: "skills/skill-b" },
+        "skill-c": { description: "Skill C", path: "skills/skill-c" },
+      },
+      "skills/skill-a/SKILL.md": "# A",
+      "skills/skill-b/SKILL.md": "# B",
+      "skills/skill-c/SKILL.md": "# C",
+      "roots.json": {
+        myroot: {
+          description: "Test root",
+          default_skills: ["skill-a", "skill-b"],
+        },
+      },
+    });
+
+    const result = tryRun(
+      `start claude --root myroot --dry-run --skills skill-c`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("skill-c");
+    // Root defaults should NOT appear because --skills overrode them
+    expect(result.stdout).not.toContain("skill-a");
+    expect(result.stdout).not.toContain("skill-b");
+  });
+
+  it("--mcp-servers overrides root defaults in dry-run output", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        mcp: ["./mcp.json"],
+        roots: ["./roots.json"],
+      },
+      "mcp.json": {
+        github: { type: "stdio", command: "npx", args: ["gh"] },
+        slack: { type: "stdio", command: "npx", args: ["slack"] },
+        postgres: { type: "stdio", command: "npx", args: ["pg"] },
+      },
+      "roots.json": {
+        myroot: {
+          description: "Test root",
+          default_mcp_servers: ["github"],
+        },
+      },
+    });
+
+    const result = tryRun(
+      `start claude --root myroot --dry-run --mcp-servers slack,postgres`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("slack");
+    expect(result.stdout).toContain("postgres");
+    // github from root default should be omitted
+    expect(result.stdout).not.toMatch(/\bgithub\b/);
+  });
+
+  it("parses comma-separated list with surrounding whitespace", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        roots: ["./roots.json"],
+      },
+      "skills.json": {
+        "skill-a": { description: "Skill A", path: "skills/skill-a" },
+        "skill-b": { description: "Skill B", path: "skills/skill-b" },
+      },
+      "skills/skill-a/SKILL.md": "# A",
+      "skills/skill-b/SKILL.md": "# B",
+      "roots.json": {
+        myroot: { description: "Test", default_skills: [] },
+      },
+    });
+
+    const result = tryRun(
+      `start claude --root myroot --dry-run --skills "skill-a , skill-b"`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("skill-a");
+    expect(result.stdout).toContain("skill-b");
+  });
+
+  it("unspecified categories fall back to root defaults when --skills is passed", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        mcp: ["./mcp.json"],
+        roots: ["./roots.json"],
+      },
+      "skills.json": {
+        "skill-a": { description: "Skill A", path: "skills/skill-a" },
+        "skill-b": { description: "Skill B", path: "skills/skill-b" },
+      },
+      "skills/skill-a/SKILL.md": "# A",
+      "skills/skill-b/SKILL.md": "# B",
+      "mcp.json": {
+        github: { type: "stdio", command: "npx", args: ["gh"] },
+      },
+      "roots.json": {
+        myroot: {
+          description: "Test",
+          default_skills: ["skill-a"],
+          default_mcp_servers: ["github"],
+        },
+      },
+    });
+
+    const result = tryRun(
+      `start claude --root myroot --dry-run --skills skill-b`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    // Skill override applied
+    expect(result.stdout).toContain("skill-b");
+    expect(result.stdout).not.toContain("skill-a");
+    // MCP server falls back to root default
+    expect(result.stdout).toContain("github");
+  });
+
+  it("supports --hooks and --plugins overrides", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        hooks: ["./hooks.json"],
+        plugins: ["./plugins.json"],
+        roots: ["./roots.json"],
+      },
+      "hooks.json": {
+        "hook-a": {
+          description: "Hook A",
+          path: "hooks/hook-a",
+        },
+        "hook-b": {
+          description: "Hook B",
+          path: "hooks/hook-b",
+        },
+      },
+      "hooks/hook-a/HOOK.json": {
+        events: [
+          { event: "PreToolUse", matcher: ".*", command: "echo a" },
+        ],
+      },
+      "hooks/hook-b/HOOK.json": {
+        events: [
+          { event: "PreToolUse", matcher: ".*", command: "echo b" },
+        ],
+      },
+      "plugins.json": {
+        "plugin-a": {
+          description: "Plugin A",
+          version: "1.0.0",
+          author: { name: "Test" },
+        },
+        "plugin-b": {
+          description: "Plugin B",
+          version: "1.0.0",
+          author: { name: "Test" },
+        },
+      },
+      "roots.json": {
+        myroot: {
+          description: "Test",
+          default_hooks: ["hook-a"],
+          default_plugins: ["plugin-a"],
+        },
+      },
+    });
+
+    const result = tryRun(
+      `start claude --root myroot --dry-run --hooks hook-b --plugins plugin-b`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("hook-b");
+    expect(result.stdout).toContain("plugin-b");
+    expect(result.stdout).not.toContain("hook-a");
+    expect(result.stdout).not.toContain("plugin-a");
+  });
+});

--- a/packages/cli/tests/start-command.test.ts
+++ b/packages/cli/tests/start-command.test.ts
@@ -371,6 +371,39 @@ describe("start command — CLI artifact selection flags", () => {
     expect(result.stdout).toContain("plugin-b");
   });
 
+  it("when an ID appears in both --skills and --without-skills, the removal wins", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        roots: ["./roots.json"],
+      },
+      "skills.json": {
+        "skill-a": { description: "Skill A", path: "skills/skill-a" },
+        "skill-b": { description: "Skill B", path: "skills/skill-b" },
+      },
+      "skills/skill-a/SKILL.md": "# A",
+      "skills/skill-b/SKILL.md": "# B",
+      "roots.json": {
+        myroot: {
+          description: "Test",
+          default_skills: [],
+        },
+      },
+    });
+
+    const result = tryRun(
+      `start claude --root myroot --dry-run --skills skill-a,skill-b --without-skills skill-a`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    // skill-a was added then removed — final selection is just skill-b
+    expect(result.stdout).toContain("Skills (1)");
+    expect(result.stdout).toContain("skill-b");
+    expect(result.stdout).not.toMatch(/\u2022 skill-a\b/);
+  });
+
   it("combining --skills and --without-skills within the same category works", () => {
     const catalog = createTemp({
       "air.json": {

--- a/packages/cli/tests/start-command.test.ts
+++ b/packages/cli/tests/start-command.test.ts
@@ -56,7 +56,7 @@ function createTemp(files: Record<string, unknown>): string {
 // These tests use --dry-run so we don't actually spawn the agent. Dry run
 // respects the CLI artifact flags, which is what we want to verify.
 describe("start command — CLI artifact selection flags", () => {
-  it("--skills overrides root defaults in dry-run output", () => {
+  it("--skills adds on top of root defaults (union)", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -85,45 +85,86 @@ describe("start command — CLI artifact selection flags", () => {
     );
 
     expect(result.exitCode).toBe(0);
+    // All three: defaults (a, b) + added (c)
+    expect(result.stdout).toContain("skill-a");
+    expect(result.stdout).toContain("skill-b");
     expect(result.stdout).toContain("skill-c");
-    // Root defaults should NOT appear because --skills overrode them
-    expect(result.stdout).not.toContain("skill-a");
-    expect(result.stdout).not.toContain("skill-b");
+    expect(result.stdout).toContain("Skills (3)");
   });
 
-  it("--mcp-servers overrides root defaults in dry-run output", () => {
+  it("--without-skills removes specific skills from root defaults", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
-        mcp: ["./mcp.json"],
+        skills: ["./skills.json"],
         roots: ["./roots.json"],
       },
-      "mcp.json": {
-        github: { type: "stdio", command: "npx", args: ["gh"] },
-        slack: { type: "stdio", command: "npx", args: ["slack"] },
-        postgres: { type: "stdio", command: "npx", args: ["pg"] },
+      "skills.json": {
+        "skill-a": { description: "Skill A", path: "skills/skill-a" },
+        "skill-b": { description: "Skill B", path: "skills/skill-b" },
+        "skill-c": { description: "Skill C", path: "skills/skill-c" },
       },
+      "skills/skill-a/SKILL.md": "# A",
+      "skills/skill-b/SKILL.md": "# B",
+      "skills/skill-c/SKILL.md": "# C",
       "roots.json": {
         myroot: {
           description: "Test root",
+          default_skills: ["skill-a", "skill-b", "skill-c"],
+        },
+      },
+    });
+
+    const result = tryRun(
+      `start claude --root myroot --dry-run --without-skills skill-b`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("skill-a");
+    expect(result.stdout).toContain("skill-c");
+    expect(result.stdout).toContain("Skills (2)");
+    // skill-b removed — verify it does not appear as a selected skill bullet
+    expect(result.stdout).not.toMatch(/\u2022 skill-b\b/);
+  });
+
+  it("--without-defaults drops all root defaults", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        mcp: ["./mcp.json"],
+        roots: ["./roots.json"],
+      },
+      "skills.json": {
+        "skill-a": { description: "Skill A", path: "skills/skill-a" },
+      },
+      "skills/skill-a/SKILL.md": "# A",
+      "mcp.json": {
+        github: { type: "stdio", command: "npx", args: ["gh"] },
+      },
+      "roots.json": {
+        myroot: {
+          description: "Test",
+          default_skills: ["skill-a"],
           default_mcp_servers: ["github"],
         },
       },
     });
 
     const result = tryRun(
-      `start claude --root myroot --dry-run --mcp-servers slack,postgres`,
+      `start claude --root myroot --dry-run --without-defaults`,
       { AIR_CONFIG: resolve(catalog, "air.json") }
     );
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("slack");
-    expect(result.stdout).toContain("postgres");
-    // github from root default should be omitted
-    expect(result.stdout).not.toMatch(/\bgithub\b/);
+    expect(result.stdout).toContain("Skills (0)");
+    expect(result.stdout).toContain("MCP Servers (0)");
+    expect(result.stdout).not.toMatch(/\u2022 skill-a\b/);
+    expect(result.stdout).not.toMatch(/\u2022 github\b/);
   });
 
-  it("parses comma-separated list with surrounding whitespace", () => {
+  it("--without-defaults combined with --skills activates only the added skill", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -137,21 +178,25 @@ describe("start command — CLI artifact selection flags", () => {
       "skills/skill-a/SKILL.md": "# A",
       "skills/skill-b/SKILL.md": "# B",
       "roots.json": {
-        myroot: { description: "Test", default_skills: [] },
+        myroot: {
+          description: "Test",
+          default_skills: ["skill-a"],
+        },
       },
     });
 
     const result = tryRun(
-      `start claude --root myroot --dry-run --skills "skill-a , skill-b"`,
+      `start claude --root myroot --dry-run --without-defaults --skills skill-b`,
       { AIR_CONFIG: resolve(catalog, "air.json") }
     );
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("skill-a");
+    expect(result.stdout).toContain("Skills (1)");
     expect(result.stdout).toContain("skill-b");
+    expect(result.stdout).not.toMatch(/\u2022 skill-a\b/);
   });
 
-  it("unspecified categories fall back to root defaults when --skills is passed", () => {
+  it("unspecified categories are unaffected by flags for other categories", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -183,14 +228,15 @@ describe("start command — CLI artifact selection flags", () => {
     );
 
     expect(result.exitCode).toBe(0);
-    // Skill override applied
+    // Skills: default skill-a plus added skill-b
+    expect(result.stdout).toContain("Skills (2)");
+    expect(result.stdout).toContain("skill-a");
     expect(result.stdout).toContain("skill-b");
-    expect(result.stdout).not.toContain("skill-a");
-    // MCP server falls back to root default
+    // MCP untouched: still uses root default
     expect(result.stdout).toContain("github");
   });
 
-  it("treats an empty --skills value as explicit deselect (no skills)", () => {
+  it("parses comma-separated list with surrounding whitespace", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -199,51 +245,68 @@ describe("start command — CLI artifact selection flags", () => {
       },
       "skills.json": {
         "skill-a": { description: "Skill A", path: "skills/skill-a" },
+        "skill-b": { description: "Skill B", path: "skills/skill-b" },
       },
       "skills/skill-a/SKILL.md": "# A",
+      "skills/skill-b/SKILL.md": "# B",
       "roots.json": {
-        myroot: { description: "Test", default_skills: ["skill-a"] },
+        myroot: { description: "Test", default_skills: [] },
       },
     });
 
     const result = tryRun(
-      `start claude --root myroot --dry-run --skills ""`,
+      `start claude --root myroot --dry-run --skills "skill-a , skill-b"`,
       { AIR_CONFIG: resolve(catalog, "air.json") }
     );
 
     expect(result.exitCode).toBe(0);
-    // Empty flag means no skills; root default skill-a should not appear
-    expect(result.stdout).toContain("Skills (0)");
-    expect(result.stdout).not.toContain("skill-a");
+    expect(result.stdout).toContain("skill-a");
+    expect(result.stdout).toContain("skill-b");
+    expect(result.stdout).toContain("Skills (2)");
   });
 
-  it("treats a comma-only --skills value as explicit deselect", () => {
+  it("supports --without-skills and --without-mcp-servers together", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
         skills: ["./skills.json"],
+        mcp: ["./mcp.json"],
         roots: ["./roots.json"],
       },
       "skills.json": {
         "skill-a": { description: "Skill A", path: "skills/skill-a" },
+        "skill-b": { description: "Skill B", path: "skills/skill-b" },
       },
       "skills/skill-a/SKILL.md": "# A",
+      "skills/skill-b/SKILL.md": "# B",
+      "mcp.json": {
+        github: { type: "stdio", command: "npx", args: ["gh"] },
+        slack: { type: "stdio", command: "npx", args: ["slack"] },
+      },
       "roots.json": {
-        myroot: { description: "Test", default_skills: ["skill-a"] },
+        myroot: {
+          description: "Test",
+          default_skills: ["skill-a", "skill-b"],
+          default_mcp_servers: ["github", "slack"],
+        },
       },
     });
 
     const result = tryRun(
-      `start claude --root myroot --dry-run --skills ",, ,"`,
+      `start claude --root myroot --dry-run --without-skills skill-a --without-mcp-servers slack`,
       { AIR_CONFIG: resolve(catalog, "air.json") }
     );
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Skills (0)");
-    expect(result.stdout).not.toContain("skill-a");
+    expect(result.stdout).toContain("Skills (1)");
+    expect(result.stdout).toContain("skill-b");
+    expect(result.stdout).not.toMatch(/\u2022 skill-a\b/);
+    expect(result.stdout).toContain("MCP Servers (1)");
+    expect(result.stdout).toContain("github");
+    expect(result.stdout).not.toMatch(/\u2022 slack\b/);
   });
 
-  it("supports --hooks and --plugins overrides", () => {
+  it("supports --hooks and --plugins adds", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -298,9 +361,49 @@ describe("start command — CLI artifact selection flags", () => {
     );
 
     expect(result.exitCode).toBe(0);
+    // Hooks: default + added
+    expect(result.stdout).toContain("Hooks (2)");
+    expect(result.stdout).toContain("hook-a");
     expect(result.stdout).toContain("hook-b");
+    // Plugins: default + added
+    expect(result.stdout).toContain("Plugins (2)");
+    expect(result.stdout).toContain("plugin-a");
     expect(result.stdout).toContain("plugin-b");
-    expect(result.stdout).not.toContain("hook-a");
-    expect(result.stdout).not.toContain("plugin-a");
+  });
+
+  it("combining --skills and --without-skills within the same category works", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        roots: ["./roots.json"],
+      },
+      "skills.json": {
+        "skill-a": { description: "Skill A", path: "skills/skill-a" },
+        "skill-b": { description: "Skill B", path: "skills/skill-b" },
+        "skill-c": { description: "Skill C", path: "skills/skill-c" },
+      },
+      "skills/skill-a/SKILL.md": "# A",
+      "skills/skill-b/SKILL.md": "# B",
+      "skills/skill-c/SKILL.md": "# C",
+      "roots.json": {
+        myroot: {
+          description: "Test",
+          default_skills: ["skill-a", "skill-b"],
+        },
+      },
+    });
+
+    const result = tryRun(
+      `start claude --root myroot --dry-run --skills skill-c --without-skills skill-a`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    // Final: default skill-b + added skill-c; skill-a removed
+    expect(result.stdout).toContain("Skills (2)");
+    expect(result.stdout).toContain("skill-b");
+    expect(result.stdout).toContain("skill-c");
+    expect(result.stdout).not.toMatch(/\u2022 skill-a\b/);
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.29"
+    "@pulsemcp/air-core": "0.0.30"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.29"
+    "@pulsemcp/air-core": "0.0.30"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.29"
+    "@pulsemcp/air-core": "0.0.30"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.29"
+    "@pulsemcp/air-core": "0.0.30"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.29"
+    "@pulsemcp/air-core": "0.0.30"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.29"
+    "@pulsemcp/air-core": "0.0.30"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -92,10 +92,15 @@ export type { ArtifactType, ListArtifactsOptions, ListArtifactsResult } from "./
 export { startSession } from "./start.js";
 export type { StartSessionOptions, StartSessionResult } from "./start.js";
 
-export { prepareSession } from "./prepare.js";
+export {
+  prepareSession,
+  computeMergedDefaults,
+  resolveCategoryOverride,
+} from "./prepare.js";
 export type {
   PrepareSessionOptions,
   PrepareSessionResult,
+  MergedArtifactDefaults,
 } from "./prepare.js";
 
 export { exportMarketplace } from "./export-marketplace.js";

--- a/packages/sdk/src/prepare.ts
+++ b/packages/sdk/src/prepare.ts
@@ -3,6 +3,7 @@ import {
   loadAirConfig,
   getAirJsonPath,
   resolveArtifacts,
+  type ResolvedArtifacts,
   type RootEntry,
   type PreparedSession,
   type McpConfig,
@@ -36,6 +37,28 @@ export interface PrepareSessionOptions {
   hooks?: string[];
   /** Plugin IDs to activate (overrides root defaults). */
   plugins?: string[];
+  /** Skill IDs to add on top of (merged) root defaults. */
+  addSkills?: string[];
+  /** MCP server IDs to add on top of (merged) root defaults. */
+  addMcpServers?: string[];
+  /** Hook IDs to add on top of (merged) root defaults. */
+  addHooks?: string[];
+  /** Plugin IDs to add on top of (merged) root defaults. */
+  addPlugins?: string[];
+  /** Skill IDs to remove from (merged) root defaults. */
+  removeSkills?: string[];
+  /** MCP server IDs to remove from (merged) root defaults. */
+  removeMcpServers?: string[];
+  /** Hook IDs to remove from (merged) root defaults. */
+  removeHooks?: string[];
+  /** Plugin IDs to remove from (merged) root defaults. */
+  removePlugins?: string[];
+  /**
+   * Start from an empty set instead of root defaults when computing additions
+   * and removals. Use to opt out of all root-declared defaults (including
+   * subagent-root unions) and activate only the artifacts explicitly added.
+   */
+  withoutDefaults?: boolean;
   /**
    * Skip merging subagent roots' artifacts into the parent session.
    * Orchestrators that manage subagent composition externally should set this.
@@ -151,16 +174,50 @@ export async function prepareSession(
     }
   }
 
+  // Compute per-category overrides. Explicit `skills`/`mcpServers`/`hooks`/
+  // `plugins` values are final (from TUI/orchestrator selection). Otherwise,
+  // any `add*`/`remove*`/`withoutDefaults` intent is applied on top of the
+  // union of parent-root and subagent-root defaults.
+  const merged = computeMergedDefaults(root, artifacts, options.skipSubagentMerge);
+  const skillOverrides = resolveCategoryOverride(
+    options.skills,
+    merged.skillIds,
+    options.addSkills,
+    options.removeSkills,
+    options.withoutDefaults
+  );
+  const mcpServerOverrides = resolveCategoryOverride(
+    options.mcpServers,
+    merged.mcpServerIds,
+    options.addMcpServers,
+    options.removeMcpServers,
+    options.withoutDefaults
+  );
+  const hookOverrides = resolveCategoryOverride(
+    options.hooks,
+    merged.hookIds,
+    options.addHooks,
+    options.removeHooks,
+    options.withoutDefaults
+  );
+  const pluginOverrides = resolveCategoryOverride(
+    options.plugins,
+    merged.pluginIds,
+    options.addPlugins,
+    options.removePlugins,
+    options.withoutDefaults
+  );
+
   // Adapter writes .mcp.json and injects skills (no secret resolution)
   const session = await adapter.prepareSession(
     artifacts,
     options.target ?? process.cwd(),
     {
       root,
-      skillOverrides: options.skills,
-      mcpServerOverrides: options.mcpServers,
-      hookOverrides: options.hooks,
-      pluginOverrides: options.plugins,
+      skillOverrides,
+      mcpServerOverrides,
+      hookOverrides,
+      pluginOverrides,
       skipSubagentMerge: options.skipSubagentMerge,
     }
   );
@@ -206,4 +263,76 @@ export async function prepareSession(
     rootAutoDetected,
     warnings: warnings.length > 0 ? warnings : undefined,
   };
+}
+
+/**
+ * Merged default IDs across parent root and its subagent roots.
+ */
+export interface MergedArtifactDefaults {
+  mcpServerIds: string[];
+  skillIds: string[];
+  hookIds: string[];
+  pluginIds: string[];
+}
+
+/**
+ * Compute the union of parent root and subagent roots' defaults for each
+ * artifact category. Subagent merging can be disabled via `skipSubagentMerge`,
+ * in which case only the parent root's defaults are returned.
+ */
+export function computeMergedDefaults(
+  root: RootEntry | undefined,
+  artifacts: ResolvedArtifacts,
+  skipSubagentMerge = false
+): MergedArtifactDefaults {
+  const mcpSet = new Set(root?.default_mcp_servers ?? []);
+  const skillSet = new Set(root?.default_skills ?? []);
+  const hookSet = new Set(root?.default_hooks ?? []);
+  const pluginSet = new Set(root?.default_plugins ?? []);
+
+  if (!skipSubagentMerge) {
+    for (const subId of root?.default_subagent_roots ?? []) {
+      const sub = artifacts.roots[subId];
+      if (!sub) continue;
+      for (const id of sub.default_mcp_servers ?? []) mcpSet.add(id);
+      for (const id of sub.default_skills ?? []) skillSet.add(id);
+      for (const id of sub.default_hooks ?? []) hookSet.add(id);
+      for (const id of sub.default_plugins ?? []) pluginSet.add(id);
+    }
+  }
+
+  return {
+    mcpServerIds: [...mcpSet],
+    skillIds: [...skillSet],
+    hookIds: [...hookSet],
+    pluginIds: [...pluginSet],
+  };
+}
+
+/**
+ * Resolve the final override for a single artifact category.
+ *
+ * - If an explicit override is provided (e.g. from a TUI selection), it wins.
+ * - Otherwise, if any add/remove/withoutDefaults intent is present, the
+ *   merged defaults are the base, additions are unioned in, removals are
+ *   subtracted, and `withoutDefaults` starts from an empty base.
+ * - If no intent is expressed, returns `undefined` — the adapter uses its
+ *   own default resolution.
+ */
+export function resolveCategoryOverride(
+  explicitOverride: string[] | undefined,
+  mergedDefaults: string[],
+  add: string[] | undefined,
+  remove: string[] | undefined,
+  withoutDefaults: boolean | undefined
+): string[] | undefined {
+  if (explicitOverride !== undefined) return explicitOverride;
+  const hasIntent =
+    add !== undefined || remove !== undefined || (withoutDefaults ?? false);
+  if (!hasIntent) return undefined;
+  const base = withoutDefaults ? [] : mergedDefaults;
+  const set = new Set(base);
+  for (const id of add ?? []) set.add(id);
+  for (const id of remove ?? []) set.delete(id);
+  return [...set];
 }


### PR DESCRIPTION
## Summary

Adds non-interactive CLI flags to `air start` and `air prepare` for tweaking which artifacts a session activates without the TUI.

- `--skills <ids>` / `--mcp-servers <ids>` / `--hooks <ids>` / `--plugins <ids>` — **add** IDs on top of root defaults (union)
- `--without-skills <ids>` / `--without-mcp-servers <ids>` / `--without-hooks <ids>` / `--without-plugins <ids>` — remove IDs from root defaults
- `--without-defaults` — start from an empty set (only activate IDs explicitly added via the flags above)

For `air start`, any of these flags suppresses the interactive TUI. `--dry-run` honors the flags so scripted invocations can be previewed.

### Breaking change

`air prepare --skills <ids>` (and `--mcp-servers` / `--hooks` / `--plugins`) no longer *replaces* root defaults — it **adds** to them, matching the new `air start` behavior. To restore the previous override semantics, combine with `--without-defaults`:

```bash
# Previous behavior (override)
air prepare claude --skills a,b

# Same behavior now
air prepare claude --without-defaults --skills a,b
```

Programmatic SDK consumers calling `prepareSession({ skills: [...] })` are unaffected — the `skills` / `mcpServers` / `hooks` / `plugins` options on `PrepareSessionOptions` keep their original override meaning. The CLI flags route through new `addSkills` / `removeSkills` / `withoutDefaults` fields instead.

### Examples

```bash
# Add an extra skill and MCP server on top of web-app's root defaults
air start claude --root web-app --skills deploy-staging --mcp-servers postgres-prod

# Drop a specific hook from the defaults
air start claude --root web-app --without-hooks prevent-secrets-in-context

# Start with only what you list — no root defaults
air start claude --root web-app --without-defaults --skills pr-review --mcp-servers github
```

### What's in the SDK

New exports from `@pulsemcp/air-sdk`:
- `computeMergedDefaults(root, artifacts, skipSubagentMerge?)` — union of parent root and subagent-root defaults per category
- `resolveCategoryOverride(explicit, defaults, add, remove, withoutDefaults)` — reusable per-category resolver. Explicit override wins; otherwise `base = withoutDefaults ? [] : merged`, then `add` is unioned in and `remove` is subtracted.
- `MergedArtifactDefaults` type
- New fields on `PrepareSessionOptions`: `addSkills` / `addMcpServers` / `addHooks` / `addPlugins`, `removeSkills` / `removeMcpServers` / `removeHooks` / `removePlugins`, `withoutDefaults`

## Verification

- [x] CI green — all 5 checks (test 18/20/22, e2e, validate-schemas) pass on the latest commit (`21658b1`)
- [x] 10 tests in `packages/cli/tests/start-command.test.ts` cover: add-on-top, remove specific IDs, `--without-defaults` drops everything, `--without-defaults` combined with `--skills`, unspecified-category passthrough, CSV whitespace trimming, combined without-skills + without-mcp-servers, hooks/plugins add, `--skills` + `--without-skills` (different IDs), and the same-ID case where removal wins over addition
- [x] 4 updated tests in `packages/cli/tests/prepare-command.test.ts` cover the add-on-top semantics for `air prepare --skills` / `--mcp-servers`, `--without-skills`, and `--without-defaults --skills`
- [x] No regression: full test suite (537 tests across 31 files) passes locally and in CI
- [x] Fresh-eyes subagent PR review done — verdict was "Minor nits — LGTM, no blocking issues." The one actionable nit (missing test for the same-ID remove-wins case) was addressed in commit `21658b1`
- [x] Docs updated (`docs/guides/running-sessions.md`) with the new flag descriptions, three shell examples (add / remove / without-defaults), and the tweak to the dry-run example
- [x] CHANGELOG explicitly calls out the `air prepare` breaking change with migration guidance
- [x] Proof the change works (live CLI invocation):

```
$ AIR_CONFIG=/tmp/air-semver-debug/air.json air start claude --root web-app --dry-run --without-hooks prevent-secrets-in-context

=== AIR Session Configuration ===
Agent: claude
Root: Test root

MCP Servers (1):
  • github — GitHub

Skills (2):
  • skill-a — Skill A
  • skill-b — Skill B

Hooks (1):
  • format-on-save — Format on save
```

Confirms `--without-hooks prevent-secrets-in-context` removes the hook from the root's `default_hooks: [prevent-secrets-in-context, format-on-save]` while leaving other categories untouched. Verified similarly for add, `--without-defaults`, and combined cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)