### PR TITLE
docs: clarify ~/.air/air.json as composition surface (v0.0.31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.31] - 2026-04-17
+
+### Changed
+- Documentation: clarify that `~/.air/air.json` is the single composition surface — purely local artifact directories, remote catalogs, and any mix are all first-class shapes. README's Composition & Layering section now shows local-only, local-catalog + remote-catalog, and stacked-remote examples. `docs/guides/composition-and-overrides.md` gains local-only and local-team-catalog layering patterns. `docs/guides/understanding-air-json.md` explicitly frames `air.json` as the composition point.
+- `air init` blank-mode output now explains that each artifact field accepts an array of local and/or remote index paths, includes an inline example, and links to the composition-and-overrides guide.
+
 ## [0.0.30] - 2026-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -106,18 +106,18 @@ Every AIR configuration starts with an `air.json` file. Each artifact property i
 }
 ```
 
-**Local catalog + shared remote catalog.** Your private team skills live in a directory you maintain (checked into your own repo), and you layer an org-wide catalog on top for shared defaults:
+**Local catalog + shared remote catalog.** Your private team skills live in a directory you maintain (e.g., a sibling repo checked into `~/.air/` or an absolute path elsewhere on disk), layered with an org-wide catalog for shared defaults. Local paths resolve relative to `air.json`, so `./platform-team-catalog/...` below points at `~/.air/platform-team-catalog/...`:
 
 ```json
 {
   "name": "platform-team",
   "skills": [
     "github://acme/air-org/skills/skills.json",
-    "~/code/platform-team-catalog/skills/skills.json"
+    "./platform-team-catalog/skills/skills.json"
   ],
   "mcp": [
     "github://acme/air-org/mcp/mcp.json",
-    "~/code/platform-team-catalog/mcp/mcp.json"
+    "./platform-team-catalog/mcp/mcp.json"
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ AIR organizes agent configuration into **artifact types**, each with its own ind
     └── hooks.json                # Lifecycle hooks index
 ```
 
-Orgs and teams provide default `air.json` files as starting points. Users keep their own at `~/.air/air.json`, pointing to a mix of org-provided and local artifact files.
+Your own `air.json` at `~/.air/air.json` is where you assemble whichever artifacts you want — purely local directories you maintain yourself, catalogs your team ships, remote org-wide defaults, or any combination. Orgs and teams can publish ready-made index files as building blocks; nothing is compulsory.
 
 ### air.json — The Root Config
 
-Every AIR configuration starts with an `air.json` file. Each artifact property is an array of paths to index files. Files are loaded and merged in order — later entries override earlier ones by ID:
+Every AIR configuration starts with an `air.json` file. Each artifact property is an array of paths to index files. Paths can be local (relative to `air.json`) or remote URIs like `github://` when a catalog provider is installed. Files are loaded and merged in order — later entries override earlier ones by ID:
 
 ```json
 {
@@ -94,7 +94,35 @@ Every AIR configuration starts with an `air.json` file. Each artifact property i
 
 ### Composition & Layering
 
-Composition is expressed directly in `air.json`. List multiple sources per artifact type — org-wide configs first, then team or project overrides:
+`~/.air/air.json` is the single composition surface — everything active in a session comes from the arrays you list here. Each artifact field accepts **any number of local or remote index paths**, and you mix and match to fit your situation. A few shapes:
+
+**Local-only.** A solo developer or a small team using only their own artifacts:
+
+```json
+{
+  "name": "just-me",
+  "skills": ["./skills/skills.json"],
+  "mcp": ["./mcp/mcp.json"]
+}
+```
+
+**Local catalog + shared remote catalog.** Your private team skills live in a directory you maintain (checked into your own repo), and you layer an org-wide catalog on top for shared defaults:
+
+```json
+{
+  "name": "platform-team",
+  "skills": [
+    "github://acme/air-org/skills/skills.json",
+    "~/code/platform-team-catalog/skills/skills.json"
+  ],
+  "mcp": [
+    "github://acme/air-org/mcp/mcp.json",
+    "~/code/platform-team-catalog/mcp/mcp.json"
+  ]
+}
+```
+
+**Stacked remotes with local overrides.** Org → team → project, with the local file getting the last word:
 
 ```json
 {

--- a/docs/guides/composition-and-overrides.md
+++ b/docs/guides/composition-and-overrides.md
@@ -78,7 +78,7 @@ This is the simplest setup and a fully supported shape — no providers required
 
 ### Local team catalog + shared remote catalog
 
-A common team shape is a private catalog checked into your own repo, composed alongside a shared org-wide catalog. The local paths can live anywhere on disk — they do not need to be under `~/.air/`:
+A common team shape is a private catalog kept as a sibling directory under `~/.air/` (often a git submodule or a checked-out team repo), composed alongside a shared org-wide catalog:
 
 ```json
 {
@@ -86,16 +86,18 @@ A common team shape is a private catalog checked into your own repo, composed al
   "extensions": ["@pulsemcp/air-provider-github"],
   "skills": [
     "github://acme/air-org/skills/skills.json",
-    "~/code/platform-team-catalog/skills/skills.json"
+    "./platform-team-catalog/skills/skills.json"
   ],
   "mcp": [
     "github://acme/air-org/mcp/mcp.json",
-    "~/code/platform-team-catalog/mcp/mcp.json"
+    "./platform-team-catalog/mcp/mcp.json"
   ]
 }
 ```
 
 Here the org catalog provides the baseline and the team's local catalog adds team-specific artifacts (and overrides any org defaults it wants to replace). Swap or add paths at will — each artifact field is just an ordered list of sources.
+
+Local paths are resolved relative to the directory containing `air.json` (so `./platform-team-catalog/...` above points at `~/.air/platform-team-catalog/...`). If your catalog lives elsewhere on disk, use an absolute path like `/opt/team-catalog/skills/skills.json`. **Tildes (`~/`) are not expanded** — either use a relative path or spell out the absolute path.
 
 ### Org → Team → Project
 

--- a/docs/guides/composition-and-overrides.md
+++ b/docs/guides/composition-and-overrides.md
@@ -1,6 +1,8 @@
 # Composition and Overrides
 
-AIR's composition model lets you layer configuration across organizational levels — org-wide defaults, team overrides, and project-local customizations. This guide covers the mechanics and advanced patterns.
+AIR's composition model lets you layer configuration from whatever sources make sense for you — purely local directories, catalogs your team ships, remote org-wide defaults, or any mix. This guide covers the mechanics and advanced patterns.
+
+`~/.air/air.json` is the single composition surface: every active artifact in a session comes from the arrays you list there. Nothing else contributes to a session's config, and you are not required to use remote catalogs — a fully local setup is a supported first-class shape.
 
 ## The override model
 
@@ -59,6 +61,41 @@ The result is the team version **only**. The org's `title` and `description` are
 Full replacement is predictable. You never have to wonder which fields came from which layer. The winning entry is exactly what you see in its file. Deep merge creates ambiguity: if a field is present in the result, did it come from the org layer or the team layer? With full replacement, the answer is always "whichever file defined this ID last."
 
 ## Layering patterns
+
+### Local-only
+
+You don't need a remote source to use layering. A team that maintains its skills in a private directory can point `air.json` straight at local index files:
+
+```json
+{
+  "name": "my-team",
+  "skills": ["./skills/skills.json"],
+  "mcp": ["./mcp/mcp.json"]
+}
+```
+
+This is the simplest setup and a fully supported shape — no providers required, no network calls at resolution time.
+
+### Local team catalog + shared remote catalog
+
+A common team shape is a private catalog checked into your own repo, composed alongside a shared org-wide catalog. The local paths can live anywhere on disk — they do not need to be under `~/.air/`:
+
+```json
+{
+  "name": "platform-team",
+  "extensions": ["@pulsemcp/air-provider-github"],
+  "skills": [
+    "github://acme/air-org/skills/skills.json",
+    "~/code/platform-team-catalog/skills/skills.json"
+  ],
+  "mcp": [
+    "github://acme/air-org/mcp/mcp.json",
+    "~/code/platform-team-catalog/mcp/mcp.json"
+  ]
+}
+```
+
+Here the org catalog provides the baseline and the team's local catalog adds team-specific artifacts (and overrides any org defaults it wants to replace). Swap or add paths at will — each artifact field is just an ordered list of sources.
 
 ### Org → Team → Project
 

--- a/docs/guides/understanding-air-json.md
+++ b/docs/guides/understanding-air-json.md
@@ -2,9 +2,11 @@
 
 `air.json` is the root configuration file for AIR. It ties together all your artifact indexes — skills, MCP servers, references, plugins, roots, and hooks — into a single, composable configuration.
 
+`air.json` is the **composition point** — it is the one file that decides which artifacts are active in a session. Each artifact field is an array of index paths, so a single `air.json` can assemble any combination you want: purely local directories you maintain, catalogs your team ships, remote org-wide defaults, or a mix of all three. There is no other place to point AIR at artifacts.
+
 ## Location
 
-By default, the CLI looks for `air.json` at `~/.air/air.json`. You can override this with:
+By default, the CLI looks for `air.json` at `~/.air/air.json` — this is where most users keep the `air.json` that governs their sessions. You can override this with:
 
 - The `AIR_CONFIG` environment variable
 - The `--config` flag on commands that support it (`prepare`, `install`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1776434722-826c1c4f",
+  "name": "air-main-1776442398-c80b5a97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -847,9 +847,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.30",
+        "@pulsemcp/air-sdk": "0.0.31",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -868,7 +868,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -884,9 +884,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.30"
+        "@pulsemcp/air-core": "0.0.31"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -899,9 +899,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.30"
+        "@pulsemcp/air-core": "0.0.31"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -914,9 +914,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.30"
+        "@pulsemcp/air-core": "0.0.31"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -929,9 +929,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.30"
+        "@pulsemcp/air-core": "0.0.31"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -944,9 +944,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.30"
+        "@pulsemcp/air-core": "0.0.31"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -959,9 +959,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.30"
+        "@pulsemcp/air-core": "0.0.31"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.30",
+    "@pulsemcp/air-sdk": "0.0.31",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -36,7 +36,17 @@ export function initCommand(): Command {
             `Initialized AIR configuration at ${result.airJsonPath}`
           );
           console.log(
-            "\nEdit air.json to configure your setup. Run 'air validate ~/.air/air.json' to check."
+            "\nair.json is the composition point for your sessions — each artifact field" +
+              "\n(skills, mcp, roots, hooks, references, plugins) accepts an ARRAY of index" +
+              "\npaths. Mix local directories and/or remote catalogs; later entries override" +
+              "\nearlier ones by ID. Example:"
+          );
+          console.log(
+            '\n  {\n    "name": "my-config",\n    "skills": [\n      "./skills/skills.json",\n      "github://acme/shared-catalog/skills/skills.json"\n    ]\n  }'
+          );
+          console.log(
+            "\nSee https://github.com/pulsemcp/air/blob/main/docs/guides/composition-and-overrides.md" +
+              "\nValidate with: air validate ~/.air/air.json"
           );
         }
       } catch (err) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.30"
+    "@pulsemcp/air-core": "0.0.31"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.30"
+    "@pulsemcp/air-core": "0.0.31"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.30"
+    "@pulsemcp/air-core": "0.0.31"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.30"
+    "@pulsemcp/air-core": "0.0.31"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.30"
+    "@pulsemcp/air-core": "0.0.31"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.30"
+    "@pulsemcp/air-core": "0.0.31"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary

Reframes AIR documentation so readers can tell from the docs alone that `~/.air/air.json` is the single composition surface — the one place you list whichever artifacts (local, remote, or any mix) you want active in a session.

### Why

In a recent design discussion we discovered that a downstream integration had bypassed the array-of-index-paths composition mechanism entirely (hardcoding specific index file paths instead of reading them from `air.json`). The user's reaction — "I thought the idea was: `~/.air/air.json` should allow you to compose whatever artifacts you want (particularly local ones!)" — suggested the docs may not be making the intent vivid enough.

Audit finding: the composition model **is** documented, but every example in the docs showed either a single-file setup or an "org + team + local override" shape. There was no example of composing purely local catalogs, and no example of a local team-owned directory layered with a remote catalog. The `air init` blank-mode post-message said only `Edit air.json to configure your setup.` — no hint that arrays and layering exist.

### What changed (docs only, plus one CLI-output tweak)

- **`README.md` — Composition & Layering section.** Now leads with "`~/.air/air.json` is the single composition surface — everything active in a session comes from the arrays you list here" and shows three concrete shapes: **local-only**, **local catalog + shared remote catalog** (relative paths, resolved from `~/.air/`), and **stacked remotes with local overrides**. The preamble above the section now explicitly calls out that purely local directories are a first-class use case.
- **`docs/guides/composition-and-overrides.md`.** New lead paragraph naming `~/.air/air.json` as the single composition surface. Two new "Layering patterns" subsections: **Local-only** (supported first-class shape, no provider required) and **Local team catalog + shared remote catalog** (private team directory layered with an org catalog, plus an explicit note that tildes in paths are not expanded — use a relative or absolute path).
- **`docs/guides/understanding-air-json.md`.** New sentence at the top framing `air.json` as the composition point with no other place to point AIR at artifacts.
- **`packages/cli/src/commands/init.ts` — blank-mode post-message.** Replaces the one-line "Edit air.json to configure your setup" with a four-point explanation (array-valued fields, local + remote mix, later-wins-by-ID) plus an example JSON snippet and a link to `composition-and-overrides.md`.

### What did NOT change

- The CLI help text for `air init` / `air prepare` / `air start`. The composition surface is `air.json`, not a flag — the right place to teach it is the docs and the `init` post-message.
- The repo-mode `air init` path.
- No behavior changed. No schemas changed. No API changed.

## Review round-trip

Opened the initial PR, then asked a fresh-eyes subagent to audit the diff. It caught a factual error: I had used `~/code/...` style paths in the local-catalog examples, but `resolveArtifacts` in `packages/core/src/config.ts:95` uses `path.resolve(baseDir, p)` which does **not** expand `~/`. A reader following the old examples would have been broken. Fix commit `45f5cb5` switches the examples to relative paths (`./platform-team-catalog/...`, resolved from `~/.air/`) and adds an explicit note in the composition guide that tildes are not expanded.

## Before / after snippets

**Before — README composition section intro:**
> Composition is expressed directly in `air.json`. List multiple sources per artifact type — org-wide configs first, then team or project overrides

**After — README composition section intro:**
> `~/.air/air.json` is the single composition surface — everything active in a session comes from the arrays you list here. Each artifact field accepts **any number of local or remote index paths**, and you mix and match to fit your situation. A few shapes: ...

**Before — `air init` blank-mode stdout:**
```
Initialized AIR configuration at ~/.air/air.json

Edit air.json to configure your setup. Run 'air validate ~/.air/air.json' to check.
```

**After — `air init` blank-mode stdout (captured from actual command output):**
```
Initialized AIR configuration at ~/.air/air.json

air.json is the composition point for your sessions — each artifact field
(skills, mcp, roots, hooks, references, plugins) accepts an ARRAY of index
paths. Mix local directories and/or remote catalogs; later entries override
earlier ones by ID. Example:

  {
    "name": "my-config",
    "skills": [
      "./skills/skills.json",
      "github://acme/shared-catalog/skills/skills.json"
    ]
  }

See https://github.com/pulsemcp/air/blob/main/docs/guides/composition-and-overrides.md
Validate with: air validate ~/.air/air.json
```

## Verification

- [x] Ran the full test suite locally after initial changes: `npx vitest run` — 31 files, **537 tests passed**, 0 failed
- [x] Ran `npm run build -w packages/core && npm run build` — all 6 packages built clean
- [x] Manually invoked `air init` in an isolated temp `$HOME` to confirm the new blank-mode message renders correctly (output pasted above, reproduced from actual stdout)
- [x] Fresh-eyes subagent PR review completed with "Blocking issue" verdict on tilde-expansion error in examples — addressed in follow-up commit `45f5cb5`
- [x] Verified the subagent's technical claim directly: `grep` of `packages/core/src/config.ts` confirms `path.resolve(baseDir, p)` at line 95 with no tilde-expansion path
- [x] Self-reviewed both commits' diffs (`git diff main..HEAD`)
- [x] GitHub Actions CI **green on both commits**: `validate-schemas`, `e2e`, `test (18)`, `test (20)`, `test (22)` all passed (run 24575832454)
- [x] Version bumped per `air-version-bump` skill: all 8 workspace `package.json` files → `0.0.31`, internal `@pulsemcp/air-*` cross-refs → `0.0.31`, `package-lock.json` → `0.0.31`, `CHANGELOG.md` new `[0.0.31] - 2026-04-17` entry
- [x] Grepped for stale version strings: zero hits for `0.0.30` outside `node_modules/` and the CHANGELOG's historical entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)