### PR TITLE
fix(cli): revert artifact flags to singular variadic (v0.0.32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.32] - 2026-04-17
+
+### Changed
+- **Breaking:** CLI artifact selection flags on `air start` / `air prepare` are now singular with variadic cardinality: `--skill`, `--mcp-server`, `--hook`, `--plugin` (and their `--without-*` counterparts). Pass multiple IDs by repeating the flag (`--skill a --skill b`) or listing them after a single flag (`--skill a b`) — the previous comma-separated plural syntax (`--skills a,b`) is no longer supported. The singular naming is clearer and avoids ambiguity with acronyms (e.g., `--mcp-server` vs. `--mcp-servers`), and matches Commander's own conventions for variadic options.
+
 ## [0.0.31] - 2026-04-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.32] - 2026-04-17
+## [0.0.32] - 2026-04-18
 
 ### Changed
 - **Breaking:** CLI artifact selection flags on `air start` / `air prepare` are now singular with variadic cardinality: `--skill`, `--mcp-server`, `--hook`, `--plugin` (and their `--without-*` counterparts). Pass multiple IDs by repeating the flag (`--skill a --skill b`) or listing them after a single flag (`--skill a b`) — the previous comma-separated plural syntax (`--skills a,b`) is no longer supported. The singular naming is clearer and avoids ambiguity with acronyms (e.g., `--mcp-server` vs. `--mcp-servers`), and matches Commander's own conventions for variadic options.
+- **Breaking:** `air export cowork --plugins <ids>` is renamed to `--plugin <id...>` for parity — same variadic shape (`--plugin a b` or `--plugin a --plugin b`). The old comma-separated form is no longer accepted; Commander errors out with `unknown option '--plugins'`.
 - `air start` and `air prepare` now print a one-line stderr warning when they see any of the old plural flag names in argv (before the `--` passthrough boundary) so scripts upgrading from 0.0.30/0.0.31 get a clear hint instead of a silent drop.
-
-### Note
-- The `--plugins <ids>` filter on `air export cowork` is **intentionally unchanged** and remains a plural comma-separated list. It's a different feature with different semantics (select a subset of plugins to export, not additively tweak a session's active set), so the naming convention does not apply.
 
 ## [0.0.31] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Breaking:** CLI artifact selection flags on `air start` / `air prepare` are now singular with variadic cardinality: `--skill`, `--mcp-server`, `--hook`, `--plugin` (and their `--without-*` counterparts). Pass multiple IDs by repeating the flag (`--skill a --skill b`) or listing them after a single flag (`--skill a b`) — the previous comma-separated plural syntax (`--skills a,b`) is no longer supported. The singular naming is clearer and avoids ambiguity with acronyms (e.g., `--mcp-server` vs. `--mcp-servers`), and matches Commander's own conventions for variadic options.
+- `air start` and `air prepare` now print a one-line stderr warning when they see any of the old plural flag names in argv (before the `--` passthrough boundary) so scripts upgrading from 0.0.30/0.0.31 get a clear hint instead of a silent drop.
+
+### Note
+- The `--plugins <ids>` filter on `air export cowork` is **intentionally unchanged** and remains a plural comma-separated list. It's a different feature with different semantics (select a subset of plugins to export, not additively tweak a session's active set), so the naming convention does not apply.
 
 ## [0.0.31] - 2026-04-17
 

--- a/docs/guides/configuring-mcp-servers.md
+++ b/docs/guides/configuring-mcp-servers.md
@@ -186,13 +186,17 @@ The `title` and `description` fields are stripped during translation (they're AI
 
 ### Selecting specific servers
 
-Override which servers are activated with `air prepare`:
+Add or remove servers when running `air prepare`:
 
 ```bash
-air prepare claude --mcp-servers github,postgres
+# Add github and postgres on top of the root's defaults
+air prepare claude --mcp-server github postgres
+
+# Start from empty and activate only the listed servers
+air prepare claude --without-defaults --mcp-server github postgres
 ```
 
-This activates only the listed servers, ignoring root defaults.
+Pass `--mcp-server <id...>` one or more times (or list multiple IDs after a single flag) to add servers. Pair with `--without-defaults` to ignore root defaults entirely.
 
 ## Listing configured servers
 

--- a/docs/guides/managing-skills.md
+++ b/docs/guides/managing-skills.md
@@ -176,13 +176,17 @@ When you run `air start` or `air prepare`, the adapter:
 
 ### Selecting specific skills
 
-With `air prepare`, you can override which skills are activated:
+Add or remove skills when running `air prepare`:
 
 ```bash
-air prepare claude --skills deploy-staging,initial-pr-review
+# Add deploy-staging and initial-pr-review on top of the root's defaults
+air prepare claude --skill deploy-staging initial-pr-review
+
+# Start from empty and activate only the listed skills
+air prepare claude --without-defaults --skill deploy-staging initial-pr-review
 ```
 
-This activates only the listed skills, ignoring root defaults.
+Pass `--skill <id...>` one or more times (or list multiple IDs after a single flag) to add skills. Pair with `--without-defaults` to ignore root defaults entirely.
 
 ## Best practices
 

--- a/docs/guides/roots.md
+++ b/docs/guides/roots.md
@@ -189,7 +189,7 @@ Roots (2):
 ## Best practices
 
 - **Scope tightly.** Each root should represent a single project or bounded context. Avoid catch-all roots.
-- **Minimize defaults.** Only include the skills and servers that are genuinely needed for most sessions in that root. Users can always override with `--skills` and `--mcp-servers`.
+- **Minimize defaults.** Only include the skills and servers that are genuinely needed for most sessions in that root. Users can always adjust with `--skill` and `--mcp-server` (or their `--without-*` counterparts).
 - **Set URLs for auto-detection.** Without `url`, the root can only be used with explicit `--root`.
 - **Mark utility roots as non-invocable.** If a root only makes sense as a subagent dependency, set `user_invocable: false`.
 

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -38,17 +38,20 @@ When not in a TTY (e.g., in a CI pipeline) or when `--skip-confirmation` is pass
 
 ### Non-interactive selection
 
-Pass any of `--skills`, `--mcp-servers`, `--hooks`, or `--plugins` to tweak the selection from the command line instead of the TUI. Each flag takes a comma-separated list of IDs and **adds** those artifacts on top of the root defaults (union). Use the matching `--without-*` flag to remove specific IDs from the defaults, or `--without-defaults` to opt out of all root defaults and start from an empty set.
+Pass any of `--skill`, `--mcp-server`, `--hook`, or `--plugin` to tweak the selection from the command line instead of the TUI. Each flag names an ID to **add** on top of the root defaults (union). To pass multiple IDs, repeat the flag (`--skill a --skill b`) or list them after a single flag (`--skill a b`). Use the matching `--without-*` flag to remove specific IDs from the defaults, or `--without-defaults` to opt out of all root defaults and start from an empty set.
 
 ```bash
 # Add an extra skill and MCP server on top of web-app's defaults
-air start claude --root web-app --skills deploy-staging --mcp-servers postgres-prod
+air start claude --root web-app --skill deploy-staging --mcp-server postgres-prod
+
+# Add multiple skills after a single flag (variadic)
+air start claude --root web-app --skill deploy-staging initial-pr-review
 
 # Drop a specific hook from the defaults
-air start claude --root web-app --without-hooks prevent-secrets-in-context
+air start claude --root web-app --without-hook prevent-secrets-in-context
 
 # Run with only the explicitly listed artifacts (no root defaults at all)
-air start claude --root web-app --without-defaults --skills pr-review --mcp-servers github
+air start claude --root web-app --without-defaults --skill pr-review --mcp-server github
 ```
 
 When any of these flags is provided, `air start` skips the interactive TUI even if stdin/stdout are a TTY. Flags for unspecified categories leave those categories at their root defaults.
@@ -62,15 +65,15 @@ Required argument: `<agent>` — the agent to start (e.g., `claude`).
 | `--root <name>` | Activate a specific root |
 | `--dry-run` | Preview configuration without starting |
 | `--skip-confirmation` | Skip the interactive TUI and launch directly |
-| `--skills <ids>` | Comma-separated skill IDs to add on top of root defaults (skips the TUI) |
-| `--mcp-servers <ids>` | Comma-separated MCP server IDs to add on top of root defaults (skips the TUI) |
-| `--hooks <ids>` | Comma-separated hook IDs to add on top of root defaults (skips the TUI) |
-| `--plugins <ids>` | Comma-separated plugin IDs to add on top of root defaults (skips the TUI) |
-| `--without-skills <ids>` | Skill IDs to remove from the root defaults |
-| `--without-mcp-servers <ids>` | MCP server IDs to remove from the root defaults |
-| `--without-hooks <ids>` | Hook IDs to remove from the root defaults |
-| `--without-plugins <ids>` | Plugin IDs to remove from the root defaults |
-| `--without-defaults` | Ignore all root defaults — start from an empty set and activate only the artifacts added via `--skills` / `--mcp-servers` / `--hooks` / `--plugins` |
+| `--skill <id...>` | Skill ID(s) to add on top of root defaults — repeat the flag or list multiple IDs after one flag. Skips the TUI. |
+| `--mcp-server <id...>` | MCP server ID(s) to add on top of root defaults (repeatable or variadic). Skips the TUI. |
+| `--hook <id...>` | Hook ID(s) to add on top of root defaults (repeatable or variadic). Skips the TUI. |
+| `--plugin <id...>` | Plugin ID(s) to add on top of root defaults (repeatable or variadic). Skips the TUI. |
+| `--without-skill <id...>` | Skill ID(s) to remove from the root defaults |
+| `--without-mcp-server <id...>` | MCP server ID(s) to remove from the root defaults |
+| `--without-hook <id...>` | Hook ID(s) to remove from the root defaults |
+| `--without-plugin <id...>` | Plugin ID(s) to remove from the root defaults |
+| `--without-defaults` | Ignore all root defaults — start from an empty set and activate only the artifacts added via `--skill` / `--mcp-server` / `--hook` / `--plugin` |
 | `--no-subagent-merge` | Skip merging subagent roots' artifacts |
 
 ### Passing arguments to the agent
@@ -94,7 +97,7 @@ air start claude --dry-run
 Dry run honors the non-interactive selection flags, so you can preview exactly what a scripted invocation would run:
 
 ```bash
-air start claude --dry-run --skills deploy-staging --without-hooks prevent-secrets-in-context
+air start claude --dry-run --skill deploy-staging --without-hook prevent-secrets-in-context
 ```
 
 Output:
@@ -165,14 +168,14 @@ Required argument: `<adapter>` — the agent adapter to use (e.g., `claude`).
 | `--config <path>` | Path to air.json (default: `~/.air/air.json` or `AIR_CONFIG`) |
 | `--root <name>` | Root to activate (auto-detected from cwd if omitted) |
 | `--target <dir>` | Directory to prepare (default: current directory) |
-| `--skills <ids>` | Comma-separated skill IDs to add on top of root defaults |
-| `--mcp-servers <ids>` | Comma-separated MCP server IDs to add on top of root defaults |
-| `--hooks <ids>` | Comma-separated hook IDs to add on top of root defaults |
-| `--plugins <ids>` | Comma-separated plugin IDs to add on top of root defaults |
-| `--without-skills <ids>` | Skill IDs to remove from the root defaults |
-| `--without-mcp-servers <ids>` | MCP server IDs to remove from the root defaults |
-| `--without-hooks <ids>` | Hook IDs to remove from the root defaults |
-| `--without-plugins <ids>` | Plugin IDs to remove from the root defaults |
+| `--skill <id...>` | Skill ID(s) to add on top of root defaults (repeatable or variadic) |
+| `--mcp-server <id...>` | MCP server ID(s) to add on top of root defaults (repeatable or variadic) |
+| `--hook <id...>` | Hook ID(s) to add on top of root defaults (repeatable or variadic) |
+| `--plugin <id...>` | Plugin ID(s) to add on top of root defaults (repeatable or variadic) |
+| `--without-skill <id...>` | Skill ID(s) to remove from the root defaults |
+| `--without-mcp-server <id...>` | MCP server ID(s) to remove from the root defaults |
+| `--without-hook <id...>` | Hook ID(s) to remove from the root defaults |
+| `--without-plugin <id...>` | Plugin ID(s) to remove from the root defaults |
 | `--without-defaults` | Ignore all root defaults — start from an empty set |
 | `--no-subagent-merge` | Skip merging subagent roots' artifacts |
 | `--skip-validation` | Skip `${VAR}` validation |
@@ -221,13 +224,16 @@ Add artifacts on top of root defaults, remove specific IDs, or drop all defaults
 
 ```bash
 # Add a skill and an MCP server on top of the root's defaults
-air prepare claude --skills deploy-staging --mcp-servers postgres-prod
+air prepare claude --skill deploy-staging --mcp-server postgres-prod
+
+# Add multiple skills at once (variadic)
+air prepare claude --skill deploy-staging initial-pr-review
 
 # Remove a hook from the defaults
-air prepare claude --without-hooks prevent-secrets-in-context
+air prepare claude --without-hook prevent-secrets-in-context
 
 # Start from empty and include only what you list
-air prepare claude --without-defaults --skills deploy-staging --mcp-servers github
+air prepare claude --without-defaults --skill deploy-staging --mcp-server github
 ```
 
 ## air export — building plugin marketplaces

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -268,14 +268,14 @@ Required argument: `<emitter>` — the target format (e.g., `cowork`).
 |------|-------------|
 | `--output <dir>` | Output directory for the marketplace (required) |
 | `--config <path>` | Path to air.json (default: `~/.air/air.json` or `AIR_CONFIG`) |
-| `--plugins <ids>` | Comma-separated plugin IDs to export (default: all plugins) |
+| `--plugin <id...>` | Plugin ID to export (repeatable: `--plugin a --plugin b`, or variadic: `--plugin a b`). Default: all plugins. |
 | `--marketplace-name <name>` | Override the marketplace display name |
 | `--marketplace-description <desc>` | Override the marketplace description |
 
 ### Output
 
 ```bash
-air export cowork --output ./marketplace --plugins code-quality,deploy-toolkit
+air export cowork --output ./marketplace --plugin code-quality deploy-toolkit
 ```
 
 Produces:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -36,7 +36,7 @@ Plugins are registered in `plugins.json`. Each entry declares which AIR artifact
 
 Plugins declare which AIR artifacts they bundle via the `skills`, `mcp_servers`, and `hooks` arrays. These reference IDs of artifacts defined in the corresponding AIR index files (skills.json, mcp.json, hooks.json).
 
-This declarative mapping is designed to enable CLI deduplication — if you request `--skills lint-fix --plugins code-quality` and `code-quality` already bundles `lint-fix`, the CLI can determine that only the plugin needs to be activated.
+This declarative mapping is designed to enable CLI deduplication — if you request `--skill lint-fix --plugin code-quality` and `code-quality` already bundles `lint-fix`, the CLI can determine that only the plugin needs to be activated.
 
 ### Plugin Composition
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1776442398-c80b5a97",
+  "name": "air-main-1776457654-ebdbf70b",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -847,9 +847,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.31",
+        "@pulsemcp/air-sdk": "0.0.32",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -868,7 +868,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -884,9 +884,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.31"
+        "@pulsemcp/air-core": "0.0.32"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -899,9 +899,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.31"
+        "@pulsemcp/air-core": "0.0.32"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -914,9 +914,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.31"
+        "@pulsemcp/air-core": "0.0.32"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -929,9 +929,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.31"
+        "@pulsemcp/air-core": "0.0.32"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -944,9 +944,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.31"
+        "@pulsemcp/air-core": "0.0.32"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -959,9 +959,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.31"
+        "@pulsemcp/air-core": "0.0.32"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.31",
+    "@pulsemcp/air-sdk": "0.0.32",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/deprecated-flags.ts
+++ b/packages/cli/src/commands/deprecated-flags.ts
@@ -1,0 +1,36 @@
+const RENAMED_FLAGS: Record<string, string> = {
+  "--skills": "--skill",
+  "--mcp-servers": "--mcp-server",
+  "--hooks": "--hook",
+  "--plugins": "--plugin",
+  "--without-skills": "--without-skill",
+  "--without-mcp-servers": "--without-mcp-server",
+  "--without-hooks": "--without-hook",
+  "--without-plugins": "--without-plugin",
+};
+
+/**
+ * Warns if the user invoked any of the old plural artifact-selection flags
+ * (renamed in v0.0.32). Both `air start` and `air prepare` use
+ * `.allowUnknownOption(true)` so these would otherwise be silently dropped.
+ *
+ * `start` forwards everything after `--` to the agent, so the scan stops there
+ * to avoid warning on agent flags that happen to share a name.
+ */
+export function warnOnDeprecatedArtifactFlags(argv: readonly string[]): void {
+  const dashDashIdx = argv.indexOf("--");
+  const scan = dashDashIdx === -1 ? argv : argv.slice(0, dashDashIdx);
+  const seen = new Set<string>();
+  for (const arg of scan) {
+    const base = arg.includes("=") ? arg.slice(0, arg.indexOf("=")) : arg;
+    const replacement = RENAMED_FLAGS[base];
+    if (replacement && !seen.has(base)) {
+      seen.add(base);
+      console.error(
+        `Warning: ${base} was renamed to ${replacement} in v0.0.32. ` +
+          `Pass multiple IDs as \`${replacement} a b\` or by repeating the flag. ` +
+          `The old flag is being ignored.`
+      );
+    }
+  }
+}

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -19,8 +19,8 @@ export function exportCommand(): Command {
       "Path to air.json (defaults to AIR_CONFIG env or ~/.air/air.json)"
     )
     .option(
-      "--plugins <ids>",
-      "Comma-separated plugin IDs to export (defaults to all plugins)"
+      "--plugin <id...>",
+      "Plugin ID to export (repeatable: --plugin a --plugin b, or variadic: --plugin a b). Defaults to all plugins when omitted."
     )
     .option(
       "--marketplace-name <name>",
@@ -40,7 +40,7 @@ export function exportCommand(): Command {
         options: {
           output: string;
           config?: string;
-          plugins?: string;
+          plugin?: string[];
           marketplaceName?: string;
           marketplaceDescription?: string;
           marketplaceOwner?: string;
@@ -51,9 +51,7 @@ export function exportCommand(): Command {
             config: options.config,
             emitter,
             output: options.output,
-            plugins: options.plugins
-              ? options.plugins.split(",").map((s) => s.trim())
-              : undefined,
+            plugins: options.plugin,
             marketplaceName: options.marketplaceName,
             marketplaceDescription: options.marketplaceDescription,
             marketplaceOwner: options.marketplaceOwner

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -36,11 +36,6 @@ function parseArgvFlag(flagName: string): string | undefined {
   return undefined;
 }
 
-function parseIdList(value: string | undefined): string[] | undefined {
-  if (value === undefined) return undefined;
-  return value.split(",").map((s) => s.trim()).filter(Boolean);
-}
-
 export function prepareCommand(): Command {
   const cmd = new Command("prepare")
     .description(
@@ -58,40 +53,40 @@ export function prepareCommand(): Command {
       process.cwd()
     )
     .option(
-      "--skills <ids>",
-      "Comma-separated skill IDs to ADD on top of root defaults"
+      "--skill <id...>",
+      "Skill ID to ADD on top of root defaults (repeatable: --skill a --skill b, or variadic: --skill a b)"
     )
     .option(
-      "--mcp-servers <ids>",
-      "Comma-separated MCP server IDs to ADD on top of root defaults"
+      "--mcp-server <id...>",
+      "MCP server ID to ADD on top of root defaults (repeatable or variadic)"
     )
     .option(
-      "--hooks <ids>",
-      "Comma-separated hook IDs to ADD on top of root defaults"
+      "--hook <id...>",
+      "Hook ID to ADD on top of root defaults (repeatable or variadic)"
     )
     .option(
-      "--plugins <ids>",
-      "Comma-separated plugin IDs to ADD on top of root defaults"
+      "--plugin <id...>",
+      "Plugin ID to ADD on top of root defaults (repeatable or variadic)"
     )
     .option(
-      "--without-skills <ids>",
-      "Comma-separated skill IDs to remove from root defaults"
+      "--without-skill <id...>",
+      "Skill ID to remove from root defaults (repeatable or variadic)"
     )
     .option(
-      "--without-mcp-servers <ids>",
-      "Comma-separated MCP server IDs to remove from root defaults"
+      "--without-mcp-server <id...>",
+      "MCP server ID to remove from root defaults (repeatable or variadic)"
     )
     .option(
-      "--without-hooks <ids>",
-      "Comma-separated hook IDs to remove from root defaults"
+      "--without-hook <id...>",
+      "Hook ID to remove from root defaults (repeatable or variadic)"
     )
     .option(
-      "--without-plugins <ids>",
-      "Comma-separated plugin IDs to remove from root defaults"
+      "--without-plugin <id...>",
+      "Plugin ID to remove from root defaults (repeatable or variadic)"
     )
     .option(
       "--without-defaults",
-      "Ignore all root defaults — start from an empty selection (only artifacts added via --skills / --mcp-servers / --hooks / --plugins will be activated)"
+      "Ignore all root defaults — start from an empty selection (only artifacts added via --skill / --mcp-server / --hook / --plugin will be activated)"
     )
     .option(
       "--no-subagent-merge",
@@ -107,14 +102,14 @@ export function prepareCommand(): Command {
         config?: string;
         root?: string;
         target: string;
-        skills?: string;
-        mcpServers?: string;
-        hooks?: string;
-        plugins?: string;
-        withoutSkills?: string;
-        withoutMcpServers?: string;
-        withoutHooks?: string;
-        withoutPlugins?: string;
+        skill?: string[];
+        mcpServer?: string[];
+        hook?: string[];
+        plugin?: string[];
+        withoutSkill?: string[];
+        withoutMcpServer?: string[];
+        withoutHook?: string[];
+        withoutPlugin?: string[];
         withoutDefaults?: boolean;
         subagentMerge: boolean;
         skipValidation?: boolean;
@@ -155,14 +150,14 @@ export function prepareCommand(): Command {
             root: options.root,
             target: options.target,
             adapter,
-            addSkills: parseIdList(options.skills),
-            addMcpServers: parseIdList(options.mcpServers),
-            addHooks: parseIdList(options.hooks),
-            addPlugins: parseIdList(options.plugins),
-            removeSkills: parseIdList(options.withoutSkills),
-            removeMcpServers: parseIdList(options.withoutMcpServers),
-            removeHooks: parseIdList(options.withoutHooks),
-            removePlugins: parseIdList(options.withoutPlugins),
+            addSkills: options.skill,
+            addMcpServers: options.mcpServer,
+            addHooks: options.hook,
+            addPlugins: options.plugin,
+            removeSkills: options.withoutSkill,
+            removeMcpServers: options.withoutMcpServer,
+            removeHooks: options.withoutHook,
+            removePlugins: options.withoutPlugin,
             withoutDefaults: options.withoutDefaults,
             skipSubagentMerge: !options.subagentMerge,
             skipValidation: options.skipValidation,

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -6,6 +6,7 @@ import {
   getAirJsonPath,
   loadExtensions,
 } from "@pulsemcp/air-sdk";
+import { warnOnDeprecatedArtifactFlags } from "./deprecated-flags.js";
 
 /**
  * Extract the flag name from a Commander flag string.
@@ -114,6 +115,7 @@ export function prepareCommand(): Command {
         subagentMerge: boolean;
         skipValidation?: boolean;
       }) => {
+        warnOnDeprecatedArtifactFlags(process.argv);
         try {
           // Load extensions once — pass to SDK to avoid double loading
           const airJsonPath = options.config || getAirJsonPath();

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -10,6 +10,7 @@ import {
   type RootEntry,
 } from "@pulsemcp/air-sdk";
 import { runInteractiveSelector } from "../tui/interactive-selector.js";
+import { warnOnDeprecatedArtifactFlags } from "./deprecated-flags.js";
 
 export function startCommand(): Command {
   const cmd = new Command("start")
@@ -84,6 +85,8 @@ export function startCommand(): Command {
         const dashDashIdx = process.argv.indexOf("--");
         const passthroughArgs =
           dashDashIdx !== -1 ? process.argv.slice(dashDashIdx + 1) : [];
+
+        warnOnDeprecatedArtifactFlags(process.argv);
 
         let result;
         try {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -22,40 +22,40 @@ export function startCommand(): Command {
       "Don't prompt for confirmation before starting"
     )
     .option(
-      "--skills <ids>",
-      "Comma-separated skill IDs to ADD on top of root defaults (skips interactive TUI)"
+      "--skill <id...>",
+      "Skill ID to ADD on top of root defaults (repeatable: --skill a --skill b, or variadic: --skill a b). Skips interactive TUI."
     )
     .option(
-      "--mcp-servers <ids>",
-      "Comma-separated MCP server IDs to ADD on top of root defaults (skips interactive TUI)"
+      "--mcp-server <id...>",
+      "MCP server ID to ADD on top of root defaults (repeatable or variadic). Skips interactive TUI."
     )
     .option(
-      "--hooks <ids>",
-      "Comma-separated hook IDs to ADD on top of root defaults (skips interactive TUI)"
+      "--hook <id...>",
+      "Hook ID to ADD on top of root defaults (repeatable or variadic). Skips interactive TUI."
     )
     .option(
-      "--plugins <ids>",
-      "Comma-separated plugin IDs to ADD on top of root defaults (skips interactive TUI)"
+      "--plugin <id...>",
+      "Plugin ID to ADD on top of root defaults (repeatable or variadic). Skips interactive TUI."
     )
     .option(
-      "--without-skills <ids>",
-      "Comma-separated skill IDs to remove from root defaults"
+      "--without-skill <id...>",
+      "Skill ID to remove from root defaults (repeatable or variadic)"
     )
     .option(
-      "--without-mcp-servers <ids>",
-      "Comma-separated MCP server IDs to remove from root defaults"
+      "--without-mcp-server <id...>",
+      "MCP server ID to remove from root defaults (repeatable or variadic)"
     )
     .option(
-      "--without-hooks <ids>",
-      "Comma-separated hook IDs to remove from root defaults"
+      "--without-hook <id...>",
+      "Hook ID to remove from root defaults (repeatable or variadic)"
     )
     .option(
-      "--without-plugins <ids>",
-      "Comma-separated plugin IDs to remove from root defaults"
+      "--without-plugin <id...>",
+      "Plugin ID to remove from root defaults (repeatable or variadic)"
     )
     .option(
       "--without-defaults",
-      "Ignore all root defaults — start from an empty selection (only artifacts added via --skills / --mcp-servers / --hooks / --plugins will be activated)"
+      "Ignore all root defaults — start from an empty selection (only artifacts added via --skill / --mcp-server / --hook / --plugin will be activated)"
     )
     .option(
       "--no-subagent-merge",
@@ -69,14 +69,14 @@ export function startCommand(): Command {
           root?: string;
           dryRun?: boolean;
           skipConfirmation?: boolean;
-          skills?: string;
-          mcpServers?: string;
-          hooks?: string;
-          plugins?: string;
-          withoutSkills?: string;
-          withoutMcpServers?: string;
-          withoutHooks?: string;
-          withoutPlugins?: string;
+          skill?: string[];
+          mcpServer?: string[];
+          hook?: string[];
+          plugin?: string[];
+          withoutSkill?: string[];
+          withoutMcpServer?: string[];
+          withoutHook?: string[];
+          withoutPlugin?: string[];
           withoutDefaults?: boolean;
           subagentMerge: boolean;
         },
@@ -122,22 +122,17 @@ export function startCommand(): Command {
 
         const skipSubagentMerge = !options.subagentMerge;
 
-        // Parse CLI artifact flags. Values are comma-separated ID lists with
-        // whitespace trimmed and empty entries filtered. `undefined` means the
-        // flag was not passed.
-        const parseIdList = (value: string | undefined): string[] | undefined => {
-          if (value === undefined) return undefined;
-          return value.split(",").map((s) => s.trim()).filter(Boolean);
-        };
-
-        const addSkills = parseIdList(options.skills);
-        const addMcpServers = parseIdList(options.mcpServers);
-        const addHooks = parseIdList(options.hooks);
-        const addPlugins = parseIdList(options.plugins);
-        const removeSkills = parseIdList(options.withoutSkills);
-        const removeMcpServers = parseIdList(options.withoutMcpServers);
-        const removeHooks = parseIdList(options.withoutHooks);
-        const removePlugins = parseIdList(options.withoutPlugins);
+        // Variadic commander options: `undefined` means the flag was not passed;
+        // otherwise we get an array of IDs (supports `--skill a --skill b`,
+        // `--skill a b`, or a mix).
+        const addSkills = options.skill;
+        const addMcpServers = options.mcpServer;
+        const addHooks = options.hook;
+        const addPlugins = options.plugin;
+        const removeSkills = options.withoutSkill;
+        const removeMcpServers = options.withoutMcpServer;
+        const removeHooks = options.withoutHook;
+        const removePlugins = options.withoutPlugin;
         const withoutDefaults = options.withoutDefaults ?? false;
 
         const hasArtifactFlags =

--- a/packages/cli/tests/prepare-command.test.ts
+++ b/packages/cli/tests/prepare-command.test.ts
@@ -213,7 +213,7 @@ describe("prepare command", () => {
     expect(mcpJson.mcpServers.slack).toBeUndefined();
   });
 
-  it("--skills adds on top of root defaults (union)", () => {
+  it("--skill adds on top of root defaults (union)", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -249,7 +249,7 @@ describe("prepare command", () => {
 
     // Add skill-c on top of the root's default skills
     const result = tryRun(
-      `prepare claude --config ${join(catalog, "air.json")} --root myroot --skills skill-c --target ${target}`
+      `prepare claude --config ${join(catalog, "air.json")} --root myroot --skill skill-c --target ${target}`
     );
     expect(result.exitCode).toBe(0);
 
@@ -265,7 +265,7 @@ describe("prepare command", () => {
     ).toBe(true);
   });
 
-  it("--without-skills removes specific skills from root defaults", () => {
+  it("--without-skill removes specific skills from root defaults", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -289,7 +289,7 @@ describe("prepare command", () => {
     const target = createTemp({});
 
     const result = tryRun(
-      `prepare claude --config ${join(catalog, "air.json")} --root myroot --without-skills skill-a --target ${target}`
+      `prepare claude --config ${join(catalog, "air.json")} --root myroot --without-skill skill-a --target ${target}`
     );
     expect(result.exitCode).toBe(0);
 
@@ -331,7 +331,7 @@ describe("prepare command", () => {
     const target = createTemp({});
 
     const result = tryRun(
-      `prepare claude --config ${join(catalog, "air.json")} --root myroot --without-defaults --skills skill-b --target ${target}`
+      `prepare claude --config ${join(catalog, "air.json")} --root myroot --without-defaults --skill skill-b --target ${target}`
     );
     expect(result.exitCode).toBe(0);
 
@@ -350,7 +350,7 @@ describe("prepare command", () => {
     expect(mcpJson.mcpServers ?? {}).toEqual({});
   });
 
-  it("--mcp-servers adds on top of root defaults (union)", () => {
+  it("--mcp-server adds on top of root defaults (union)", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -373,7 +373,7 @@ describe("prepare command", () => {
 
     // Add slack alongside the root's github default
     const result = tryRun(
-      `prepare claude --config ${join(catalog, "air.json")} --root myroot --mcp-servers slack --target ${target}`
+      `prepare claude --config ${join(catalog, "air.json")} --root myroot --mcp-server slack --target ${target}`
     );
     expect(result.exitCode).toBe(0);
 

--- a/packages/cli/tests/start-command.test.ts
+++ b/packages/cli/tests/start-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { execSync } from "child_process";
+import { spawnSync } from "child_process";
 import { resolve } from "path";
 import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
 import { tmpdir } from "os";
@@ -7,21 +7,20 @@ import { tmpdir } from "os";
 const CLI = resolve(__dirname, "../src/index.ts");
 
 const tryRun = (args: string, env?: Record<string, string>) => {
-  try {
-    const stdout = execSync(`npx tsx ${CLI} ${args}`, {
+  const result = spawnSync(
+    "npx",
+    ["tsx", CLI, ...args.match(/(?:[^\s"]+|"[^"]*")+/g)!.map((s) => s.replace(/^"|"$/g, ""))],
+    {
       encoding: "utf-8",
       cwd: resolve(__dirname, "../../.."),
-      stdio: ["pipe", "pipe", "pipe"],
       env: { ...process.env, ...env },
-    });
-    return { stdout, stderr: "", exitCode: 0 };
-  } catch (err: any) {
-    return {
-      stdout: err.stdout?.toString() || "",
-      stderr: err.stderr?.toString() || "",
-      exitCode: err.status ?? 1,
-    };
-  }
+    }
+  );
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    exitCode: result.status ?? 1,
+  };
 };
 
 const tempDirs: string[] = [];
@@ -431,6 +430,63 @@ describe("start command — CLI artifact selection flags", () => {
     expect(result.stdout).toContain("Skills (1)");
     expect(result.stdout).toContain("skill-b");
     expect(result.stdout).not.toMatch(/\u2022 skill-a\b/);
+  });
+
+  it("emits a deprecation warning when the old plural --skills flag is used", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        roots: ["./roots.json"],
+      },
+      "skills.json": {
+        "skill-a": { description: "Skill A", path: "skills/skill-a" },
+      },
+      "skills/skill-a/SKILL.md": "# A",
+      "roots.json": {
+        myroot: {
+          description: "Test",
+          default_skills: ["skill-a"],
+        },
+      },
+    });
+
+    const result = tryRun(
+      `start claude --root myroot --dry-run --skills skill-a`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("--skills was renamed to --skill");
+    expect(result.stderr).toContain("v0.0.32");
+  });
+
+  it("does not warn when an agent passthrough arg after -- happens to match an old flag name", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        roots: ["./roots.json"],
+      },
+      "skills.json": {
+        "skill-a": { description: "Skill A", path: "skills/skill-a" },
+      },
+      "skills/skill-a/SKILL.md": "# A",
+      "roots.json": {
+        myroot: {
+          description: "Test",
+          default_skills: ["skill-a"],
+        },
+      },
+    });
+
+    const result = tryRun(
+      `start claude --root myroot --dry-run -- --skills something-else`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("was renamed to");
   });
 
   it("combining --skill and --without-skill within the same category works", () => {

--- a/packages/cli/tests/start-command.test.ts
+++ b/packages/cli/tests/start-command.test.ts
@@ -56,7 +56,7 @@ function createTemp(files: Record<string, unknown>): string {
 // These tests use --dry-run so we don't actually spawn the agent. Dry run
 // respects the CLI artifact flags, which is what we want to verify.
 describe("start command — CLI artifact selection flags", () => {
-  it("--skills adds on top of root defaults (union)", () => {
+  it("--skill adds on top of root defaults (union)", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -80,7 +80,7 @@ describe("start command — CLI artifact selection flags", () => {
     });
 
     const result = tryRun(
-      `start claude --root myroot --dry-run --skills skill-c`,
+      `start claude --root myroot --dry-run --skill skill-c`,
       { AIR_CONFIG: resolve(catalog, "air.json") }
     );
 
@@ -92,7 +92,7 @@ describe("start command — CLI artifact selection flags", () => {
     expect(result.stdout).toContain("Skills (3)");
   });
 
-  it("--without-skills removes specific skills from root defaults", () => {
+  it("--without-skill removes specific skills from root defaults", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -116,7 +116,7 @@ describe("start command — CLI artifact selection flags", () => {
     });
 
     const result = tryRun(
-      `start claude --root myroot --dry-run --without-skills skill-b`,
+      `start claude --root myroot --dry-run --without-skill skill-b`,
       { AIR_CONFIG: resolve(catalog, "air.json") }
     );
 
@@ -164,7 +164,7 @@ describe("start command — CLI artifact selection flags", () => {
     expect(result.stdout).not.toMatch(/\u2022 github\b/);
   });
 
-  it("--without-defaults combined with --skills activates only the added skill", () => {
+  it("--without-defaults combined with --skill activates only the added skill", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -186,7 +186,7 @@ describe("start command — CLI artifact selection flags", () => {
     });
 
     const result = tryRun(
-      `start claude --root myroot --dry-run --without-defaults --skills skill-b`,
+      `start claude --root myroot --dry-run --without-defaults --skill skill-b`,
       { AIR_CONFIG: resolve(catalog, "air.json") }
     );
 
@@ -223,7 +223,7 @@ describe("start command — CLI artifact selection flags", () => {
     });
 
     const result = tryRun(
-      `start claude --root myroot --dry-run --skills skill-b`,
+      `start claude --root myroot --dry-run --skill skill-b`,
       { AIR_CONFIG: resolve(catalog, "air.json") }
     );
 
@@ -236,7 +236,7 @@ describe("start command — CLI artifact selection flags", () => {
     expect(result.stdout).toContain("github");
   });
 
-  it("parses comma-separated list with surrounding whitespace", () => {
+  it("accepts multiple variadic IDs after a single --skill flag", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -255,7 +255,7 @@ describe("start command — CLI artifact selection flags", () => {
     });
 
     const result = tryRun(
-      `start claude --root myroot --dry-run --skills "skill-a , skill-b"`,
+      `start claude --root myroot --dry-run --skill skill-a skill-b`,
       { AIR_CONFIG: resolve(catalog, "air.json") }
     );
 
@@ -265,7 +265,36 @@ describe("start command — CLI artifact selection flags", () => {
     expect(result.stdout).toContain("Skills (2)");
   });
 
-  it("supports --without-skills and --without-mcp-servers together", () => {
+  it("accepts repeated --skill flags (each adds one ID)", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        roots: ["./roots.json"],
+      },
+      "skills.json": {
+        "skill-a": { description: "Skill A", path: "skills/skill-a" },
+        "skill-b": { description: "Skill B", path: "skills/skill-b" },
+      },
+      "skills/skill-a/SKILL.md": "# A",
+      "skills/skill-b/SKILL.md": "# B",
+      "roots.json": {
+        myroot: { description: "Test", default_skills: [] },
+      },
+    });
+
+    const result = tryRun(
+      `start claude --root myroot --dry-run --skill skill-a --skill skill-b`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("skill-a");
+    expect(result.stdout).toContain("skill-b");
+    expect(result.stdout).toContain("Skills (2)");
+  });
+
+  it("supports --without-skill and --without-mcp-server together", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -293,7 +322,7 @@ describe("start command — CLI artifact selection flags", () => {
     });
 
     const result = tryRun(
-      `start claude --root myroot --dry-run --without-skills skill-a --without-mcp-servers slack`,
+      `start claude --root myroot --dry-run --without-skill skill-a --without-mcp-server slack`,
       { AIR_CONFIG: resolve(catalog, "air.json") }
     );
 
@@ -306,7 +335,7 @@ describe("start command — CLI artifact selection flags", () => {
     expect(result.stdout).not.toMatch(/\u2022 slack\b/);
   });
 
-  it("supports --hooks and --plugins adds", () => {
+  it("supports --hook and --plugin adds", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -356,7 +385,7 @@ describe("start command — CLI artifact selection flags", () => {
     });
 
     const result = tryRun(
-      `start claude --root myroot --dry-run --hooks hook-b --plugins plugin-b`,
+      `start claude --root myroot --dry-run --hook hook-b --plugin plugin-b`,
       { AIR_CONFIG: resolve(catalog, "air.json") }
     );
 
@@ -371,7 +400,7 @@ describe("start command — CLI artifact selection flags", () => {
     expect(result.stdout).toContain("plugin-b");
   });
 
-  it("when an ID appears in both --skills and --without-skills, the removal wins", () => {
+  it("when an ID appears in both --skill and --without-skill, the removal wins", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -393,7 +422,7 @@ describe("start command — CLI artifact selection flags", () => {
     });
 
     const result = tryRun(
-      `start claude --root myroot --dry-run --skills skill-a,skill-b --without-skills skill-a`,
+      `start claude --root myroot --dry-run --skill skill-a skill-b --without-skill skill-a`,
       { AIR_CONFIG: resolve(catalog, "air.json") }
     );
 
@@ -404,7 +433,7 @@ describe("start command — CLI artifact selection flags", () => {
     expect(result.stdout).not.toMatch(/\u2022 skill-a\b/);
   });
 
-  it("combining --skills and --without-skills within the same category works", () => {
+  it("combining --skill and --without-skill within the same category works", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -428,7 +457,7 @@ describe("start command — CLI artifact selection flags", () => {
     });
 
     const result = tryRun(
-      `start claude --root myroot --dry-run --skills skill-c --without-skills skill-a`,
+      `start claude --root myroot --dry-run --skill skill-c --without-skill skill-a`,
       { AIR_CONFIG: resolve(catalog, "air.json") }
     );
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.31"
+    "@pulsemcp/air-core": "0.0.32"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.31"
+    "@pulsemcp/air-core": "0.0.32"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.31"
+    "@pulsemcp/air-core": "0.0.32"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.31"
+    "@pulsemcp/air-core": "0.0.32"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.31"
+    "@pulsemcp/air-core": "0.0.32"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.31"
+    "@pulsemcp/air-core": "0.0.32"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary

Reverts the plural comma-separated artifact-selection flags introduced in #88 back to singular variadic flags, per reviewer feedback, and extends the same rename to `air export cowork` for CLI-wide parity:

- `--skills a,b` → `--skill a b` (or `--skill a --skill b`) on `air start` / `air prepare`
- `--mcp-servers a,b` → `--mcp-server a b`
- `--hooks a,b` → `--hook a b`
- `--plugins a,b` → `--plugin a b`
- Same pattern for the `--without-*` counterparts
- `air export cowork --plugins a,b` → `air export cowork --plugin a b`

Rationale: singular is clearer, avoids ambiguity with acronyms (`--mcp-server` reads unambiguously vs. `--mcp-servers`), and matches Commander's own documented convention for variadic options.

**Upgrade UX:**
- `air start` / `air prepare` use `.allowUnknownOption(true)` (needed for `--` passthrough and extension-contributed flags), which would otherwise silently drop the old flags. A `warnOnDeprecatedArtifactFlags` helper prints a one-line stderr hint instead.
- `air export` doesn't use `.allowUnknownOption(true)`, so Commander natively errors on the old form with a helpful `"Did you mean --plugin?"` suggestion — no custom helper needed there.

Bumps all packages to 0.0.32.

## Verification

- [x] **CI green** on latest commit `0be9ae9` — all 5 checks pass (test 18/20/22, e2e, validate-schemas). Prior commits `f076ab3` and `aa6c621` also went green.
- [x] **Fresh-eyes subagent review** returned LGTM with 4 non-blocking nits. Actionable nit (silent drop of old flags) was addressed with the `warnOnDeprecatedArtifactFlags` helper and two new tests covering both the happy path and the post-`--` passthrough edge case.
- [x] **User review feedback addressed:** reviewer asked for parity on `air export --plugins`. This commit renames it to `--plugin <id...>` and removes the CHANGELOG "Note" that previously documented the deliberate inconsistency.
- [x] **Lockstep version bump** — all 8 `packages/**/package.json` files at 0.0.32 with matching internal `@pulsemcp/air-*` dep references; CLI's hardcoded `.version()` string updated; CHANGELOG entry for 0.0.32 covers both breaking renames.
- [x] **540 tests pass locally** across 31 files (up from 538 pre-review, +2 deprecation-warning tests).
- [x] **Manual smoke tests:**
  - `air start claude --skill a b` and `--skill a --skill b` — both accepted (variadic works)
  - `air start claude --skills a,b` — prints stderr warning and flag is ignored (deprecation path)
  - `air export cowork --plugins a,b --output ...` — fails with `error: unknown option '--plugins' (Did you mean --plugin?)` (Commander native hint)
  - `air export --help` shows new `--plugin <id...>` signature
- [x] **Docs updated** — `docs/guides/running-sessions.md` (flag tables + multi-ID examples for both start/prepare and export), `configuring-mcp-servers.md`, `managing-skills.md`, `roots.md`, `docs/plugins.md`. `configuring-mcp-servers.md` and `managing-skills.md` also received a stale-semantic fix (pre-0.0.30 docs claimed the flag replaced root defaults; 0.0.30+ is additive unless `--without-defaults` is passed).