### PR TITLE
feat(cli): make air init idempotent via top-up mode (v0.0.38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.38] - 2026-04-24
+
+### Added
+- `air init` is now idempotent: re-running it on an existing `~/.air/` no longer errors. When `air.json` already exists, the command runs in **top-up mode** — your `air.json` is left untouched, and only missing scaffold pieces (index files, `README.md`) are created. This gives users who initialized on an older version a clean upgrade path to fill in newer scaffold files without losing their configuration. Pass `--force` to regenerate `air.json` from scratch.
+- New `topUp` option on the SDK's `initConfig` function for invoking this behavior programmatically.
+- New `mode: "topup"` variant on `SmartInitResult`'s discriminated union so CLI consumers can tell top-up from fresh blank init.
+
 ## [0.0.37] - 2026-04-24
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,6 +34,10 @@ When run inside a git repo with AIR artifact index files, also discovers them au
 
 Open the directory in your editor and start adding entries.
 
+**Re-running on an existing config (top-up mode):** If `~/.air/air.json` already exists and `--force` is not set, `air init` runs in idempotent **top-up mode**: your existing `air.json` is left untouched, and only missing scaffold pieces (index files, `README.md`) are created. This is safe to run repeatedly and gives users who initialized on an older version a way to fill in newer scaffold pieces without losing their configuration.
+
+To regenerate `air.json` from scratch (overwriting the existing file), use `--force`.
+
 Orgs and teams can provide default `air.json` files as starting points. Copy one into `~/.air/air.json` and customize.
 
 ### `air validate <file>`

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -69,8 +69,10 @@ The resulting `~/.air/` directory always looks like this:
 
 Each index file ships with a `$schema` reference, so editors like VS Code and JetBrains give you autocomplete and inline validation as you add entries. Open the directory in your editor and start typing — `README.md` has a worked example for every artifact type. When a github:// catalog is discovered, `air.json` lists the remote URI first and your local index file second; since later entries win by ID, anything you add locally overrides the shared catalog.
 
+**Re-running `air init`** is safe. If `~/.air/air.json` already exists, the command runs in **top-up mode**: it leaves your existing `air.json` untouched and only creates the scaffold pieces that are missing. This lets users who initialized on an older version fill in newer scaffold files without losing their configuration. Pass `--force` to regenerate `air.json` from scratch.
+
 Options:
-- `--force` — overwrite an existing `air.json`
+- `--force` — overwrite an existing `air.json` (skips top-up mode)
 - `--path <path>` — write the config to a custom location instead of `~/.air/air.json`
 
 ## 3. Add an MCP server

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1776990967-4abc3610",
+  "name": "air-main-1776991563-2ec84985",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -847,9 +847,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.37",
+        "@pulsemcp/air-sdk": "0.0.38",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -868,7 +868,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -884,9 +884,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.37"
+        "@pulsemcp/air-core": "0.0.38"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -899,9 +899,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.37"
+        "@pulsemcp/air-core": "0.0.38"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -914,9 +914,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.37"
+        "@pulsemcp/air-core": "0.0.38"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -929,9 +929,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.37"
+        "@pulsemcp/air-core": "0.0.38"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -944,9 +944,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.37"
+        "@pulsemcp/air-core": "0.0.38"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -959,9 +959,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.37"
+        "@pulsemcp/air-core": "0.0.38"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.37",
+    "@pulsemcp/air-sdk": "0.0.38",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,6 +1,6 @@
 import { relative } from "path";
 import { Command } from "commander";
-import { smartInit, InitFromRepoError } from "@pulsemcp/air-sdk";
+import { smartInit } from "@pulsemcp/air-sdk";
 
 export function initCommand(): Command {
   const cmd = new Command("init")
@@ -47,6 +47,38 @@ export function initCommand(): Command {
           console.log(
             "Local entries in the index files above override the discovered catalog by ID."
           );
+        } else if (result.mode === "topup") {
+          if (result.scaffolded.length === 0) {
+            console.log(
+              `AIR configuration at ${result.airDir} is already fully scaffolded — nothing to do.`
+            );
+            console.log(
+              "To regenerate air.json from scratch, re-run with --force."
+            );
+            console.log(
+              "\nValidate anytime with: air validate " + result.airJsonPath
+            );
+          } else {
+            console.log(
+              `Topped up existing AIR configuration at ${result.airDir}`
+            );
+            console.log(
+              `\nAdded ${result.scaffolded.length} missing file(s):`
+            );
+            for (const file of result.scaffolded) {
+              console.log(
+                `  [${file.kind}] ${relative(result.airDir, file.path)}`
+              );
+            }
+            console.log(
+              "\nYour existing air.json was left untouched. Open the directory" +
+                "\nin your editor — each new index file has a $schema reference," +
+                "\nso you'll get autocomplete as you add entries."
+            );
+            console.log(
+              "\nValidate anytime with: air validate " + result.airJsonPath
+            );
+          }
         } else {
           console.log(
             `Initialized AIR configuration at ${result.airDir}`
@@ -65,10 +97,6 @@ export function initCommand(): Command {
           );
         }
       } catch (err) {
-        if (err instanceof InitFromRepoError && err.code === "EXISTS") {
-          console.error(`Error: ${err.message} Use --force to overwrite.`);
-          process.exit(1);
-        }
         const message =
           err instanceof Error ? err.message : "Unknown error";
         console.error(`Error: ${message}`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.37"
+    "@pulsemcp/air-core": "0.0.38"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.37"
+    "@pulsemcp/air-core": "0.0.38"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.37"
+    "@pulsemcp/air-core": "0.0.38"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.37"
+    "@pulsemcp/air-core": "0.0.38"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.37"
+    "@pulsemcp/air-core": "0.0.38"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.37"
+    "@pulsemcp/air-core": "0.0.38"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/init-from-repo.ts
+++ b/packages/sdk/src/init-from-repo.ts
@@ -373,17 +373,23 @@ export function initFromRepo(
 /** Result from `smartInit` — discriminated by `mode`. */
 export type SmartInitResult =
   | ({ mode: "repo" } & InitFromRepoResult)
-  | ({ mode: "blank" } & InitConfigResult);
+  | ({ mode: "blank" } & InitConfigResult)
+  | ({ mode: "topup" } & InitConfigResult);
 
 /**
  * High-level init that tries repo-based discovery first and falls back to
  * blank scaffolding when no git context or artifacts are available.
  *
- * @throws InitFromRepoError with code "EXISTS" if config exists and force is false.
- * @throws Error for unexpected failures.
+ * When `air.json` already exists and `--force` isn't set, falls back to
+ * "topup" mode: leaves the existing config untouched but scaffolds any
+ * missing index files or README. This provides a safe upgrade path for
+ * users initialized on older versions that didn't scaffold all pieces.
+ *
+ * @throws Error for unexpected failures (non-InitFromRepoError).
  */
 export function smartInit(options?: InitFromRepoOptions): SmartInitResult {
   const force = options?.force ?? false;
+  const targetPath = options?.path ?? getDefaultAirJsonPath();
 
   try {
     const result = initFromRepo(options);
@@ -391,15 +397,16 @@ export function smartInit(options?: InitFromRepoOptions): SmartInitResult {
   } catch (err) {
     if (!(err instanceof InitFromRepoError)) throw err;
 
-    // Config already exists — don't silently fall back
-    if (err.code === "EXISTS") throw err;
+    // Config already exists — scaffold any missing pieces without touching air.json.
+    // Forced overwrite is handled by initFromRepo itself (re-run not needed here).
+    if (err.code === "EXISTS") {
+      const result = initConfig({ path: options?.path, topUp: true });
+      return { mode: "topup", ...result };
+    }
 
     // Fallback conditions: no git, no remote, non-GitHub remote, no artifacts
-    if (force) {
-      const targetPath = options?.path ?? getDefaultAirJsonPath();
-      if (existsSync(targetPath)) {
-        unlinkSync(targetPath);
-      }
+    if (force && existsSync(targetPath)) {
+      unlinkSync(targetPath);
     }
 
     const result = initConfig({ path: options?.path });

--- a/packages/sdk/src/init.ts
+++ b/packages/sdk/src/init.ts
@@ -9,6 +9,13 @@ import {
 export interface InitConfigOptions {
   /** Override the default air.json path (~/.air/air.json). */
   path?: string;
+  /**
+   * When true, treat an existing `air.json` as pre-existing and leave it
+   * untouched instead of throwing. Missing scaffold pieces (index files,
+   * README) are still created. Use this to provide an upgrade path for
+   * users who initialized before newer scaffold pieces existed.
+   */
+  topUp?: boolean;
 }
 
 export interface ScaffoldedFile {
@@ -194,13 +201,19 @@ export function scaffoldLocalFiles(airDir: string): ScaffoldedFile[] {
  * so editors give autocomplete out of the box, plus a README orienting the
  * user to the layout.
  *
- * @throws Error if air.json already exists at the target path.
+ * Existing index files and README are always left untouched. By default,
+ * an existing `air.json` causes an error; pass `topUp: true` to instead
+ * leave it in place and only scaffold any missing pieces.
+ *
+ * @throws Error if `air.json` exists and `topUp` is not set.
  */
 export function initConfig(options?: InitConfigOptions): InitConfigResult {
   const airJsonPath = options?.path ?? getDefaultAirJsonPath();
   const airDir = dirname(airJsonPath);
+  const topUp = options?.topUp ?? false;
 
-  if (existsSync(airJsonPath)) {
+  const airJsonExists = existsSync(airJsonPath);
+  if (airJsonExists && !topUp) {
     throw new Error(`${airJsonPath} already exists.`);
   }
 
@@ -208,8 +221,10 @@ export function initConfig(options?: InitConfigOptions): InitConfigResult {
 
   const scaffolded: ScaffoldedFile[] = [];
 
-  writeFileSync(airJsonPath, JSON.stringify(buildAirJson(), null, 2) + "\n");
-  scaffolded.push({ path: airJsonPath, kind: "air" });
+  if (!airJsonExists) {
+    writeFileSync(airJsonPath, JSON.stringify(buildAirJson(), null, 2) + "\n");
+    scaffolded.push({ path: airJsonPath, kind: "air" });
+  }
 
   scaffolded.push(...scaffoldLocalFiles(airDir));
 

--- a/packages/sdk/tests/init-from-repo.test.ts
+++ b/packages/sdk/tests/init-from-repo.test.ts
@@ -834,7 +834,7 @@ describe("smartInit", () => {
     expect(existsSync(airJsonPath)).toBe(true);
   });
 
-  it("throws EXISTS error when config exists without force", () => {
+  it("returns topup mode when config exists without force (leaves air.json untouched)", () => {
     const repoDir = createGitRepo(
       "https://github.com/acme/config.git",
       {
@@ -846,14 +846,54 @@ describe("smartInit", () => {
 
     const outputDir = makeTempDir();
     const airJsonPath = resolve(outputDir, "air.json");
-    writeFileSync(airJsonPath, "{}");
+    const originalContent = '{"name":"my-existing-config"}\n';
+    writeFileSync(airJsonPath, originalContent);
 
-    try {
-      smartInit({ cwd: repoDir, path: airJsonPath });
-      expect.unreachable("should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(InitFromRepoError);
-      expect((err as InitFromRepoError).code).toBe("EXISTS");
+    const result = smartInit({ cwd: repoDir, path: airJsonPath });
+
+    expect(result.mode).toBe("topup");
+    // Existing air.json must not be rewritten
+    expect(readFileSync(airJsonPath, "utf-8")).toBe(originalContent);
+
+    if (result.mode === "topup") {
+      // Some scaffold pieces should have been added
+      expect(result.scaffolded.length).toBeGreaterThan(0);
+      // But never the air.json itself
+      expect(result.scaffolded.map((f) => f.kind)).not.toContain("air");
+    }
+  });
+
+  it("topup mode reports empty scaffolded array when everything is already present", () => {
+    const dir = makeTempDir();
+    const airJsonPath = resolve(dir, "air.json");
+
+    // First call: fresh blank init creates the full scaffold
+    const first = smartInit({ cwd: dir, path: airJsonPath });
+    expect(first.mode).toBe("blank");
+
+    // Second call: top-up finds nothing to add
+    const second = smartInit({ cwd: dir, path: airJsonPath });
+    expect(second.mode).toBe("topup");
+    if (second.mode === "topup") {
+      expect(second.scaffolded).toEqual([]);
+    }
+  });
+
+  it("topup mode fills in missing scaffold pieces without touching air.json", () => {
+    const dir = makeTempDir();
+    const airJsonPath = resolve(dir, "air.json");
+    const originalContent = '{"name":"existing"}\n';
+    writeFileSync(airJsonPath, originalContent);
+
+    const result = smartInit({ cwd: dir, path: airJsonPath });
+
+    expect(result.mode).toBe("topup");
+    expect(readFileSync(airJsonPath, "utf-8")).toBe(originalContent);
+    if (result.mode === "topup") {
+      const kinds = result.scaffolded.map((f) => f.kind);
+      expect(kinds).toContain("skills");
+      expect(kinds).toContain("mcp");
+      expect(kinds).toContain("readme");
     }
   });
 

--- a/packages/sdk/tests/init.test.ts
+++ b/packages/sdk/tests/init.test.ts
@@ -115,4 +115,86 @@ describe("initConfig", () => {
     expect(existsSync(airJsonPath)).toBe(true);
     expect(result.airDir).toBe(resolve(dir, "nested/deep"));
   });
+
+  describe("topUp option", () => {
+    it("leaves an existing air.json untouched and scaffolds missing pieces", () => {
+      const dir = makeTempDir();
+      const airJsonPath = resolve(dir, "air.json");
+      const originalContent = '{"name":"my-own-config","custom":true}\n';
+      writeFileSync(airJsonPath, originalContent);
+
+      const result = initConfig({ path: airJsonPath, topUp: true });
+
+      // Existing air.json is untouched
+      expect(readFileSync(airJsonPath, "utf-8")).toBe(originalContent);
+
+      // `air` is NOT in scaffolded since it pre-existed
+      const kinds = result.scaffolded.map((f) => f.kind);
+      expect(kinds).not.toContain("air");
+
+      // All six indexes + README were created
+      for (const type of ARTIFACT_TYPES) {
+        expect(kinds).toContain(type);
+        expect(existsSync(resolve(dir, `${type}/${type}.json`))).toBe(true);
+      }
+      expect(kinds).toContain("readme");
+      expect(existsSync(resolve(dir, "README.md"))).toBe(true);
+    });
+
+    it("only fills in the specific index files that are missing", () => {
+      const dir = makeTempDir();
+      const airJsonPath = resolve(dir, "air.json");
+      writeFileSync(airJsonPath, '{"name":"existing"}\n');
+
+      // Pre-create skills.json and README.md with custom contents
+      mkdirSync(resolve(dir, "skills"), { recursive: true });
+      const customSkills = '{"my-skill":{"description":"mine","path":"p"}}\n';
+      writeFileSync(resolve(dir, "skills/skills.json"), customSkills);
+      const customReadme = "# my custom readme\n";
+      writeFileSync(resolve(dir, "README.md"), customReadme);
+
+      const result = initConfig({ path: airJsonPath, topUp: true });
+
+      // Custom files remain intact
+      expect(readFileSync(resolve(dir, "skills/skills.json"), "utf-8")).toBe(
+        customSkills
+      );
+      expect(readFileSync(resolve(dir, "README.md"), "utf-8")).toBe(
+        customReadme
+      );
+
+      // Skills and readme were skipped, other indexes were created
+      const kinds = result.scaffolded.map((f) => f.kind);
+      expect(kinds).not.toContain("skills");
+      expect(kinds).not.toContain("readme");
+      expect(kinds).not.toContain("air");
+      for (const type of ARTIFACT_TYPES) {
+        if (type === "skills") continue;
+        expect(kinds).toContain(type);
+      }
+    });
+
+    it("returns an empty scaffolded array when nothing is missing", () => {
+      const dir = makeTempDir();
+      const airJsonPath = resolve(dir, "air.json");
+
+      // Fresh init creates everything
+      initConfig({ path: airJsonPath });
+
+      // Second call in topUp mode should find nothing to do
+      const result = initConfig({ path: airJsonPath, topUp: true });
+      expect(result.scaffolded).toEqual([]);
+    });
+
+    it("creates a fresh scaffold when air.json does not exist (topUp is a no-op)", () => {
+      const dir = makeTempDir();
+      const airJsonPath = resolve(dir, "air.json");
+
+      const result = initConfig({ path: airJsonPath, topUp: true });
+
+      // Same behavior as a fresh init — all files scaffolded
+      expect(result.scaffolded.map((f) => f.kind)).toContain("air");
+      expect(existsSync(airJsonPath)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Makes `air init` idempotent so users on older versions have a clean upgrade path to pull in newer scaffold pieces without deleting their config.

- When `air.json` already exists and `--force` isn't set, `air init` runs in **top-up mode**: existing `air.json` is left untouched, only missing scaffold pieces (index files, `README.md`) are created.
- New `topUp` option on the SDK's `initConfig`.
- New `mode: "topup"` discriminated variant on `SmartInitResult` so the CLI can message distinctly.
- CLI prints differentiated output for top-up (what was added), no-op top-up (nothing missing), and fresh init.

## Context

This PR was originally layered on top of #92 (the scaffold feature), which has since merged. The branch has been repeatedly rebased to stay current with `main`:
- After #92 merged: version rolled `0.0.34 → 0.0.37` to clear the versions main had already shipped (0.0.34/0.0.35/0.0.36).
- After #100 merged (which also used `v0.0.37`): rolled forward again to **`0.0.38`** to avoid a collision.

Each rebase resolved `CHANGELOG.md` (new top-up entry kept, main's entries preserved), all 8 `package.json` files + `package-lock.json` (regenerated via `npm install`), and — on the earlier rebase — one output line in `packages/cli/src/commands/init.ts` (both sides kept, they don't semantically conflict).

Before this change, users who initialized on < 0.0.33 had no clean way to pull in the scaffold pieces (6 index files + README) without either deleting `~/.air/` or recreating the files manually. After this change, they just run `air init` again.

## Verification

- [x] **Rebased onto latest main; conflicts resolved.** Two sequential rebases were required as `main` advanced during the review cycle. Final rebase resolved `CHANGELOG.md` (added new `[0.0.38]` entry at the top; kept main's `[0.0.37]` entry intact), all 8 `package.json` files bumped `0.0.37 → 0.0.38`, and `package-lock.json` regenerated via `npm install`.
- [x] **Local test suite passes:** `npx vitest run` → **600/600 tests pass** across 34 test files (up from 550 at the original PR; main added coverage in the interim). No new failures introduced.
- [x] **CI green on the final rebased branch:** all 5 checks passed — `test (18)`, `test (20)`, `test (22)`, `e2e`, `validate-schemas`. Latest run: https://github.com/pulsemcp/air/actions/runs/24868927965
- [x] **Fresh-eyes self-review completed by a subagent with no prior context** (on the pre-rebase `v0.0.37` commit). Verdict: **Approve**. No blocking issues. One consistency nit addressed: topup no-op branch now prints the same `Validate anytime with:` hint as the blank-init branch (`packages/cli/src/commands/init.ts:58-60`). Remaining nits (template-literal vs concat stylistic, wording quibble about `--force`, absence of CLI-layer init tests — matches the pre-existing repo pattern) intentionally deferred as non-blocking. The code under review is unchanged post-rebase aside from version numbers and the CHANGELOG header; no new substantive logic was introduced by the rebase.
- [x] **PR mergeability:** `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN` (verified via `gh pr view 93 --json mergeable,mergeStateStatus`).
- [x] **Version bump consistent:** every package at `0.0.38`, all internal `@pulsemcp/air-core`/`@pulsemcp/air-sdk` dependency pins updated to match, `package-lock.json` workspace entries regenerated. `CHANGELOG.md` top entry is `[0.0.38] - 2026-04-24`, with `[0.0.37]` (main's `air resolve --json` feature) directly below. No lingering stale version references.

### Test coverage added

- 6 new SDK unit tests covering idempotent `topUp` behavior (leaves `air.json` untouched, skips existing index files, empty scaffold when nothing missing, falls through to fresh scaffold when `air.json` doesn't exist).
- Updated `smartInit` tests: topup mode when config exists, empty scaffold on repeat invocation, partial fill-in.

### Behavior sample (for reviewer reference)

Fresh `air.json` + existing `skills/skills.json` → **top-up with additions**:
```
Topped up existing AIR configuration at /home/user/.air

Added 6 missing file(s):
  [references] references/references.json
  [mcp_servers] mcp_servers/mcp_servers.json
  ...

Your existing air.json was left untouched. Open the directory
in your editor — each new index file has a $schema reference,
so you'll get autocomplete as you add entries.

Validate anytime with: air validate /home/user/.air/air.json
```

Fully-scaffolded dir → **no-op top-up**:
```
AIR configuration at /home/user/.air is already fully scaffolded — nothing to do.
To regenerate air.json from scratch, re-run with --force.

Validate anytime with: air validate /home/user/.air/air.json
```