### PR TITLE
feat: add catalogs field for whole-catalog composition (v0.0.34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.34] - 2026-04-21
+
+### Added
+- New `catalogs` field on `air.json` — each entry references a whole catalog (directory or provider URI) that follows the standard `<type>/<type>.json` layout, and AIR expands it into all six artifact arrays at resolution time. Makes the common "org catalog + local catalog" setup a two-line config instead of six separate arrays. Missing files inside a catalog are silently skipped, so catalogs can ship only the artifact types they need. Catalogs and the per-type arrays compose: catalogs expand first, per-type arrays layer on top.
+- Optional `fileExists(uri)` method on `CatalogProvider` — used during catalog expansion to skip conventional paths a given catalog doesn't provide. Providers without this method fall back to try/catch around `resolve()`.
+- `GitHubCatalogProvider` now implements `fileExists(uri)` so catalog expansion surfaces real clone failures (network, auth, missing repo) while still silently skipping artifact files that simply don't exist in a given catalog.
+
+### Changed
+- The `air init` scaffolded `README.md` now documents the `catalogs` field as the simplest way to layer on top of the local workspace, alongside the existing per-type array pattern.
+- Documentation updates: `README.md`, `docs/configuration.md`, `docs/guides/understanding-air-json.md`, and `docs/guides/composition-and-overrides.md` all cover the new `catalogs` field alongside the existing per-type arrays.
+
 ## [0.0.33] - 2026-04-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -106,7 +106,19 @@ Every AIR configuration starts with an `air.json` file. Each artifact property i
 }
 ```
 
-**Local catalog + shared remote catalog.** Your private team skills live in a directory you maintain (e.g., a sibling repo checked into `~/.air/` or an absolute path elsewhere on disk), layered with an org-wide catalog for shared defaults. Local paths resolve relative to `air.json`, so `./platform-team-catalog/...` below points at `~/.air/platform-team-catalog/...`:
+**Local catalog + shared remote catalog.** Your private team skills live in a directory you maintain (e.g., a sibling repo checked into `~/.air/` or an absolute path elsewhere on disk), layered with an org-wide catalog for shared defaults. When both sources follow the standard `<type>/<type>.json` layout, `catalogs` lets you reference each one with a single entry:
+
+```json
+{
+  "name": "platform-team",
+  "catalogs": [
+    "github://acme/air-org",
+    "./platform-team-catalog"
+  ]
+}
+```
+
+AIR expands each catalog into all six artifact arrays automatically — missing files within a catalog are silently skipped. If you need finer-grained control (e.g., pull only skills from a remote source), use the per-type arrays instead:
 
 ```json
 {
@@ -121,6 +133,8 @@ Every AIR configuration starts with an `air.json` file. Each artifact property i
   ]
 }
 ```
+
+`catalogs` and the per-type arrays compose: catalogs expand first, per-type arrays layer on top. Local paths resolve relative to `air.json`, so `./platform-team-catalog` above points at `~/.air/platform-team-catalog`.
 
 **Stacked remotes with local overrides.** Org → team → project, with the local file getting the last word:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,22 @@ All composition is expressed in `air.json`. Each artifact property is an array o
 
 There is no separate CLI config file. `air.json` is the single composition point.
 
+### Whole-catalog composition
+
+When you're layering full catalogs that follow the standard `<type>/<type>.json` layout, the `catalogs` field lets you reference each catalog once instead of listing every artifact type separately:
+
+```json
+{
+  "name": "frontend-team",
+  "catalogs": [
+    "github://acme/air-org",
+    "./local-catalog"
+  ]
+}
+```
+
+Each entry expands into all six artifact arrays at resolution time; files that aren't present in a given catalog are silently skipped. `catalogs` and the per-type arrays compose — catalogs expand first, per-type arrays layer on top — so you can mix them to pull most artifacts from catalogs and add targeted overrides via the per-type arrays.
+
 ## Merging Strategy
 
 For each artifact type, files in the array merge by ID:

--- a/docs/guides/composition-and-overrides.md
+++ b/docs/guides/composition-and-overrides.md
@@ -60,6 +60,64 @@ The result is the team version **only**. The org's `title` and `description` are
 
 Full replacement is predictable. You never have to wonder which fields came from which layer. The winning entry is exactly what you see in its file. Deep merge creates ambiguity: if a field is present in the result, did it come from the org layer or the team layer? With full replacement, the answer is always "whichever file defined this ID last."
 
+## Whole-catalog composition
+
+When you want to layer two or more full catalogs — say, a shared team catalog and your own local catalog — you don't need to list every artifact type separately. The `catalogs` field in `air.json` accepts an ordered array of catalog roots, and AIR expands each one into all six artifact arrays automatically.
+
+A **catalog** is a directory (local or remote) that follows AIR's standard layout:
+
+```
+<catalog>/
+├── skills/skills.json
+├── references/references.json
+├── mcp/mcp.json
+├── plugins/plugins.json
+├── roots/roots.json
+└── hooks/hooks.json
+```
+
+This is the same layout `air init` creates, and it's what each official example in this repo uses. You don't need all six files — any that are missing are silently skipped, so a catalog that only ships skills and MCP servers works fine.
+
+### Two-catalog composition (the common case)
+
+```json
+{
+  "name": "platform-team",
+  "extensions": ["@pulsemcp/air-provider-github"],
+  "catalogs": [
+    "github://acme/air-org",
+    "./platform-team-catalog"
+  ]
+}
+```
+
+That's it. Both catalogs contribute skills, MCP servers, plugins, roots, hooks, and references. The later catalog (local) overrides the earlier one (org) by ID, following the same full-replacement rule as the per-type arrays.
+
+### Mixing catalogs and explicit arrays
+
+You can use `catalogs` and the per-type arrays together. Catalogs expand first; the per-type arrays layer on top of them and can override anything a catalog contributed:
+
+```json
+{
+  "catalogs": [
+    "github://acme/air-org",
+    "./team-catalog"
+  ],
+  "mcp": [
+    "./local-mcp-overrides.json"
+  ]
+}
+```
+
+Effective load order for MCP servers: `github://acme/air-org/mcp/mcp.json` → `./team-catalog/mcp/mcp.json` → `./local-mcp-overrides.json`. Later wins by ID.
+
+### When to prefer `catalogs` over per-type arrays
+
+- You're layering full catalogs (org + team + local). `catalogs: [A, B, C]` beats writing each of the six artifact arrays for every catalog.
+- The catalog's layout matches the standard `<type>/<type>.json` convention (which is what `air init` produces).
+
+Use the per-type arrays when you want to pull just one artifact type from a source, or when the index file doesn't live at the standard path.
+
 ## Layering patterns
 
 ### Local-only
@@ -78,7 +136,22 @@ This is the simplest setup and a fully supported shape — no providers required
 
 ### Local team catalog + shared remote catalog
 
-A common team shape is a private catalog kept as a sibling directory under `~/.air/` (often a git submodule or a checked-out team repo), composed alongside a shared org-wide catalog:
+A common team shape is a private catalog kept as a sibling directory under `~/.air/` (often a git submodule or a checked-out team repo), composed alongside a shared org-wide catalog. Using the `catalogs` field keeps this compact — one entry per catalog rather than six paths per catalog:
+
+```json
+{
+  "name": "platform-team",
+  "extensions": ["@pulsemcp/air-provider-github"],
+  "catalogs": [
+    "github://acme/air-org",
+    "./platform-team-catalog"
+  ]
+}
+```
+
+The org catalog provides the baseline and the team's local catalog adds team-specific artifacts (and overrides any org defaults it wants to replace).
+
+If your catalogs don't follow the standard layout — or you only need some artifact types from a source — use the per-type arrays instead:
 
 ```json
 {
@@ -94,8 +167,6 @@ A common team shape is a private catalog kept as a sibling directory under `~/.a
   ]
 }
 ```
-
-Here the org catalog provides the baseline and the team's local catalog adds team-specific artifacts (and overrides any org defaults it wants to replace). Swap or add paths at will — each artifact field is just an ordered list of sources.
 
 Local paths are resolved relative to the directory containing `air.json` (so `./platform-team-catalog/...` above points at `~/.air/platform-team-catalog/...`). If your catalog lives elsewhere on disk, use an absolute path like `/opt/team-catalog/skills/skills.json`. **Tildes (`~/`) are not expanded** — either use a relative path or spell out the absolute path.
 
@@ -257,6 +328,8 @@ To effectively "remove" an artifact from an earlier layer, you'd need to overrid
 | Plugin references other plugin | Recursive expansion, parent overrides child |
 | Subagent root artifacts | Merged into parent session, parent takes priority |
 | Remote + local files | Both loaded, same override rules apply |
+| `catalogs` + per-type arrays | Catalogs expand first, per-type arrays layer on top |
+| Catalog missing an artifact file | Silently skipped — the catalog contributes nothing for that type |
 
 ## Next steps
 

--- a/docs/guides/understanding-air-json.md
+++ b/docs/guides/understanding-air-json.md
@@ -26,6 +26,10 @@ Here's a complete `air.json` with all fields:
     "@pulsemcp/air-secrets-env",
     "@pulsemcp/air-secrets-file"
   ],
+  "catalogs": [
+    "github://acme/air-org",
+    "./platform-team-catalog"
+  ],
   "skills": ["./skills/skills.json"],
   "references": ["./references/references.json"],
   "mcp": ["./mcp/mcp.json"],
@@ -34,6 +38,8 @@ Here's a complete `air.json` with all fields:
   "hooks": ["./hooks/hooks.json"]
 }
 ```
+
+You don't need both `catalogs` and the per-type arrays. Use `catalogs` when you're layering full catalogs (one entry per catalog), use the per-type arrays when you want fine-grained control, or mix them — catalogs expand first and the per-type arrays layer on top.
 
 ## Fields
 
@@ -50,6 +56,7 @@ Here's a complete `air.json` with all fields:
 | `$schema` | string | JSON Schema URI for editor validation and autocomplete. |
 | `description` | string | Human-readable description of this configuration scope. Max 500 characters. |
 | `extensions` | string[] | Extension packages or local paths to load (adapters, providers, transforms). |
+| `catalogs` | string[] | Paths or URIs to artifact catalogs — directories that follow the standard `<type>/<type>.json` layout. Each catalog expands into all six artifact arrays; missing files are silently skipped. |
 | `skills` | string[] | Paths to skills index files. |
 | `references` | string[] | Paths to references index files. |
 | `mcp` | string[] | Paths to MCP server configuration files. |
@@ -101,6 +108,23 @@ Each artifact field is an **ordered array** of index file paths. Files are loade
 If `org-defaults.json` defines a server with ID `"github"` and `team-overrides.json` also defines `"github"`, the team version completely replaces the org version. The org definition is discarded entirely — fields are not merged between the two.
 
 This makes override behavior predictable: you always know which definition wins by looking at array order.
+
+## Whole-catalog composition
+
+For the common case of layering two or more full catalogs, the `catalogs` field lets you reference a catalog root once instead of listing every artifact type separately:
+
+```json
+{
+  "catalogs": [
+    "github://acme/air-org",
+    "./platform-team-catalog"
+  ]
+}
+```
+
+Each entry is a directory that follows the standard AIR layout — `<type>/<type>.json` for each of the six artifact types. AIR expands every catalog into all six artifact arrays at resolution time. Files that aren't present in a catalog are silently skipped, so a catalog can ship only the artifact types it needs.
+
+`catalogs` and the per-type arrays compose: catalogs expand first, then the per-type arrays layer on top. See [Composition and Overrides](composition-and-overrides.md) for details.
 
 ### Example
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1776778480-4a34b0f5",
+  "name": "air-main-1776781248-a0510edf",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -847,9 +847,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.33",
+        "@pulsemcp/air-sdk": "0.0.34",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -868,7 +868,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -884,9 +884,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.33"
+        "@pulsemcp/air-core": "0.0.34"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -899,9 +899,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.33"
+        "@pulsemcp/air-core": "0.0.34"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -914,9 +914,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.33"
+        "@pulsemcp/air-core": "0.0.34"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -929,9 +929,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.33"
+        "@pulsemcp/air-core": "0.0.34"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -944,9 +944,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.33"
+        "@pulsemcp/air-core": "0.0.34"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -959,9 +959,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.33"
+        "@pulsemcp/air-core": "0.0.34"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.33",
+    "@pulsemcp/air-sdk": "0.0.34",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -136,9 +136,95 @@ export interface ResolveOptions {
 }
 
 /**
+ * Artifact types recognized by the standard catalog layout.
+ * A catalog is a directory where each of these types lives at
+ * `<type>/<type>.json` relative to the catalog root.
+ */
+type ArtifactType =
+  | "skills"
+  | "references"
+  | "mcp"
+  | "plugins"
+  | "roots"
+  | "hooks";
+
+const CATALOG_LAYOUT: Record<ArtifactType, string> = {
+  skills: "skills/skills.json",
+  references: "references/references.json",
+  mcp: "mcp/mcp.json",
+  plugins: "plugins/plugins.json",
+  roots: "roots/roots.json",
+  hooks: "hooks/hooks.json",
+};
+
+/** Build the conventional path for a catalog entry + artifact type. */
+function buildCatalogPath(catalog: string, type: ArtifactType): string {
+  return catalog.replace(/\/+$/, "") + "/" + CATALOG_LAYOUT[type];
+}
+
+/**
+ * Expand catalog entries into concrete index paths for a given artifact type,
+ * filtering to only those that actually exist. Missing files (local or remote)
+ * are silently skipped so that a catalog may omit artifact types it doesn't
+ * provide.
+ */
+async function expandCatalogPaths(
+  catalogs: string[],
+  type: ArtifactType,
+  baseDir: string,
+  providers: CatalogProvider[]
+): Promise<string[]> {
+  const result: string[] = [];
+
+  for (const catalog of catalogs) {
+    const candidate = buildCatalogPath(catalog, type);
+    const scheme = getScheme(candidate);
+
+    if (scheme) {
+      const provider = providers.find((prov) => prov.scheme === scheme);
+      if (!provider) {
+        throw new Error(
+          `No catalog provider registered for scheme "${scheme}://" (catalog: ${catalog}). ` +
+            `Install an extension that handles this scheme.`
+        );
+      }
+
+      if (provider.fileExists) {
+        if (await provider.fileExists(candidate)) {
+          result.push(candidate);
+        }
+        continue;
+      }
+
+      // Note: this also swallows real failures (network, auth) for providers
+      // that don't implement fileExists. Providers used for catalogs should
+      // implement fileExists to surface such errors clearly.
+      try {
+        await provider.resolve(candidate, baseDir);
+        result.push(candidate);
+      } catch {
+        // intentionally empty
+      }
+    } else {
+      const resolvedPath = resolve(baseDir, candidate);
+      if (existsSync(resolvedPath)) {
+        result.push(candidate);
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
  * Resolve all artifacts from an air.json file.
  * Each artifact property is an array of paths; files merge in order.
  * Remote URIs are delegated to the matching CatalogProvider.
+ *
+ * `catalogs` entries are expanded first into per-type paths following the
+ * standard layout (`<catalog>/<type>/<type>.json`), then the explicit
+ * per-type arrays layer on top. Missing files within a catalog are
+ * silently skipped.
  *
  * All `path` fields in resolved entries are absolute paths,
  * making artifacts self-contained regardless of source location.
@@ -150,35 +236,46 @@ export async function resolveArtifacts(
   const airConfig = loadAirConfig(airJsonPath);
   const baseDir = dirname(resolve(airJsonPath));
   const providers = options?.providers || [];
+  const catalogs = airConfig.catalogs || [];
+
+  async function paths(type: ArtifactType, explicit: string[]): Promise<string[]> {
+    const fromCatalogs = await expandCatalogPaths(
+      catalogs,
+      type,
+      baseDir,
+      providers
+    );
+    return [...fromCatalogs, ...explicit];
+  }
 
   const resolved: ResolvedArtifacts = {
     skills: await loadAndMerge<SkillEntry>(
-      airConfig.skills || [],
+      await paths("skills", airConfig.skills || []),
       baseDir,
       providers
     ),
     references: await loadAndMerge<ReferenceEntry>(
-      airConfig.references || [],
+      await paths("references", airConfig.references || []),
       baseDir,
       providers
     ),
     mcp: await loadAndMerge<McpServerEntry>(
-      airConfig.mcp || [],
+      await paths("mcp", airConfig.mcp || []),
       baseDir,
       providers
     ),
     plugins: await loadAndMerge<PluginEntry>(
-      airConfig.plugins || [],
+      await paths("plugins", airConfig.plugins || []),
       baseDir,
       providers
     ),
     roots: await loadAndMerge<RootEntry>(
-      airConfig.roots || [],
+      await paths("roots", airConfig.roots || []),
       baseDir,
       providers
     ),
     hooks: await loadAndMerge<HookEntry>(
-      airConfig.hooks || [],
+      await paths("hooks", airConfig.hooks || []),
       baseDir,
       providers
     ),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,6 +6,14 @@ export interface AirConfig {
   name: string;
   description?: string;
   extensions?: string[];
+  /**
+   * Catalog references — each entry is a directory (local path or provider URI)
+   * that follows the standard AIR layout: `<type>/<type>.json` for each of the
+   * six artifact types. Catalogs expand into all six artifact arrays in order;
+   * missing files within a catalog are silently skipped. The per-type arrays
+   * below layer on top of (and can override) catalog-expanded entries.
+   */
+  catalogs?: string[];
   skills?: string[];
   references?: string[];
   mcp?: string[];
@@ -218,6 +226,17 @@ export interface CatalogProvider {
    * Returns a result for each cached entry describing what happened.
    */
   refreshCache?(): Promise<CacheRefreshResult[]>;
+  /**
+   * Check whether the URI resolves to an existing file.
+   * Used during catalog expansion to skip conventional paths that aren't
+   * present in a given catalog. Implementations should throw for real
+   * failures (network, auth, missing repo) and only return false for
+   * "file does not exist in an otherwise-reachable source".
+   *
+   * If omitted, catalog expansion falls back to trying resolve() and
+   * treating any thrown error as "does not exist".
+   */
+  fileExists?(uri: string): Promise<boolean>;
 }
 
 /**

--- a/packages/core/tests/catalogs.test.ts
+++ b/packages/core/tests/catalogs.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { join } from "path";
+import { resolveArtifacts } from "../src/config.js";
+import type { CatalogProvider } from "../src/types.js";
+import {
+  createTempAirDir,
+  exampleSkill,
+  exampleMcpStdio,
+  exampleHook,
+  exampleReference,
+  examplePlugin,
+  exampleRoot,
+} from "./helpers.js";
+
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
+
+describe("catalogs", () => {
+  it("expands a single local catalog into all artifact types", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./team"],
+      },
+      "team/skills/skills.json": {
+        deploy: exampleSkill("deploy"),
+      },
+      "team/references/references.json": {
+        "git-workflow": exampleReference("git-workflow"),
+      },
+      "team/mcp/mcp.json": {
+        github: exampleMcpStdio({ title: "Team GitHub" }),
+      },
+      "team/plugins/plugins.json": {
+        toolkit: examplePlugin("toolkit"),
+      },
+      "team/roots/roots.json": {
+        "web-app": exampleRoot("web-app"),
+      },
+      "team/hooks/hooks.json": {
+        "pre-commit": exampleHook("pre-commit"),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+
+    expect(artifacts.skills["deploy"]).toBeDefined();
+    expect(artifacts.references["git-workflow"]).toBeDefined();
+    expect(artifacts.mcp["github"].title).toBe("Team GitHub");
+    expect(artifacts.plugins["toolkit"]).toBeDefined();
+    expect(artifacts.roots["web-app"]).toBeDefined();
+    expect(artifacts.hooks["pre-commit"]).toBeDefined();
+  });
+
+  it("tolerates a catalog that omits some artifact types", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./partial"],
+      },
+      "partial/skills/skills.json": {
+        deploy: exampleSkill("deploy"),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+
+    expect(artifacts.skills["deploy"]).toBeDefined();
+    expect(artifacts.mcp).toEqual({});
+    expect(artifacts.hooks).toEqual({});
+  });
+
+  it("layers multiple catalogs: later wins by ID, both contribute new IDs", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./org", "./team"],
+      },
+      "org/skills/skills.json": {
+        deploy: exampleSkill("deploy", { description: "Org deploy" }),
+        review: exampleSkill("review"),
+      },
+      "team/skills/skills.json": {
+        deploy: exampleSkill("deploy", { description: "Team deploy" }),
+        lint: exampleSkill("lint"),
+      },
+      "org/mcp/mcp.json": {
+        github: exampleMcpStdio({ title: "Org GitHub" }),
+      },
+      "team/mcp/mcp.json": {
+        github: exampleMcpStdio({ title: "Team GitHub" }),
+        jira: exampleMcpStdio({ title: "Team Jira" }),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+
+    expect(artifacts.skills["deploy"].description).toBe("Team deploy");
+    expect(artifacts.skills["review"]).toBeDefined();
+    expect(artifacts.skills["lint"]).toBeDefined();
+    expect(artifacts.mcp["github"].title).toBe("Team GitHub");
+    expect(artifacts.mcp["jira"]).toBeDefined();
+  });
+
+  it("explicit per-type arrays layer on top of catalogs", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./team"],
+        skills: ["./local-skills.json"],
+      },
+      "team/skills/skills.json": {
+        deploy: exampleSkill("deploy", { description: "Team deploy" }),
+        review: exampleSkill("review"),
+      },
+      "local-skills.json": {
+        deploy: exampleSkill("deploy", { description: "Local deploy" }),
+        custom: exampleSkill("custom"),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+
+    expect(artifacts.skills["deploy"].description).toBe("Local deploy");
+    expect(artifacts.skills["review"]).toBeDefined();
+    expect(artifacts.skills["custom"]).toBeDefined();
+  });
+
+  it("tolerates trailing slashes on catalog paths", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./team/"],
+      },
+      "team/skills/skills.json": {
+        deploy: exampleSkill("deploy"),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.skills["deploy"]).toBeDefined();
+  });
+
+  it("catalog skill paths are resolved to absolute paths relative to the catalog", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./team"],
+      },
+      "team/skills/skills.json": {
+        deploy: { description: "Deploy", path: "deploy" },
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    // Path field is resolved relative to the index file's directory (team/skills/)
+    expect(artifacts.skills["deploy"].path).toBe(join(dir, "team/skills/deploy"));
+  });
+
+  it("throws a clear error for catalog URIs without a registered provider", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["github://acme/org"],
+      },
+    });
+    cleanup = c;
+
+    await expect(resolveArtifacts(join(dir, "air.json"))).rejects.toThrow(
+      /No catalog provider registered for scheme "github:\/\/"/
+    );
+  });
+
+  it("uses a provider's fileExists to skip missing catalog files", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["mock://catalog-a"],
+      },
+    });
+    cleanup = c;
+
+    const calls: string[] = [];
+    const provider: CatalogProvider = {
+      scheme: "mock",
+      async fileExists(uri: string): Promise<boolean> {
+        calls.push(`exists:${uri}`);
+        return uri.endsWith("skills/skills.json");
+      },
+      async resolve(uri: string): Promise<Record<string, unknown>> {
+        calls.push(`resolve:${uri}`);
+        if (uri.endsWith("skills/skills.json")) {
+          return { deploy: exampleSkill("deploy") };
+        }
+        throw new Error(`Mock provider asked to resolve unexpected URI: ${uri}`);
+      },
+    };
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      providers: [provider],
+    });
+
+    expect(artifacts.skills["deploy"]).toBeDefined();
+    expect(artifacts.mcp).toEqual({});
+    // fileExists was called for every artifact type, resolve only for the existing one
+    const existsCalls = calls.filter((c) => c.startsWith("exists:"));
+    const resolveCalls = calls.filter((c) => c.startsWith("resolve:"));
+    expect(existsCalls).toHaveLength(6);
+    expect(resolveCalls).toEqual(["resolve:mock://catalog-a/skills/skills.json"]);
+  });
+
+  it("falls back to resolve() when a provider does not implement fileExists", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["mock2://cat"],
+      },
+    });
+    cleanup = c;
+
+    const provider: CatalogProvider = {
+      scheme: "mock2",
+      async resolve(uri: string): Promise<Record<string, unknown>> {
+        if (uri.endsWith("mcp/mcp.json")) {
+          return { server: exampleMcpStdio({ title: "Mock Server" }) };
+        }
+        throw new Error("not found");
+      },
+    };
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      providers: [provider],
+    });
+
+    expect(artifacts.mcp["server"]?.title).toBe("Mock Server");
+    expect(artifacts.skills).toEqual({});
+  });
+
+  it("allows per-catalog scoping — explicit arrays are unaffected when no catalogs are listed", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        skills: ["./skills/skills.json"],
+      },
+      "skills/skills.json": { deploy: exampleSkill("deploy") },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.skills["deploy"]).toBeDefined();
+  });
+});

--- a/packages/core/tests/catalogs.test.ts
+++ b/packages/core/tests/catalogs.test.ts
@@ -259,4 +259,51 @@ describe("catalogs", () => {
     const artifacts = await resolveArtifacts(join(dir, "air.json"));
     expect(artifacts.skills["deploy"]).toBeDefined();
   });
+
+  it("treats catalogs: [] as a no-op (equivalent to no catalogs key)", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: [],
+        skills: ["./skills/skills.json"],
+      },
+      "skills/skills.json": { deploy: exampleSkill("deploy") },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.skills["deploy"]).toBeDefined();
+    expect(artifacts.mcp).toEqual({});
+  });
+
+  it("expands plugins declared across separate catalogs", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./org", "./team"],
+      },
+      "org/plugins/plugins.json": {
+        base: examplePlugin("base", {
+          skills: ["shared-skill"],
+        }),
+      },
+      "org/skills/skills.json": {
+        "shared-skill": exampleSkill("shared-skill"),
+      },
+      "team/plugins/plugins.json": {
+        app: examplePlugin("app", {
+          plugins: ["base"],
+        }),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+
+    expect(artifacts.plugins["base"]).toBeDefined();
+    expect(artifacts.plugins["app"]).toBeDefined();
+    // app references base from the other catalog; after plugin expansion,
+    // app's primitives should include base's shared-skill.
+    expect(artifacts.plugins["app"].skills).toContain("shared-skill");
+  });
 });

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.33"
+    "@pulsemcp/air-core": "0.0.34"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.33"
+    "@pulsemcp/air-core": "0.0.34"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.33"
+    "@pulsemcp/air-core": "0.0.34"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/src/github-provider.ts
+++ b/packages/extensions/provider-github/src/github-provider.ts
@@ -194,6 +194,19 @@ export class GitHubCatalogProvider implements CatalogProvider {
   }
 
   /**
+   * Check whether the file referenced by a github:// URI exists in the clone.
+   * Ensures the repository is cloned (throwing on real clone failures) and
+   * then checks the file on disk. Used by catalog expansion to skip
+   * conventional artifact paths that a given catalog doesn't provide.
+   */
+  async fileExists(uri: string): Promise<boolean> {
+    const parsed = parseGitHubUri(uri);
+    const ref = parsed.ref || "HEAD";
+    const cloneDir = this.ensureClone(parsed.owner, parsed.repo, ref);
+    return existsSync(resolve(cloneDir, parsed.path));
+  }
+
+  /**
    * Return the local clone directory for a given github:// URI.
    * This allows loadAndMerge to resolve relative path/file fields
    * in artifact entries to absolute paths within the clone.

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.33"
+    "@pulsemcp/air-core": "0.0.34"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.33"
+    "@pulsemcp/air-core": "0.0.34"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.33"
+    "@pulsemcp/air-core": "0.0.34"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/init.ts
+++ b/packages/sdk/src/init.ts
@@ -116,18 +116,31 @@ Skills live as directories containing a \`SKILL.md\`. Point at one from
 
 ## Adding remote catalogs
 
-Each array in \`air.json\` can mix local paths with remote URIs. Append a
-\`github://\` entry after your local index to layer a team or org catalog on
-top — later entries override earlier ones by ID:
+The simplest way to layer a shared team or org catalog on top of your local
+workspace is the \`catalogs\` field. Each entry is a directory (local path or
+\`github://\` URI) that follows the standard \`<type>/<type>.json\` layout, and
+AIR expands it into all six artifact arrays automatically:
 
 \`\`\`json
 {
-  "skills": [
-    "./skills/skills.json",
-    "github://acme/shared-air-config/skills/skills.json"
-  ]
+  "catalogs": [
+    "github://acme/shared-air-config"
+  ],
+  "skills": ["./skills/skills.json"],
+  "references": ["./references/references.json"],
+  "mcp": ["./mcp/mcp.json"],
+  "plugins": ["./plugins/plugins.json"],
+  "roots": ["./roots/roots.json"],
+  "hooks": ["./hooks/hooks.json"]
 }
 \`\`\`
+
+Catalogs expand first; your per-type arrays layer on top. Later entries
+override earlier ones by ID — so anything you define locally wins over the
+shared catalog.
+
+You can also mix local and remote URIs inside a single per-type array for
+finer-grained overrides, e.g. \`"skills": ["./skills/skills.json", "github://acme/shared/skills/skills.json"]\`.
 
 (Remote URIs require an appropriate catalog provider extension to be
 installed, e.g. \`@pulsemcp/air-provider-github\`.)

--- a/schemas/air.schema.json
+++ b/schemas/air.schema.json
@@ -26,6 +26,11 @@
       "maxLength": 500,
       "description": "Human-readable description of this AIR configuration scope (e.g., 'Acme Corp engineering team agent configs')."
     },
+    "catalogs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths or URIs to artifact catalogs. A catalog is a directory that follows the standard layout — each of {skills,references,mcp,plugins,roots,hooks}/<name>.json in its root. Catalogs expand into all six artifact arrays in order; missing files are silently skipped. Later catalogs override earlier ones by ID; the per-type artifact arrays layer on top of catalogs."
+    },
     "skills": {
       "type": "array",
       "items": { "type": "string" },


### PR DESCRIPTION
## Summary

- Adds a top-level `catalogs` array to `air.json` that references entire catalog directories (local or remote) instead of requiring per-artifact entries. Each catalog expands into all six artifact arrays following the standard `<type>/<type>.json` layout; missing files are silently skipped.
- Adds an optional `fileExists(uri)` method on the `CatalogProvider` interface so providers can report existence without the cost of a full resolve. Implemented for the GitHub provider; providers without it fall back to try/catch around `resolve()` (with a documented caveat).
- Catalog entries compose with the existing per-type arrays: catalogs expand first, per-type arrays layer on top, later wins by ID.

## Rebased after #92 merged

This PR was originally stacked on #92 (`scaffold-air-init`). #92 has now landed in main, so this branch has been rebased directly onto main. Only two commits sit on top of main — the feature commit and the test addendum. Bumps to **v0.0.34** (since #92 took 0.0.33).

Rebased integration preserved:

- The scaffolded `~/.air/README.md` template (introduced by #92) documents the `catalogs` field as the simplest layering pattern.
- My earlier blank-mode terminal-hint change in `air init` was dropped (obsolete — the scaffolded README is the right surface for composition guidance now).

## Motivation

Previously, to layer two catalogs (e.g. a team's shared repo-hosted catalog and a local one), users had to repeat every artifact type for both catalogs:

```json
{
  "skills": ["github://acme/shared/skills/skills.json", "./skills/skills.json"],
  "references": ["github://acme/shared/references/references.json", "./references/references.json"],
  "mcp": ["github://acme/shared/mcp/mcp.json", "./mcp/mcp.json"],
  "plugins": ["github://acme/shared/plugins/plugins.json", "./plugins/plugins.json"],
  "roots": ["github://acme/shared/roots/roots.json", "./roots/roots.json"],
  "hooks": ["github://acme/shared/hooks/hooks.json", "./hooks/hooks.json"]
}
```

Now they can write:

```json
{
  "catalogs": ["github://acme/shared", "./local-catalog"]
}
```

The per-type arrays remain available for targeted overrides that layer on top of catalogs.

## Files changed

- `schemas/air.schema.json` — new `catalogs` field
- `packages/core/src/types.ts` — `AirConfig.catalogs`, `CatalogProvider.fileExists`
- `packages/core/src/config.ts` — catalog expansion in `resolveArtifacts`
- `packages/core/tests/catalogs.test.ts` — 12 tests
- `packages/extensions/provider-github/src/github-provider.ts` — `fileExists` implementation
- `packages/sdk/src/init.ts` — scaffolded README now documents `catalogs`
- `docs/configuration.md`, `docs/guides/composition-and-overrides.md`, `docs/guides/understanding-air-json.md`, `README.md` — docs
- All `package.json` files + `package-lock.json` + `CHANGELOG.md` — bump to 0.0.34

## Verification

- [x] **Tests added**: `packages/core/tests/catalogs.test.ts` with 12 cases — single local catalog expansion, missing artifact types tolerated, multi-catalog layering, explicit per-type arrays layered on top, trailing-slash normalization, relative path resolution, missing-provider error, provider `fileExists` path, `fileExists` fallback to `resolve()`, no-catalogs baseline, empty-`catalogs` no-op, and plugin refs across separate catalogs.
- [x] **Tests passing locally**: `npx vitest run` -> 556/556 pass across 32 files (after rebase onto main).
- [x] **Type-check / build passing locally**: `npm run build` succeeds across all workspaces post-rebase.
- [x] **Self-review done**: Ran the `simplify` review (reuse, quality, efficiency agents). Applied fixes: flattened nested conditional in `expandCatalogPaths` with an early return, removed redundant comments.
- [x] **Fresh-eyes review done**: Ran a subagent review from a blank slate. Verdict: "ship it — nothing blocking." Added tests for `catalogs: []` and cross-catalog plugin refs as suggested.
- [x] **Rebased cleanly onto main**: After #92 merged, this branch was rebased with `git rebase --onto origin/main f6c6503` (dropping #92's commits, which are now squashed in main). Result: 2 clean commits on top of main.
- [x] **Change works end-to-end**: The `catalogs` code path is exercised by 12 dedicated tests that build real temp directories, write real `air.json` and index files, run `resolveArtifacts`, and assert on merged output — including the `provider.fileExists` path (mock provider) and the `resolve()` fallback (mock provider without `fileExists`). The existing E2E suite (`packages/cli/tests/e2e.test.ts`) covers CLI flows end-to-end including a real Claude Code `.mcp.json` acceptance test, and all 23 E2E cases pass.
- [x] **Version bumped**: All 7 packages bumped to 0.0.34 with matching internal `@pulsemcp/air-*` deps, CHANGELOG entry added, `npm install` ran to regenerate lockfile.
- [x] **CI green**: All 5 checks pass on the rebased branch — e2e, test (18/20/22), validate-schemas. Run: https://github.com/pulsemcp/air/actions/runs/24812941137

🤖 Generated with [Claude Code](https://claude.com/claude-code)