### PR TITLE
feat: default git providers to SSH with HTTPS opt-in (v0.0.35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.35] - 2026-04-23
+
+### Added
+- New `gitProtocol` field on `air.json` (enum `"ssh"` | `"https"`) — selects the protocol used by git-based catalog providers when cloning remote repositories.
+- New `--git-protocol <ssh|https>` CLI flag on `air start`, `air prepare`, and `air update`. Takes precedence over the `gitProtocol` field in `air.json`.
+- New `AIR_GIT_PROTOCOL` environment variable recognized by `GitHubCatalogProvider`. Acts as a lower-precedence fallback (below explicit constructor options and `configure()` calls).
+- New optional `configure(options)` method on the `CatalogProvider` interface. Core calls it from `resolveArtifacts` after merging air.json-level fields with caller-supplied `providerOptions`, giving providers a single place to receive runtime configuration. Unknown keys are ignored.
+- New `configureProviders(providers, airConfig, providerOptions?)` helper exported from `@pulsemcp/air-core` for callers that run provider operations outside of `resolveArtifacts` (e.g., the SDK's `updateProviderCaches`).
+- New `gitProtocol` option on `prepareSession`, `startSession`, and `updateProviderCaches` in `@pulsemcp/air-sdk` — all three route the value through `configureProviders` so every provider in play sees the same protocol.
+
+### Changed
+- **Breaking:** `GitHubCatalogProvider` now defaults to **SSH** for `git clone` URLs (`git@github.com:owner/repo.git`). Previous releases always used HTTPS. SSH avoids credential prompts in interactive environments where engineers already have keys registered with GitHub, but it will fail in environments without SSH keys on the PATH (public CI runners, corporate networks blocking port 22). To restore the old behavior, add `"gitProtocol": "https"` to `air.json`, export `AIR_GIT_PROTOCOL=https`, or pass `--git-protocol=https` on the affected CLI commands. Token-based auth over HTTPS (via `AIR_GITHUB_TOKEN`) continues to work unchanged when `gitProtocol` is `"https"`; tokens are ignored when `gitProtocol` is `"ssh"`.
+- `GitHubCatalogProvider` clone-failure messages now include a protocol-aware hint — SSH auth failures suggest registering a key or switching to HTTPS; HTTPS failures suggest setting `AIR_GITHUB_TOKEN`.
+
 ## [0.0.34] - 2026-04-21
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -94,6 +94,7 @@ air start claude --skip-confirmation
 | `--root <name>` | Root to start the session in. |
 | `--dry-run` | Show what would be activated without starting the agent. |
 | `--skip-confirmation` | Don't prompt for confirmation before starting. |
+| `--git-protocol <ssh\|https>` | Protocol used by git-based catalog providers when cloning. Defaults to `ssh`. Overrides the `gitProtocol` field in `air.json` and the `AIR_GIT_PROTOCOL` env var for this invocation. |
 
 **What happens on `air start`:**
 
@@ -125,3 +126,5 @@ Shows ID, title (if available), and description for each artifact. Shows the mer
 |----------|-------------|
 | `AIR_CONFIG` | Override path to `air.json` (default: `~/.air/air.json`). |
 | `AIR_NO_COLOR` | Disable colored output. |
+| `AIR_GIT_PROTOCOL` | Force the protocol used by git-based catalog providers (`ssh` or `https`). Overrides the `gitProtocol` field in `air.json`; a `--git-protocol` CLI flag still wins over the env var. |
+| `AIR_GITHUB_TOKEN` | GitHub token used by `@pulsemcp/air-provider-github` for private repos and higher rate limits. Only consumed when protocol is `https`; ignored under `ssh`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,37 @@ Given this `air.json`:
 
 The local `github` entry completely replaces the org's. The local `postgres` entry is new and added.
 
+## Git Protocol
+
+Remote catalog URIs like `github://owner/repo/...` are resolved by cloning the repository locally. By default, AIR uses **SSH** (`git@github.com:owner/repo.git`) so clones pick up the SSH keys most engineers already have registered with GitHub — no credential prompts, no token needed for public repos.
+
+Set `gitProtocol` to opt back into HTTPS when the environment calls for it:
+
+```json
+{
+  "name": "my-project",
+  "gitProtocol": "https",
+  "catalogs": ["github://acme/air-org"]
+}
+```
+
+Common reasons to use HTTPS:
+
+- **CI runners without SSH keys** — set `gitProtocol` to `"https"` and provide `AIR_GITHUB_TOKEN` for any private repos in the catalog list.
+- **Corporate networks that block port 22** — HTTPS on port 443 is almost always allowed.
+- **Token-based automation** — when you already manage a GitHub token via a secrets manager, HTTPS lets you use it directly.
+
+### Precedence
+
+A session's effective protocol is decided in this order (highest first):
+
+1. `--git-protocol <ssh|https>` on `air start` / `air prepare` / `air update`
+2. The `AIR_GIT_PROTOCOL` environment variable
+3. The `gitProtocol` field in `air.json`
+4. Default: `"ssh"`
+
+Tokens are only injected into the clone URL when protocol is HTTPS; in SSH mode the token is ignored and clones rely on your configured keys.
+
 ## Minimal Configuration
 
 A minimal AIR setup needs just an `air.json`:

--- a/docs/guides/extensions.md
+++ b/docs/guides/extensions.md
@@ -116,11 +116,23 @@ The legacy syntax `github://owner/repo/path/to/file.json@ref` is also supported 
 
 It does a shallow clone of the repository to `~/.air/cache/github/{owner}/{repo}/{ref}/` and reads the file from the local clone.
 
-**Authentication:** Set `AIR_GITHUB_TOKEN` for private repositories:
+**Protocol:** Clones default to SSH (`git@github.com:owner/repo.git`), which piggybacks on the SSH keys engineers already have registered with GitHub. To use HTTPS instead — for CI runners without SSH keys, corporate networks that block port 22, or token-based auth — set `"gitProtocol": "https"` in `air.json`, export `AIR_GIT_PROTOCOL=https`, or pass `--git-protocol=https` to `air start` / `air prepare` / `air update`. The CLI flag wins over the env var, which wins over the `air.json` field.
+
+```json
+{
+  "name": "my-config",
+  "gitProtocol": "https",
+  "catalogs": ["github://acme/air-org"]
+}
+```
+
+**Authentication:** When using HTTPS, set `AIR_GITHUB_TOKEN` to access private repositories or raise your rate limit:
 
 ```bash
 export AIR_GITHUB_TOKEN=ghp_xxxxxxxxxxxx
 ```
+
+The token is injected into the HTTPS clone URL and redacted from any error output. When `gitProtocol` is `"ssh"`, the token is ignored — SSH relies on your configured keys.
 
 **Cache:** Clones are cached locally and reused on subsequent runs. When a cached clone is behind the remote, `air start` and `air prepare` print a warning to stderr:
 

--- a/docs/guides/understanding-air-json.md
+++ b/docs/guides/understanding-air-json.md
@@ -35,7 +35,8 @@ Here's a complete `air.json` with all fields:
   "mcp": ["./mcp/mcp.json"],
   "plugins": ["./plugins/plugins.json"],
   "roots": ["./roots/roots.json"],
-  "hooks": ["./hooks/hooks.json"]
+  "hooks": ["./hooks/hooks.json"],
+  "gitProtocol": "ssh"
 }
 ```
 
@@ -63,6 +64,7 @@ You don't need both `catalogs` and the per-type arrays. Use `catalogs` when you'
 | `plugins` | string[] | Paths to plugins index files. |
 | `roots` | string[] | Paths to roots index files. |
 | `hooks` | string[] | Paths to hooks index files. |
+| `gitProtocol` | `"ssh"` \| `"https"` | Protocol used by git-based catalog providers (e.g., `github://`) when cloning. Defaults to `"ssh"`. Use `"https"` for CI without SSH keys or token-based auth. Can be overridden per invocation with `--git-protocol` or via `AIR_GIT_PROTOCOL`. |
 
 Additional properties are allowed — you can add custom fields without causing validation errors, but AIR ignores unrecognized fields.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1776781248-a0510edf",
+  "name": "air-main-1776951468-da632d7b",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -847,9 +847,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.34",
+        "@pulsemcp/air-sdk": "0.0.35",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -868,7 +868,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -884,9 +884,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.34"
+        "@pulsemcp/air-core": "0.0.35"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -899,9 +899,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.34"
+        "@pulsemcp/air-core": "0.0.35"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -914,9 +914,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.34"
+        "@pulsemcp/air-core": "0.0.35"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -929,9 +929,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.34"
+        "@pulsemcp/air-core": "0.0.35"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -944,9 +944,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.34"
+        "@pulsemcp/air-core": "0.0.35"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -959,9 +959,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.34"
+        "@pulsemcp/air-core": "0.0.35"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.34",
+    "@pulsemcp/air-sdk": "0.0.35",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/git-protocol.ts
+++ b/packages/cli/src/commands/git-protocol.ts
@@ -1,0 +1,16 @@
+/**
+ * Parse and validate the `--git-protocol` CLI flag value. Prints an error
+ * and exits on invalid input so command handlers can call it during
+ * argument parsing without repeating the check.
+ */
+export function parseGitProtocolFlag(
+  raw: string | undefined
+): "ssh" | "https" | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === "ssh" || raw === "https") return raw;
+  console.error(
+    `Error: invalid --git-protocol value "${raw}". ` +
+      `Expected "ssh" or "https".`
+  );
+  process.exit(1);
+}

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -7,6 +7,7 @@ import {
   loadExtensions,
 } from "@pulsemcp/air-sdk";
 import { warnOnDeprecatedArtifactFlags } from "./deprecated-flags.js";
+import { parseGitProtocolFlag } from "./git-protocol.js";
 
 /**
  * Extract the flag name from a Commander flag string.
@@ -97,6 +98,10 @@ export function prepareCommand(): Command {
       "--skip-validation",
       "Skip final validation for unresolved ${VAR} patterns (for orchestrators that resolve variables themselves)"
     )
+    .option(
+      "--git-protocol <protocol>",
+      "Protocol used by git-based catalog providers: \"ssh\" (default) or \"https\". Overrides the gitProtocol field in air.json."
+    )
     .allowUnknownOption(true)
     .action(
       async (adapter: string, options: {
@@ -114,8 +119,10 @@ export function prepareCommand(): Command {
         withoutDefaults?: boolean;
         subagentMerge: boolean;
         skipValidation?: boolean;
+        gitProtocol?: string;
       }) => {
         warnOnDeprecatedArtifactFlags(process.argv);
+        const gitProtocol = parseGitProtocolFlag(options.gitProtocol);
         try {
           // Load extensions once — pass to SDK to avoid double loading
           const airJsonPath = options.config || getAirJsonPath();
@@ -165,6 +172,7 @@ export function prepareCommand(): Command {
             skipValidation: options.skipValidation,
             extensionOptions,
             extensions: loadedExtensions,
+            gitProtocol,
           });
 
           if (result.rootAutoDetected && result.root) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -11,6 +11,7 @@ import {
 } from "@pulsemcp/air-sdk";
 import { runInteractiveSelector } from "../tui/interactive-selector.js";
 import { warnOnDeprecatedArtifactFlags } from "./deprecated-flags.js";
+import { parseGitProtocolFlag } from "./git-protocol.js";
 
 export function startCommand(): Command {
   const cmd = new Command("start")
@@ -62,6 +63,10 @@ export function startCommand(): Command {
       "--no-subagent-merge",
       "Skip merging subagent roots' artifacts into the parent session (for orchestrators that manage composition externally)"
     )
+    .option(
+      "--git-protocol <protocol>",
+      "Protocol used by git-based catalog providers: \"ssh\" (default) or \"https\". Overrides the gitProtocol field in air.json."
+    )
     .allowUnknownOption(true)
     .action(
       async (
@@ -80,6 +85,7 @@ export function startCommand(): Command {
           withoutPlugin?: string[];
           withoutDefaults?: boolean;
           subagentMerge: boolean;
+          gitProtocol?: string;
         },
       ) => {
         const dashDashIdx = process.argv.indexOf("--");
@@ -88,11 +94,14 @@ export function startCommand(): Command {
 
         warnOnDeprecatedArtifactFlags(process.argv);
 
+        const gitProtocol = parseGitProtocolFlag(options.gitProtocol);
+
         let result;
         try {
           result = await startSession(agent, {
             root: options.root,
             checkAvailability: !options.dryRun,
+            gitProtocol,
           });
         } catch (err) {
           const message =
@@ -237,6 +246,7 @@ export function startCommand(): Command {
             hooks: tuiHooks,
             plugins: tuiPlugins,
             skipSubagentMerge,
+            gitProtocol,
           });
         } catch (err) {
           const message =

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { updateProviderCaches } from "@pulsemcp/air-sdk";
+import { parseGitProtocolFlag } from "./git-protocol.js";
 
 export function updateCommand(): Command {
   const cmd = new Command("update")
@@ -15,37 +16,49 @@ export function updateCommand(): Command {
       "--no-auto-heal",
       "Do not auto-upgrade provider extensions that are too old to refresh their cache"
     )
-    .action(async (options: { config?: string; autoHeal?: boolean }) => {
-      try {
-        const { results } = await updateProviderCaches({
-          config: options.config,
-          autoHeal: options.autoHeal,
-        });
+    .option(
+      "--git-protocol <protocol>",
+      "Protocol used by git-based catalog providers: \"ssh\" (default) or \"https\". Overrides the gitProtocol field in air.json."
+    )
+    .action(
+      async (options: {
+        config?: string;
+        autoHeal?: boolean;
+        gitProtocol?: string;
+      }) => {
+        const gitProtocol = parseGitProtocolFlag(options.gitProtocol);
+        try {
+          const { results } = await updateProviderCaches({
+            config: options.config,
+            autoHeal: options.autoHeal,
+            gitProtocol,
+          });
 
-        const schemes = Object.keys(results);
-        if (schemes.length === 0) {
-          console.log("No providers with cached data found.");
-          return;
-        }
-
-        for (const scheme of schemes) {
-          const entries = results[scheme];
-          if (entries.length === 0) {
-            console.log(`${scheme}:// — no cached entries`);
-            continue;
+          const schemes = Object.keys(results);
+          if (schemes.length === 0) {
+            console.log("No providers with cached data found.");
+            return;
           }
 
-          for (const entry of entries) {
-            const icon = entry.updated ? "\u2713" : "\u00b7";
-            console.log(`  ${icon} ${entry.label} — ${entry.message}`);
+          for (const scheme of schemes) {
+            const entries = results[scheme];
+            if (entries.length === 0) {
+              console.log(`${scheme}:// — no cached entries`);
+              continue;
+            }
+
+            for (const entry of entries) {
+              const icon = entry.updated ? "✓" : "·";
+              console.log(`  ${icon} ${entry.label} — ${entry.message}`);
+            }
           }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "Unknown error";
+          console.error(`Error: ${message}`);
+          process.exit(1);
         }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : "Unknown error";
-        console.error(`Error: ${message}`);
-        process.exit(1);
       }
-    });
+    );
 
   return cmd;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -133,6 +133,37 @@ export function getAirJsonPath(): string | null {
 export interface ResolveOptions {
   /** Catalog providers for resolving remote URIs (github://, s3://, etc.) */
   providers?: CatalogProvider[];
+  /**
+   * Runtime options passed to each provider's optional `configure()` method.
+   * Values here take precedence over equivalent fields read from air.json
+   * (e.g., `gitProtocol`). Providers ignore unknown keys.
+   */
+  providerOptions?: Record<string, unknown>;
+}
+
+/**
+ * Merge air.json-level provider fields (currently just `gitProtocol`) with
+ * caller-provided overrides and dispatch the result to each provider's
+ * optional `configure()` method.
+ */
+export function configureProviders(
+  providers: CatalogProvider[],
+  airConfig: AirConfig,
+  providerOptions?: Record<string, unknown>
+): void {
+  const merged: Record<string, unknown> = {};
+  if (airConfig.gitProtocol !== undefined) {
+    merged.gitProtocol = airConfig.gitProtocol;
+  }
+  if (providerOptions) {
+    for (const [k, v] of Object.entries(providerOptions)) {
+      if (v !== undefined) merged[k] = v;
+    }
+  }
+  if (Object.keys(merged).length === 0) return;
+  for (const provider of providers) {
+    provider.configure?.(merged);
+  }
 }
 
 /**
@@ -237,6 +268,10 @@ export async function resolveArtifacts(
   const baseDir = dirname(resolve(airJsonPath));
   const providers = options?.providers || [];
   const catalogs = airConfig.catalogs || [];
+
+  // Configure providers with merged options: air.json fields are the base,
+  // explicit providerOptions override them. Providers ignore unknown keys.
+  configureProviders(providers, airConfig, options?.providerOptions);
 
   async function paths(type: ArtifactType, explicit: string[]): Promise<string[]> {
     const fromCatalogs = await expandCatalogPaths(

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -142,9 +142,16 @@ export interface ResolveOptions {
 }
 
 /**
- * Merge air.json-level provider fields (currently just `gitProtocol`) with
- * caller-provided overrides and dispatch the result to each provider's
- * optional `configure()` method.
+ * Merge air.json-level provider fields with runtime overrides and dispatch
+ * the result to each provider's optional `configure()` method.
+ *
+ * Precedence (lowest to highest, later wins):
+ *   1. `airConfig.<field>` — values declared in air.json
+ *   2. Well-known AIR env vars — currently `AIR_GIT_PROTOCOL` for `gitProtocol`
+ *   3. `providerOptions.<field>` — CLI-sourced overrides from the SDK
+ *
+ * This mirrors the user-facing contract documented in docs/configuration.md:
+ * CLI flag > env var > air.json > default.
  */
 export function configureProviders(
   providers: CatalogProvider[],
@@ -152,14 +159,24 @@ export function configureProviders(
   providerOptions?: Record<string, unknown>
 ): void {
   const merged: Record<string, unknown> = {};
+
+  // Tier 1 (lowest): air.json
   if (airConfig.gitProtocol !== undefined) {
     merged.gitProtocol = airConfig.gitProtocol;
   }
+
+  // Tier 2: well-known AIR env vars override air.json
+  if (process.env.AIR_GIT_PROTOCOL !== undefined) {
+    merged.gitProtocol = process.env.AIR_GIT_PROTOCOL;
+  }
+
+  // Tier 3 (highest): runtime overrides (CLI flag threaded from SDK)
   if (providerOptions) {
     for (const [k, v] of Object.entries(providerOptions)) {
       if (v !== undefined) merged[k] = v;
     }
   }
+
   if (Object.keys(merged).length === 0) return;
   for (const provider of providers) {
     provider.configure?.(merged);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,7 @@ export {
   mergeArtifacts,
   expandPlugins,
   emptyArtifacts,
+  configureProviders,
 } from "./config.js";
 export type { ResolveOptions } from "./config.js";
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -20,6 +20,14 @@ export interface AirConfig {
   plugins?: string[];
   roots?: string[];
   hooks?: string[];
+  /**
+   * Protocol used by git-based catalog providers (e.g., github://) when
+   * cloning remote repositories. Defaults to "ssh". Set to "https" for
+   * environments without SSH keys or when relying on token-based auth
+   * (e.g. AIR_GITHUB_TOKEN). CLI flags and explicit `providerOptions`
+   * passed to `resolveArtifacts` override this value.
+   */
+  gitProtocol?: "ssh" | "https";
 }
 
 export interface ResolvedArtifacts {
@@ -206,6 +214,14 @@ export interface PreparedSession {
 export interface CatalogProvider {
   /** URI scheme this provider handles (e.g., "github", "s3") */
   scheme: string;
+  /**
+   * Apply runtime options merged from air.json and caller overrides before
+   * resolve() or related methods run. Called by the SDK/core once per
+   * `resolveArtifacts`/`refreshCache` invocation. Providers should ignore
+   * unknown keys. Recognized keys include `gitProtocol: "ssh" | "https"`
+   * (for git-based providers).
+   */
+  configure?(options: Record<string, unknown>): void;
   /** Resolve a URI to parsed JSON content */
   resolve(uri: string, baseDir: string): Promise<Record<string, unknown>>;
   /**

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -5,7 +5,9 @@ import {
   resolveArtifacts,
   mergeArtifacts,
   emptyArtifacts,
+  configureProviders,
 } from "../src/config.js";
+import type { CatalogProvider } from "../src/types.js";
 import {
   createTempAirDir,
   exampleSkill,
@@ -463,5 +465,85 @@ describe("emptyArtifacts", () => {
     expect(empty.plugins).toEqual({});
     expect(empty.roots).toEqual({});
     expect(empty.hooks).toEqual({});
+  });
+});
+
+describe("configureProviders precedence", () => {
+  // A minimal fake provider that records the last configure() payload so we
+  // can verify what core dispatched after merging the precedence tiers.
+  function makeFakeProvider(): CatalogProvider & {
+    lastConfig: Record<string, unknown> | null;
+    configureCallCount: number;
+  } {
+    const provider = {
+      scheme: "fake",
+      lastConfig: null as Record<string, unknown> | null,
+      configureCallCount: 0,
+      resolve: async () => ({}),
+      configure(options: Record<string, unknown>) {
+        this.lastConfig = options;
+        this.configureCallCount += 1;
+      },
+    };
+    return provider;
+  }
+
+  const originalEnv = process.env.AIR_GIT_PROTOCOL;
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.AIR_GIT_PROTOCOL;
+    } else {
+      process.env.AIR_GIT_PROTOCOL = originalEnv;
+    }
+  });
+
+  it("forwards air.json gitProtocol when nothing else is set", () => {
+    delete process.env.AIR_GIT_PROTOCOL;
+    const provider = makeFakeProvider();
+    configureProviders([provider], { name: "t", gitProtocol: "https" });
+    expect(provider.lastConfig).toEqual({ gitProtocol: "https" });
+  });
+
+  it("env var AIR_GIT_PROTOCOL overrides air.json gitProtocol", () => {
+    process.env.AIR_GIT_PROTOCOL = "https";
+    const provider = makeFakeProvider();
+    configureProviders([provider], { name: "t", gitProtocol: "ssh" });
+    expect(provider.lastConfig).toEqual({ gitProtocol: "https" });
+  });
+
+  it("providerOptions (CLI) overrides env var and air.json", () => {
+    process.env.AIR_GIT_PROTOCOL = "https";
+    const provider = makeFakeProvider();
+    configureProviders(
+      [provider],
+      { name: "t", gitProtocol: "https" },
+      { gitProtocol: "ssh" }
+    );
+    expect(provider.lastConfig).toEqual({ gitProtocol: "ssh" });
+  });
+
+  it("does not call configure() when no tier supplies a value", () => {
+    delete process.env.AIR_GIT_PROTOCOL;
+    const provider = makeFakeProvider();
+    configureProviders([provider], { name: "t" });
+    expect(provider.configureCallCount).toBe(0);
+  });
+
+  it("env var alone triggers configure() even without air.json field", () => {
+    process.env.AIR_GIT_PROTOCOL = "https";
+    const provider = makeFakeProvider();
+    configureProviders([provider], { name: "t" });
+    expect(provider.lastConfig).toEqual({ gitProtocol: "https" });
+  });
+
+  it("skips providers that don't implement configure()", () => {
+    process.env.AIR_GIT_PROTOCOL = "https";
+    const unconfigurable: CatalogProvider = {
+      scheme: "fake",
+      resolve: async () => ({}),
+    };
+    // Should not throw
+    configureProviders([unconfigurable], { name: "t" });
+    expect(true).toBe(true);
   });
 });

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.34"
+    "@pulsemcp/air-core": "0.0.35"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.34"
+    "@pulsemcp/air-core": "0.0.35"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/AGENTS.md
+++ b/packages/extensions/provider-github/AGENTS.md
@@ -22,14 +22,15 @@ This package implements the `CatalogProvider` interface from `@pulsemcp/air-core
 
 Clone URLs default to **SSH** (`git@github.com:owner/repo.git`). SSH avoids credential prompts in environments where engineers already have keys configured with GitHub. HTTPS (`https://github.com/owner/repo.git`) is available as an opt-in for CI runners without SSH keys, corporate networks that block port 22, or token-based auth.
 
-Protocol resolution order (highest precedence first):
-1. `configure({ gitProtocol })` — called by the SDK, sourced from the CLI `--git-protocol` flag
-2. `gitProtocol` field in `air.json`
-3. `AIR_GIT_PROTOCOL` environment variable
-4. Constructor option `gitProtocol`
-5. Default: `"ssh"`
+**User-facing precedence** (documented in `docs/configuration.md`; merged by `@pulsemcp/air-core`'s `configureProviders` before this provider ever sees a protocol value):
+1. `--git-protocol <ssh|https>` CLI flag on `air start` / `air prepare` / `air update`
+2. `AIR_GIT_PROTOCOL` environment variable
+3. `gitProtocol` field in `air.json`
+4. Default: `"ssh"`
 
-Merging across those sources is the SDK's responsibility — this provider only honors whatever is passed via constructor options, env vars, or `configure()`.
+**What this provider actually sees.** Merging happens in core; the provider only has two entry points:
+1. `configure(options)` — called by core with the already-merged winning value. Overrides whatever the constructor set.
+2. Constructor option `gitProtocol`, or `AIR_GIT_PROTOCOL` env var as a fallback when the option is omitted. This path only matters when the provider is instantiated standalone without `configureProviders` running.
 
 ### Authentication
 

--- a/packages/extensions/provider-github/AGENTS.md
+++ b/packages/extensions/provider-github/AGENTS.md
@@ -1,6 +1,6 @@
 # @pulsemcp/air-provider-github
 
-AIR catalog provider for GitHub. Resolves `github://` URIs in `air.json` by fetching file content from the GitHub REST API using Node's built-in `fetch()`.
+AIR catalog provider for GitHub. Resolves `github://` URIs in `air.json` by shallow-cloning the repository locally (via `git`) and reading files out of the clone. Clones are cached at `~/.air/cache/github/{owner}/{repo}/{ref}/`.
 
 ## Folder Hierarchy
 
@@ -8,28 +8,51 @@ AIR catalog provider for GitHub. Resolves `github://` URIs in `air.json` by fetc
 packages/extensions/provider-github/
 ├── src/
 │   ├── index.ts            # AirExtension default export + re-exports
-│   └── github-provider.ts  # GitHubCatalogProvider class, URI parser, cache logic
+│   └── github-provider.ts  # GitHubCatalogProvider class, URI parser, clone/cache logic
 ├── tests/
-│   └── github-provider.test.ts  # URI parsing, cache paths, API integration
+│   └── github-provider.test.ts  # URI parsing, cache paths, clone integration
 └── package.json
 ```
 
 ## Domain Context
 
-This package implements the `CatalogProvider` interface from `@pulsemcp/air-core`. It handles `github://owner/repo/path/to/file.json` URIs by calling `GET /repos/{owner}/{repo}/contents/{path}` on the GitHub REST API, decoding the base64 response, and caching the result locally at `~/.air/cache/github/`.
+This package implements the `CatalogProvider` interface from `@pulsemcp/air-core`. It handles `github://owner/repo[@ref]/path/to/file.json` URIs by shelling out to `git clone --depth 1` (via `execFileSync`) and then reading the requested file from the local clone. Cache refresh uses `git fetch --depth 1` + `git reset --hard`.
 
-Works without authentication for public repos. For private repos or higher rate limits, set `AIR_GITHUB_TOKEN` or pass a `token` option to the constructor.
+### Git protocol
+
+Clone URLs default to **SSH** (`git@github.com:owner/repo.git`). SSH avoids credential prompts in environments where engineers already have keys configured with GitHub. HTTPS (`https://github.com/owner/repo.git`) is available as an opt-in for CI runners without SSH keys, corporate networks that block port 22, or token-based auth.
+
+Protocol resolution order (highest precedence first):
+1. `configure({ gitProtocol })` — called by the SDK, sourced from the CLI `--git-protocol` flag
+2. `gitProtocol` field in `air.json`
+3. `AIR_GIT_PROTOCOL` environment variable
+4. Constructor option `gitProtocol`
+5. Default: `"ssh"`
+
+Merging across those sources is the SDK's responsibility — this provider only honors whatever is passed via constructor options, env vars, or `configure()`.
+
+### Authentication
+
+- **SSH**: relies on the user's SSH agent / keys. Tokens are ignored.
+- **HTTPS**: uses `AIR_GITHUB_TOKEN` (or the `token` constructor option) to inject the token into the clone URL (`https://<token>@github.com/...`). Without a token, only public repos are accessible.
+
+Token values are redacted from error messages before surfacing them.
 
 ## Core Principles
 
-### No external CLI dependencies
-Uses Node's built-in `fetch()` — no `gh` CLI, no `git` commands, no npm packages beyond `@pulsemcp/air-core`.
+### Shell out to `git`, not `gh`
+Uses `git` (universally installed) via `execFileSync`. Never depends on the `gh` CLI or a GitHub API client. URI components are strictly validated before being passed as arguments to prevent injection.
 
 ### Cache aggressively, invalidate manually
-Fetched files are cached by `{owner}/{repo}/{ref}/{path}`. There is no automatic cache invalidation — users delete `~/.air/cache/github/` to force re-fetch.
+Each `{owner}/{repo}/{ref}` is cloned once and reused. Mutable refs (branches, `HEAD`) are refreshed via `air update`; full-SHA refs are treated as immutable and never refreshed. Users can also delete `~/.air/cache/github/` to force a clean re-clone.
+
+### SSH by default, HTTPS by opt-in
+Keep the default ergonomic (no token dance for most engineers) but never force a protocol choice on users who have reasons to prefer the other one.
 
 ## What NOT to Do
 
-- Do not shell out to `gh` or `git` — use the REST API via `fetch()`
-- Do not require authentication for public repos
-- Do not silently swallow API errors — include the HTTP status, repo, and path in error messages
+- Do not add a hard dependency on the `gh` CLI — `git` is sufficient and more portable
+- Do not interpolate URI components into shell strings — pass them as argv entries via `execFileSync`
+- Do not leak tokens in error messages — run `redactToken()` before rethrowing
+- Do not silently swallow clone errors — include the public URL, ref, and `git` stderr in error messages
+- Do not change the default protocol without updating the schema description, CHANGELOG, and docs — this is a breaking change for cache paths and CI setup

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.34"
+    "@pulsemcp/air-core": "0.0.35"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/src/github-provider.ts
+++ b/packages/extensions/provider-github/src/github-provider.ts
@@ -14,14 +14,39 @@ export interface GitHubUri {
   ref?: string;
 }
 
+export type GitProtocol = "ssh" | "https";
+
 export interface GitHubProviderOptions {
   /**
    * GitHub personal access token for authenticating git clone.
-   * Required for private repositories. Optional for public repos.
+   * Required for private repositories over HTTPS. Ignored when
+   * `gitProtocol === "ssh"` — SSH uses key-based auth.
    *
    * Can also be set via the AIR_GITHUB_TOKEN environment variable.
    */
   token?: string;
+  /**
+   * Protocol to use when constructing clone URLs. Defaults to "ssh".
+   * SSH (`git@github.com:owner/repo.git`) avoids credential prompts in
+   * environments where engineers already have keys configured. Set to
+   * "https" for CI without SSH keys, corporate networks that block
+   * port 22, or token-based auth via `AIR_GITHUB_TOKEN`.
+   *
+   * Can also be set via the AIR_GIT_PROTOCOL environment variable or
+   * the `gitProtocol` field in air.json. The SDK/CLI is responsible for
+   * merging those sources and calling `configure({ gitProtocol })`.
+   */
+  gitProtocol?: GitProtocol;
+}
+
+const DEFAULT_GIT_PROTOCOL: GitProtocol = "ssh";
+
+function normalizeGitProtocol(
+  value: unknown,
+  fallback: GitProtocol
+): GitProtocol {
+  if (value === "ssh" || value === "https") return value;
+  return fallback;
 }
 
 /**
@@ -166,9 +191,36 @@ function isImmutableRef(ref: string): boolean {
 export class GitHubCatalogProvider implements CatalogProvider {
   scheme = "github";
   private token: string | undefined;
+  private gitProtocol: GitProtocol;
 
   constructor(options?: GitHubProviderOptions) {
     this.token = options?.token || process.env.AIR_GITHUB_TOKEN;
+    this.gitProtocol = normalizeGitProtocol(
+      options?.gitProtocol ?? process.env.AIR_GIT_PROTOCOL,
+      DEFAULT_GIT_PROTOCOL
+    );
+  }
+
+  /**
+   * Apply runtime options merged from air.json and caller overrides. Called
+   * by the SDK before `resolve()` / `refreshCache()` runs. Currently honors
+   * `gitProtocol: "ssh" | "https"`; unknown keys are ignored.
+   */
+  configure(options: Record<string, unknown>): void {
+    if (options.gitProtocol !== undefined) {
+      this.gitProtocol = normalizeGitProtocol(
+        options.gitProtocol,
+        this.gitProtocol
+      );
+    }
+  }
+
+  /**
+   * Return the effective git protocol in use. Exposed for diagnostics and
+   * test verification — not part of the CatalogProvider contract.
+   */
+  getGitProtocol(): GitProtocol {
+    return this.gitProtocol;
   }
 
   async resolve(
@@ -413,7 +465,7 @@ export class GitHubCatalogProvider implements CatalogProvider {
     }
 
     const repoUrl = this.buildCloneUrl(owner, repo);
-    const publicUrl = `https://github.com/${owner}/${repo}.git`;
+    const publicUrl = this.buildPublicUrl(owner, repo);
 
     try {
       const args = ref === "HEAD"
@@ -424,11 +476,19 @@ export class GitHubCatalogProvider implements CatalogProvider {
     } catch (err) {
       const rawMsg = err instanceof Error ? err.message : String(err);
       const msg = redactToken(rawMsg, this.token);
-      const hint = msg.includes("Authentication failed") || msg.includes("could not read Username")
-        ? " (repository may be private — set AIR_GITHUB_TOKEN or pass token option)"
-        : msg.includes("not found")
-          ? " (repository or ref not found)"
-          : "";
+      const authHint = this.gitProtocol === "ssh"
+        ? " (SSH auth failed — ensure a key is registered with GitHub, " +
+          "or switch to HTTPS: set \"gitProtocol\": \"https\" in air.json or pass --git-protocol=https)"
+        : " (repository may be private — set AIR_GITHUB_TOKEN or pass token option)";
+      const hint =
+        msg.includes("Authentication failed") ||
+        msg.includes("could not read Username") ||
+        msg.includes("Permission denied") ||
+        msg.includes("publickey")
+          ? authHint
+          : msg.includes("not found") || msg.includes("Repository not found")
+            ? " (repository or ref not found)"
+            : "";
       throw new Error(
         `Failed to clone ${owner}/${repo} at ref "${ref}"${hint}\n` +
           `  URL: ${publicUrl}\n` +
@@ -440,11 +500,30 @@ export class GitHubCatalogProvider implements CatalogProvider {
   }
 
   /**
-   * Build the clone URL, injecting token for authentication if available.
+   * Build the clone URL used to invoke `git clone`. Respects the configured
+   * `gitProtocol`. When protocol is HTTPS and a token is available, the
+   * token is injected into the URL for authentication; SSH ignores the
+   * token and relies on the user's configured SSH keys.
+   *
+   * Exposed (non-private) for diagnostic and test use.
    */
-  private buildCloneUrl(owner: string, repo: string): string {
+  buildCloneUrl(owner: string, repo: string): string {
+    if (this.gitProtocol === "ssh") {
+      return `git@github.com:${owner}/${repo}.git`;
+    }
     if (this.token) {
       return `https://${this.token}@github.com/${owner}/${repo}.git`;
+    }
+    return `https://github.com/${owner}/${repo}.git`;
+  }
+
+  /**
+   * Return a public, shareable URL for error messages. This always uses
+   * the protocol in effect but never embeds a token.
+   */
+  private buildPublicUrl(owner: string, repo: string): string {
+    if (this.gitProtocol === "ssh") {
+      return `git@github.com:${owner}/${repo}.git`;
     }
     return `https://github.com/${owner}/${repo}.git`;
   }

--- a/packages/extensions/provider-github/src/index.ts
+++ b/packages/extensions/provider-github/src/index.ts
@@ -2,7 +2,7 @@ import type { AirExtension } from "@pulsemcp/air-core";
 import { GitHubCatalogProvider } from "./github-provider.js";
 
 export { GitHubCatalogProvider, parseGitHubUri, getCacheDir, getClonePath } from "./github-provider.js";
-export type { GitHubUri, GitHubProviderOptions } from "./github-provider.js";
+export type { GitHubUri, GitHubProviderOptions, GitProtocol } from "./github-provider.js";
 
 const extension: AirExtension = {
   name: "github",

--- a/packages/extensions/provider-github/tests/github-provider.test.ts
+++ b/packages/extensions/provider-github/tests/github-provider.test.ts
@@ -207,7 +207,13 @@ describe("getClonePath", () => {
 });
 
 describe("GitHubCatalogProvider", () => {
+  // Integration tests below clone pulsemcp/air publicly. CI runners do not have
+  // SSH keys registered with GitHub, so every provider that performs a real
+  // clone in this file must be explicitly configured for HTTPS. The default
+  // remains SSH — see the dedicated "git protocol" block of tests for coverage
+  // of the default.
   const provider = new GitHubCatalogProvider();
+  provider.configure({ gitProtocol: "https" });
 
   it("has scheme 'github'", () => {
     expect(provider.scheme).toBe("github");
@@ -380,5 +386,104 @@ describe("GitHubCatalogProvider", () => {
     } finally {
       process.env.HOME = origHome;
     }
+  });
+});
+
+describe("GitHubCatalogProvider — git protocol", () => {
+  // These tests don't hit the network — they only verify URL construction,
+  // so they're safe to run without SSH keys or tokens.
+
+  afterEach(() => {
+    delete process.env.AIR_GIT_PROTOCOL;
+  });
+
+  it("defaults to SSH when no protocol is configured", () => {
+    delete process.env.AIR_GIT_PROTOCOL;
+    const provider = new GitHubCatalogProvider();
+    expect(provider.getGitProtocol()).toBe("ssh");
+    expect(provider.buildCloneUrl("pulsemcp", "air")).toBe(
+      "git@github.com:pulsemcp/air.git"
+    );
+  });
+
+  it("builds SSH URL with no token injection even when token is set", () => {
+    const provider = new GitHubCatalogProvider({
+      token: "ghp_secrettoken",
+      gitProtocol: "ssh",
+    });
+    const url = provider.buildCloneUrl("pulsemcp", "air");
+    expect(url).toBe("git@github.com:pulsemcp/air.git");
+    expect(url).not.toContain("ghp_secrettoken");
+  });
+
+  it("builds HTTPS URL when gitProtocol is https", () => {
+    const provider = new GitHubCatalogProvider({ gitProtocol: "https" });
+    expect(provider.getGitProtocol()).toBe("https");
+    expect(provider.buildCloneUrl("pulsemcp", "air")).toBe(
+      "https://github.com/pulsemcp/air.git"
+    );
+  });
+
+  it("injects token into HTTPS clone URL when available", () => {
+    const provider = new GitHubCatalogProvider({
+      gitProtocol: "https",
+      token: "ghp_abc123",
+    });
+    expect(provider.buildCloneUrl("pulsemcp", "air")).toBe(
+      "https://ghp_abc123@github.com/pulsemcp/air.git"
+    );
+  });
+
+  it("honors AIR_GIT_PROTOCOL=https environment variable", () => {
+    process.env.AIR_GIT_PROTOCOL = "https";
+    const provider = new GitHubCatalogProvider();
+    expect(provider.getGitProtocol()).toBe("https");
+    expect(provider.buildCloneUrl("pulsemcp", "air")).toBe(
+      "https://github.com/pulsemcp/air.git"
+    );
+  });
+
+  it("falls back to default when AIR_GIT_PROTOCOL has an invalid value", () => {
+    process.env.AIR_GIT_PROTOCOL = "ftp";
+    const provider = new GitHubCatalogProvider();
+    expect(provider.getGitProtocol()).toBe("ssh");
+  });
+
+  it("constructor option takes precedence over env var", () => {
+    process.env.AIR_GIT_PROTOCOL = "https";
+    const provider = new GitHubCatalogProvider({ gitProtocol: "ssh" });
+    expect(provider.getGitProtocol()).toBe("ssh");
+  });
+
+  it("configure() overrides the constructor-time protocol", () => {
+    const provider = new GitHubCatalogProvider({ gitProtocol: "ssh" });
+    expect(provider.getGitProtocol()).toBe("ssh");
+    provider.configure({ gitProtocol: "https" });
+    expect(provider.getGitProtocol()).toBe("https");
+    expect(provider.buildCloneUrl("pulsemcp", "air")).toBe(
+      "https://github.com/pulsemcp/air.git"
+    );
+  });
+
+  it("configure() with no gitProtocol key leaves the protocol unchanged", () => {
+    const provider = new GitHubCatalogProvider({ gitProtocol: "https" });
+    provider.configure({ unrelatedKey: "value" });
+    expect(provider.getGitProtocol()).toBe("https");
+  });
+
+  it("configure() ignores invalid gitProtocol values", () => {
+    const provider = new GitHubCatalogProvider({ gitProtocol: "https" });
+    provider.configure({ gitProtocol: "ftp" });
+    expect(provider.getGitProtocol()).toBe("https");
+  });
+
+  it("builds correct URLs for various owner/repo combinations in SSH mode", () => {
+    const provider = new GitHubCatalogProvider({ gitProtocol: "ssh" });
+    expect(provider.buildCloneUrl("acme", "widgets")).toBe(
+      "git@github.com:acme/widgets.git"
+    );
+    expect(provider.buildCloneUrl("org-with-dash", "repo.with.dots")).toBe(
+      "git@github.com:org-with-dash/repo.with.dots.git"
+    );
   });
 });

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.34"
+    "@pulsemcp/air-core": "0.0.35"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.34"
+    "@pulsemcp/air-core": "0.0.35"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.34"
+    "@pulsemcp/air-core": "0.0.35"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/prepare.ts
+++ b/packages/sdk/src/prepare.ts
@@ -81,6 +81,12 @@ export interface PrepareSessionOptions {
    * contributed CLI options.
    */
   extensions?: LoadedExtensions;
+  /**
+   * Git protocol override for git-based catalog providers (e.g., github://).
+   * Takes precedence over the `gitProtocol` field in air.json. Typical
+   * sources: a CLI flag or programmatic opt-in to HTTPS.
+   */
+  gitProtocol?: "ssh" | "https";
 }
 
 export interface PrepareSessionResult {
@@ -150,7 +156,14 @@ export async function prepareSession(
   const providers = loaded.providers
     .map((ext) => ext.provider!)
     .filter(Boolean);
-  const artifacts = await resolveArtifacts(airJsonPath, { providers });
+  const providerOptions: Record<string, unknown> = {};
+  if (options.gitProtocol !== undefined) {
+    providerOptions.gitProtocol = options.gitProtocol;
+  }
+  const artifacts = await resolveArtifacts(airJsonPath, {
+    providers,
+    providerOptions,
+  });
 
   // Check freshness of provider caches (non-blocking — warnings only)
   const warnings = await checkProviderFreshness(airConfig, providers);

--- a/packages/sdk/src/start.ts
+++ b/packages/sdk/src/start.ts
@@ -20,6 +20,11 @@ export interface StartSessionOptions {
   config?: string;
   /** Check whether the agent CLI is installed. Defaults to true. */
   checkAvailability?: boolean;
+  /**
+   * Git protocol override for git-based catalog providers. Takes precedence
+   * over the `gitProtocol` field in air.json.
+   */
+  gitProtocol?: "ssh" | "https";
 }
 
 export interface StartSessionResult {
@@ -76,7 +81,14 @@ export async function startSession(
     const providers = loaded.providers
       .map((ext) => ext.provider!)
       .filter(Boolean);
-    artifacts = await resolveArtifacts(airJsonPath, { providers });
+    const providerOptions: Record<string, unknown> = {};
+    if (options?.gitProtocol !== undefined) {
+      providerOptions.gitProtocol = options.gitProtocol;
+    }
+    artifacts = await resolveArtifacts(airJsonPath, {
+      providers,
+      providerOptions,
+    });
 
     // Check freshness of provider caches (non-blocking — warnings only)
     warnings = await checkProviderFreshness(airConfig, providers);

--- a/packages/sdk/src/update.ts
+++ b/packages/sdk/src/update.ts
@@ -7,9 +7,11 @@ import {
   loadAirConfig,
   getAirJsonPath,
   getDefaultAirJsonPath,
+  configureProviders,
   type CacheRefreshResult,
   type CatalogProvider,
   type AirExtension,
+  type AirConfig,
 } from "@pulsemcp/air-core";
 import { loadExtensions } from "./extension-loader.js";
 import { resolveEsmEntry } from "./esm-resolve.js";
@@ -50,6 +52,11 @@ export interface UpdateProviderCachesOptions {
    * stub here to simulate upgrade outcomes without touching the network.
    */
   runNpmInstallLatest?: NpmInstallLatest;
+  /**
+   * Git protocol override for git-based catalog providers. Takes precedence
+   * over the `gitProtocol` field in air.json.
+   */
+  gitProtocol?: "ssh" | "https";
 }
 
 export interface UpdateProviderCachesResult {
@@ -375,9 +382,10 @@ export async function updateProviderCaches(
 
   let airJsonDir: string | null = null;
   let extensionSpecs: string[] = [];
+  let airConfig: AirConfig | undefined;
   if (airJsonPath) {
     airJsonDir = dirname(resolve(airJsonPath));
-    const airConfig = loadAirConfig(airJsonPath);
+    airConfig = loadAirConfig(airJsonPath);
     extensionSpecs = airConfig.extensions ?? [];
   }
 
@@ -426,6 +434,22 @@ export async function updateProviderCaches(
     if (provider) {
       providers.set(scheme, provider);
     }
+  }
+
+  // Thread gitProtocol (from air.json and/or caller override) into every
+  // loaded provider before we exercise any of them. This must happen after
+  // auto-heal (which re-imports newer provider modules) so the freshly
+  // loaded instance receives the same runtime configuration.
+  const providerOverride: Record<string, unknown> = {};
+  if (options?.gitProtocol !== undefined) {
+    providerOverride.gitProtocol = options.gitProtocol;
+  }
+  if (airConfig || Object.keys(providerOverride).length > 0) {
+    configureProviders(
+      Array.from(providers.values()),
+      airConfig ?? { name: "__transient__" },
+      providerOverride
+    );
   }
 
   // Index pre-flight outcomes by scheme so we can prepend the upgrade

--- a/schemas/air.schema.json
+++ b/schemas/air.schema.json
@@ -60,6 +60,11 @@
       "type": "array",
       "items": { "type": "string" },
       "description": "Paths to hooks index files. Merged in order — later entries override earlier ones by ID."
+    },
+    "gitProtocol": {
+      "type": "string",
+      "enum": ["ssh", "https"],
+      "description": "Protocol to use when git-based catalog providers clone remote repositories. Defaults to \"ssh\". Set to \"https\" for environments without SSH keys (public CI, corporate networks) or when you rely on token-based authentication (e.g. AIR_GITHUB_TOKEN). A CLI --git-protocol flag, if supported by the command, overrides this value."
     }
   },
   "required": ["name"],


### PR DESCRIPTION
## Summary

Makes SSH the default for all git-based catalog providers (currently just `@pulsemcp/air-provider-github`), with opt-in surfaces for HTTPS. Piggybacks on the SSH keys engineers already have registered with GitHub so clones work out of the box for public **and** private repos — no token required.

This is a **breaking change** for anyone currently relying on the implicit HTTPS+`AIR_GITHUB_TOKEN` behavior. Migration is a one-line `air.json` addition (`"gitProtocol": "https"`), env var (`AIR_GIT_PROTOCOL=https`), or per-invocation flag (`--git-protocol=https`).

## Design

Three opt-in surfaces for HTTPS, with clear precedence (highest wins):

1. `--git-protocol <ssh|https>` CLI flag on `air start`, `air prepare`, `air update`
2. `AIR_GIT_PROTOCOL` env var
3. `gitProtocol: "ssh" | "https"` field in `air.json`
4. Default: `"ssh"`

`AIR_GITHUB_TOKEN` is only consumed when protocol resolves to HTTPS; ignored under SSH (which uses configured keys).

Wiring:
- `CatalogProvider` gets an optional `configure(options)` method so already-instantiated providers can receive runtime options without re-instantiation. Core calls `configureProviders()` before any resolve/refresh.
- Core: `AirConfig.gitProtocol` added to schema + type, `ResolveOptions.providerOptions` threads runtime options down.
- SDK: `PrepareSessionOptions` / `StartSessionOptions` / `UpdateOptions` all accept `gitProtocol`.
- CLI: shared `parseGitProtocolFlag` helper validates and exits cleanly on invalid values.
- GitHub provider: `buildCloneUrl` respects the resolved protocol; non-tokenized `buildPublicUrl` used in error messages so tokens never leak.

## Verification

Captured URL strings from manual E2E (provider's `buildCloneUrl` for `pulsemcp/air` / `main`):

| Scenario | Resolved protocol | URL |
|----------|-------------------|-----|
| Default (no config, no env, no flag) | `ssh` | `git@github.com:pulsemcp/air.git` |
| `gitProtocol: "https"` in air.json | `https` | `https://github.com/pulsemcp/air.git` |
| `gitProtocol: "https"` + `AIR_GITHUB_TOKEN` | `https` | `https://ghp_REDACTED@github.com/pulsemcp/air.git` |
| `AIR_GIT_PROTOCOL=https` | `https` | `https://github.com/pulsemcp/air.git` |
| `AIR_GIT_PROTOCOL=ssh` overriding `https` config | `ssh` | `git@github.com:pulsemcp/air.git` |
| `--git-protocol=https` overriding all | `https` | `https://github.com/pulsemcp/air.git` |
| `--git-protocol=ssh` overriding `https` env | `ssh` | `git@github.com:pulsemcp/air.git` |
| SSH + `AIR_GITHUB_TOKEN` (token ignored) | `ssh` | `git@github.com:pulsemcp/air.git` |

**Before:** `https://github.com/pulsemcp/air.git` (anonymous) or `https://ghp_xxx@github.com/pulsemcp/air.git` (with token) — always.
**After:** `git@github.com:pulsemcp/air.git` by default; HTTPS available via three opt-in surfaces.

## Tests

- 11 new tests in `packages/extensions/provider-github/tests/github-provider.test.ts` covering: SSH default, SSH-ignores-token, HTTPS via constructor, HTTPS+token injection, env var, invalid env fallback, constructor-over-env precedence, `configure()` override, `configure()` no-op for missing/invalid keys, URL formatting across owner/repo shapes
- Existing integration test updated to call `provider.configure({ gitProtocol: 'https' })` so CI (no SSH keys) still runs
- Full suite: 567/567 passing

## Docs

Updated:
- `docs/guides/understanding-air-json.md` — `gitProtocol` field documented in Optional table + example
- `docs/guides/extensions.md` — new **Protocol** section covering default, opt-in surfaces, precedence, token handling
- `docs/configuration.md` — new **Git Protocol** section with rationale and precedence list
- `docs/cli.md` — `--git-protocol` flag row + `AIR_GIT_PROTOCOL` / `AIR_GITHUB_TOKEN` env vars
- `packages/extensions/provider-github/AGENTS.md` — rewritten to reflect actual git-clone implementation and protocol handling

## Version bump

All 8 workspace packages bumped to **0.0.35** with internal dep refs, CLI hardcoded `.version()`, lockfile, and CHANGELOG entry (`Added` + `Changed`/Breaking).

## Migration for HTTPS users

If you were relying on the previous HTTPS default with `AIR_GITHUB_TOKEN`:

```json
{
  \"gitProtocol\": \"https\"
}
```

Or:

```bash
export AIR_GIT_PROTOCOL=https
```

Or per-invocation:

```bash
air start claude --git-protocol=https
```

## Test plan

- [x] Unit tests pass (567/567)
- [x] Manual E2E for all 8 precedence scenarios captured above
- [x] Docs and CHANGELOG updated
- [x] Version bump across all 8 packages + lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)