### PR TITLE
feat: show local .claude/skills as read-only in TUI (v0.0.36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.36] - 2026-04-24
+
+### Added
+- New optional `listLocalArtifacts(targetDir)` method on the `AgentAdapter` interface. Adapters that implement it can surface filesystem-discovered artifacts that live outside AIR's control (e.g. skills committed under `.claude/skills/`). Core exposes corresponding `LocalArtifacts` and `LocalSkillEntry` types.
+- `@pulsemcp/air-adapter-claude` now implements `listLocalArtifacts` by scanning the target directory's `.claude/skills/` tree and parsing each `SKILL.md`'s YAML frontmatter for a description.
+- `startSession()` in `@pulsemcp/air-sdk` now returns the discovered `localArtifacts` when the adapter supports scanning. A new `localScanDir` option controls the scan directory (defaults to `process.cwd()`, pass `null` to disable).
+- `air start` TUI now shows local skills (those committed under `.claude/skills/`) as read-only entries marked with a 🔒 icon. They are always active and cannot be toggled off — space, `a`, `n`, and `o` skip read-only items. A footer hint explains how to disable one (remove the directory in the repo). When a local skill's ID collides with a catalog skill, the catalog entry is replaced by the read-only local entry in the TUI.
+
 ## [0.0.35] - 2026-04-23
 
 ### Added

--- a/docs/guides/managing-skills.md
+++ b/docs/guides/managing-skills.md
@@ -174,6 +174,16 @@ When you run `air start` or `air prepare`, the adapter:
 3. Copies any referenced documents into `references/` within the skill directory
 4. Skills already present in the workspace are not overwritten (local takes priority)
 
+### Local skills tracked in the repo
+
+If your repository already contains skills under `.claude/skills/` (for example, skills you've committed and want every contributor to use), AIR never deletes them. The Claude adapter scans `.claude/skills/` at session start and surfaces each skill it finds in the `air start` TUI marked with a 🔒 icon:
+
+- **Always active.** Local skills are available to the agent regardless of AIR selection state — the adapter's "local wins" rule means they won't be overwritten by catalog entries.
+- **Read-only in the TUI.** You cannot toggle a local skill off from `air start`. Space, `a`, `n`, and `o` all skip read-only items.
+- **Disable by removing the directory.** To stop activating a local skill, delete or move its directory under `.claude/skills/`. A catalog version with the same ID can then be selected normally.
+
+If a local skill's ID matches a catalog skill, the catalog entry is replaced in the TUI by the read-only local entry (since the adapter would not write the catalog version anyway).
+
 ### Selecting specific skills
 
 Add or remove skills when running `air prepare`:

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -34,6 +34,8 @@ When run in a TTY, `air start` opens an interactive terminal UI where you can:
 
 The footer shows a cross-artifact selection summary so you can see what's selected across all types.
 
+Skills that are already checked into the working directory under `.claude/skills/` show up in the Skills tab with a 🔒 marker and cannot be toggled. They're always active (the adapter never overwrites them). To disable one, remove or move its directory in the repo. See [Local skills tracked in the repo](managing-skills.md#local-skills-tracked-in-the-repo) for details.
+
 When not in a TTY (e.g., in a CI pipeline) or when `--skip-confirmation` is passed, the TUI is skipped and the agent launches with root defaults.
 
 ### Non-interactive selection

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1776951468-da632d7b",
+  "name": "air-main-1776986711-a9bbd037",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -847,9 +847,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.35",
+        "@pulsemcp/air-sdk": "0.0.36",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -868,7 +868,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -884,9 +884,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.35"
+        "@pulsemcp/air-core": "0.0.36"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -899,9 +899,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.35"
+        "@pulsemcp/air-core": "0.0.36"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -914,9 +914,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.35"
+        "@pulsemcp/air-core": "0.0.36"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -929,9 +929,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.35"
+        "@pulsemcp/air-core": "0.0.36"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -944,9 +944,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.35"
+        "@pulsemcp/air-core": "0.0.36"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -959,9 +959,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.35"
+        "@pulsemcp/air-core": "0.0.36"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.35",
+    "@pulsemcp/air-sdk": "0.0.36",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -221,7 +221,8 @@ export function startCommand(): Command {
             root,
             rootId,
             rootAutoDetected,
-            skipSubagentMerge
+            skipSubagentMerge,
+            result.localArtifacts
           );
 
           if (!tuiResult) {

--- a/packages/cli/src/tui/interactive-selector.ts
+++ b/packages/cli/src/tui/interactive-selector.ts
@@ -1,5 +1,9 @@
 import * as readline from "readline";
-import type { ResolvedArtifacts, RootEntry } from "@pulsemcp/air-sdk";
+import type {
+  LocalArtifacts,
+  ResolvedArtifacts,
+  RootEntry,
+} from "@pulsemcp/air-sdk";
 import {
   buildInitialState,
   getSelectedIds,
@@ -75,9 +79,17 @@ export async function runInteractiveSelector(
   root?: RootEntry,
   rootId?: string,
   rootAutoDetected = false,
-  skipSubagentMerge = false
+  skipSubagentMerge = false,
+  localArtifacts?: LocalArtifacts
 ): Promise<TuiResult | null> {
-  const state = buildInitialState(artifacts, root, rootId, rootAutoDetected, skipSubagentMerge);
+  const state = buildInitialState(
+    artifacts,
+    root,
+    rootId,
+    rootAutoDetected,
+    skipSubagentMerge,
+    localArtifacts
+  );
 
   if (state.tabs.length === 0) {
     return getSelectedIds(state);
@@ -187,7 +199,7 @@ export async function runInteractiveSelector(
             const item = state.items[activeCat].find(
               (i) => i.id === targetId
             );
-            if (item) item.selected = !item.selected;
+            if (item && !item.readOnly) item.selected = !item.selected;
           }
           draw(state);
           return;
@@ -261,27 +273,37 @@ export async function runInteractiveSelector(
 
       if (key.name === "space" && items.length > 0) {
         const idx = state.cursors[activeCat];
-        items[idx].selected = !items[idx].selected;
+        if (!items[idx].readOnly) {
+          items[idx].selected = !items[idx].selected;
+        }
         draw(state);
         return;
       }
 
       if (str === "a") {
-        for (const item of items) item.selected = true;
+        for (const item of items) {
+          if (!item.readOnly) item.selected = true;
+        }
         draw(state);
         return;
       }
 
       if (str === "n") {
-        for (const item of items) item.selected = false;
+        for (const item of items) {
+          if (!item.readOnly) item.selected = false;
+        }
         draw(state);
         return;
       }
 
       if (str === "o" && items.length > 0) {
         const idx = state.cursors[activeCat];
-        for (const item of items) item.selected = false;
-        items[idx].selected = true;
+        if (!items[idx].readOnly) {
+          for (const item of items) {
+            if (!item.readOnly) item.selected = false;
+          }
+          items[idx].selected = true;
+        }
         draw(state);
         return;
       }

--- a/packages/cli/src/tui/render.ts
+++ b/packages/cli/src/tui/render.ts
@@ -61,6 +61,15 @@ export function render(state: TuiState, viewportHeight: number): string[] {
 
   if (activeCat && !isOverridable) {
     lines.push(chalk.dim("  (read-only \u2014 override not yet supported)"));
+  } else if (
+    activeCat === "skills" &&
+    visibleItems.some((it) => it.readOnly)
+  ) {
+    lines.push(
+      chalk.dim(
+        "  \ud83d\udd12 local skills are tracked in this repo \u2014 remove the directory to disable"
+      )
+    );
   }
 
   if (visibleItems.length === 0) {
@@ -171,11 +180,18 @@ function renderItem(
   isCursor: boolean,
   isOverridable: boolean
 ): string {
-  const marker = item.selected ? chalk.green("●") : chalk.dim("○");
+  const marker = item.readOnly
+    ? chalk.cyan("🔒")
+    : item.selected
+      ? chalk.green("●")
+      : chalk.dim("○");
 
   let id: string;
   let desc: string;
-  if (!isOverridable) {
+  if (item.readOnly) {
+    id = chalk.cyan(item.id);
+    desc = chalk.dim(` — ${truncate(item.description, 60)}`);
+  } else if (!isOverridable) {
     id = chalk.dim(item.id);
     desc = chalk.dim(` — ${truncate(item.description, 60)}`);
   } else if (item.selected) {

--- a/packages/cli/src/tui/types.ts
+++ b/packages/cli/src/tui/types.ts
@@ -1,4 +1,8 @@
-import type { ResolvedArtifacts, RootEntry } from "@pulsemcp/air-sdk";
+import type {
+  LocalArtifacts,
+  ResolvedArtifacts,
+  RootEntry,
+} from "@pulsemcp/air-sdk";
 
 export type ArtifactCategory = "mcp" | "skills" | "hooks" | "plugins";
 
@@ -6,6 +10,13 @@ export interface ArtifactItem {
   id: string;
   description: string;
   selected: boolean;
+  /**
+   * Locally-tracked artifacts (e.g. skills checked into `.claude/skills/`)
+   * are always active from the agent's perspective. They show up in the TUI
+   * for visibility but cannot be toggled here — to disable, the user must
+   * remove or move the directory in their repo.
+   */
+  readOnly?: boolean;
 }
 
 export interface TuiState {
@@ -103,7 +114,8 @@ export function buildInitialState(
   root?: RootEntry,
   rootId?: string,
   rootAutoDetected = false,
-  skipSubagentMerge = false
+  skipSubagentMerge = false,
+  localArtifacts?: LocalArtifacts
 ): TuiState {
   const buildItems = (
     entries: Record<string, { description?: string; title?: string }>,
@@ -136,7 +148,10 @@ export function buildInitialState(
 
   const items: Record<ArtifactCategory, ArtifactItem[]> = {
     mcp: buildItems(artifacts.mcp, mcpDefaults),
-    skills: buildItems(artifacts.skills, skillDefaults),
+    skills: mergeLocalSkills(
+      buildItems(artifacts.skills, skillDefaults),
+      localArtifacts?.skills ?? []
+    ),
     hooks: buildItems(artifacts.hooks, hookDefaults),
     plugins: buildItems(artifacts.plugins, pluginDefaults),
   };
@@ -163,20 +178,53 @@ export function buildInitialState(
 }
 
 export function getSelectedIds(state: TuiState): TuiResult {
+  // Read-only items (e.g. local skills already in `.claude/skills/`) are
+  // excluded — they're not part of AIR's override set, and some may have
+  // IDs that don't exist in `artifacts.skills`, which would fail validation
+  // downstream.
+  const pickSelected = (items: ArtifactItem[]): string[] =>
+    items.filter((i) => i.selected && !i.readOnly).map((i) => i.id);
+
   return {
-    mcpServers: state.items.mcp
-      .filter((i) => i.selected)
-      .map((i) => i.id),
-    skills: state.items.skills
-      .filter((i) => i.selected)
-      .map((i) => i.id),
-    hooks: state.items.hooks
-      .filter((i) => i.selected)
-      .map((i) => i.id),
-    plugins: state.items.plugins
-      .filter((i) => i.selected)
-      .map((i) => i.id),
+    mcpServers: pickSelected(state.items.mcp),
+    skills: pickSelected(state.items.skills),
+    hooks: pickSelected(state.items.hooks),
+    plugins: pickSelected(state.items.plugins),
   };
+}
+
+/**
+ * Fold local skills (checked into `.claude/skills/`) into the skills list.
+ * If a local skill's ID matches a catalog skill, replace the catalog entry
+ * with a read-only marker (the adapter's "local wins" rule means the
+ * catalog version won't be written anyway). Local skills with no catalog
+ * counterpart are appended as standalone read-only entries.
+ */
+function mergeLocalSkills(
+  catalogItems: ArtifactItem[],
+  localSkills: { id: string; title?: string; description: string }[]
+): ArtifactItem[] {
+  if (localSkills.length === 0) return catalogItems;
+
+  const byId = new Map(catalogItems.map((it) => [it.id, it]));
+
+  for (const local of localSkills) {
+    const description = local.description || local.title || "(local skill)";
+    const existing = byId.get(local.id);
+    if (existing) {
+      existing.readOnly = true;
+      existing.selected = true;
+    } else {
+      byId.set(local.id, {
+        id: local.id,
+        description,
+        selected: true,
+        readOnly: true,
+      });
+    }
+  }
+
+  return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
 }
 
 /** Get selection summary across all artifact types */

--- a/packages/cli/tests/tui-render.test.ts
+++ b/packages/cli/tests/tui-render.test.ts
@@ -172,6 +172,44 @@ describe("render legend", () => {
     expect(legend).toContain("only");
   });
 
+  it("renders a read-only hint and lock marker for local skills", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        skills: {
+          "catalog-skill": {
+            description: "Catalog skill",
+            path: "/skills/catalog-skill",
+          },
+        },
+      }),
+      undefined,
+      undefined,
+      false,
+      false,
+      {
+        skills: [
+          {
+            id: "local-skill",
+            description: "Local skill",
+            path: "/repo/.claude/skills/local-skill",
+          },
+        ],
+      }
+    );
+    // Skills tab is present, make it active
+    state.activeTab = state.tabs.indexOf("skills");
+
+    const lines = render(state, 10).map(stripAnsi);
+    const hint = lines.find((l) =>
+      l.includes("local skills are tracked in this repo")
+    );
+    expect(hint).toBeDefined();
+
+    const localLine = lines.find((l) => l.includes("local-skill"));
+    expect(localLine).toBeDefined();
+    expect(localLine).toContain("\u{1f512}");
+  });
+
   it("shows Space toggle in search mode on hooks tab (now overridable)", () => {
     const state = buildInitialState(
       makeArtifacts({

--- a/packages/cli/tests/tui-state.test.ts
+++ b/packages/cli/tests/tui-state.test.ts
@@ -461,6 +461,128 @@ describe("getMergedDefaults", () => {
   });
 });
 
+describe("buildInitialState with local skills", () => {
+  it("marks catalog skills that collide with a local skill as readOnly+selected", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        skills: {
+          "shared-skill": {
+            description: "Catalog version",
+            path: "/skills/shared",
+          },
+          "catalog-only": {
+            description: "Catalog only",
+            path: "/skills/catalog-only",
+          },
+        },
+      }),
+      undefined,
+      undefined,
+      false,
+      false,
+      {
+        skills: [
+          {
+            id: "shared-skill",
+            description: "Local version",
+            path: "/repo/.claude/skills/shared-skill",
+          },
+        ],
+      }
+    );
+
+    const shared = state.items.skills.find((i) => i.id === "shared-skill");
+    expect(shared?.readOnly).toBe(true);
+    expect(shared?.selected).toBe(true);
+
+    const catalogOnly = state.items.skills.find((i) => i.id === "catalog-only");
+    expect(catalogOnly?.readOnly).toBeFalsy();
+  });
+
+  it("appends local-only skills as readOnly+selected entries", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        skills: {
+          catalog: { description: "Catalog skill", path: "/skills/catalog" },
+        },
+      }),
+      undefined,
+      undefined,
+      false,
+      false,
+      {
+        skills: [
+          {
+            id: "local-only",
+            description: "A local skill",
+            path: "/repo/.claude/skills/local-only",
+          },
+        ],
+      }
+    );
+
+    const ids = state.items.skills.map((i) => i.id);
+    expect(ids).toEqual(["catalog", "local-only"]);
+
+    const local = state.items.skills.find((i) => i.id === "local-only");
+    expect(local?.readOnly).toBe(true);
+    expect(local?.selected).toBe(true);
+    expect(local?.description).toBe("A local skill");
+  });
+
+  it("excludes readOnly items from getSelectedIds output", () => {
+    const state = buildInitialState(
+      makeArtifacts({
+        skills: {
+          "catalog-skill": {
+            description: "Catalog skill",
+            path: "/skills/catalog-skill",
+          },
+        },
+      }),
+      { description: "r", default_skills: ["catalog-skill"] },
+      "r",
+      false,
+      false,
+      {
+        skills: [
+          {
+            id: "local-only",
+            description: "Local",
+            path: "/repo/.claude/skills/local-only",
+          },
+        ],
+      }
+    );
+
+    const result = getSelectedIds(state);
+    expect(result.skills).toEqual(["catalog-skill"]);
+    expect(result.skills).not.toContain("local-only");
+  });
+
+  it("falls back to title when local skill description is empty", () => {
+    const state = buildInitialState(
+      makeArtifacts(),
+      undefined,
+      undefined,
+      false,
+      false,
+      {
+        skills: [
+          {
+            id: "local",
+            description: "",
+            title: "My Title",
+            path: "/repo/.claude/skills/local",
+          },
+        ],
+      }
+    );
+
+    expect(state.items.skills[0].description).toBe("My Title");
+  });
+});
+
 describe("buildInitialState with subagent merge", () => {
   it("pre-selects subagent MCP servers when merge is enabled", () => {
     const state = buildInitialState(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,8 @@ export type {
   PluginEntry,
   RootEntry,
   HookEntry,
+  LocalArtifacts,
+  LocalSkillEntry,
 } from "./types.js";
 
 // Extension interfaces

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -152,6 +152,40 @@ export interface AgentAdapter {
     targetDir: string,
     options?: PrepareSessionOptions
   ): Promise<PreparedSession>;
+
+  /**
+   * Enumerate artifacts that exist in the target directory outside of AIR's
+   * management — e.g. skills checked into `.claude/skills/` in the user's
+   * repository. These are "always on" from the agent's perspective because
+   * the agent discovers them by walking the filesystem; AIR can surface them
+   * to the user (as read-only in the TUI) but must not toggle, overwrite, or
+   * delete them. Adapters that don't have filesystem-discovered artifacts
+   * can omit this method.
+   */
+  listLocalArtifacts?(targetDir: string): Promise<LocalArtifacts>;
+}
+
+/**
+ * Artifacts discovered in the target directory outside of AIR's management.
+ * Currently limited to skills; other artifact types may be added later.
+ */
+export interface LocalArtifacts {
+  skills: LocalSkillEntry[];
+}
+
+/**
+ * A skill discovered on the filesystem in the target directory (e.g. under
+ * `.claude/skills/`), independent of any catalog or `air.json` config.
+ */
+export interface LocalSkillEntry {
+  /** Stable identifier, typically the skill's directory name. */
+  id: string;
+  /** Short human-readable description (pulled from frontmatter if present). */
+  description: string;
+  /** Optional display title (pulled from frontmatter if present). */
+  title?: string;
+  /** Absolute path to the skill's directory. */
+  path: string;
 }
 
 export interface PrepareSessionOptions {

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.35"
+    "@pulsemcp/air-core": "0.0.36"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/adapter-claude/src/claude-adapter.ts
+++ b/packages/extensions/adapter-claude/src/claude-adapter.ts
@@ -20,7 +20,9 @@ import type {
   PluginEntry,
   PrepareSessionOptions,
   PreparedSession,
+  LocalArtifacts,
 } from "@pulsemcp/air-core";
+import { scanLocalSkills } from "./scan-local-skills.js";
 
 export class ClaudeAdapter implements AgentAdapter {
   name = "claude";
@@ -265,6 +267,16 @@ export class ClaudeAdapter implements AgentAdapter {
     }
 
     return { configFiles, skillPaths, hookPaths, startCommand, subagentContext };
+  }
+
+  /**
+   * Enumerate skills checked into `<targetDir>/.claude/skills/`. These are
+   * loaded by Claude Code directly from the filesystem regardless of AIR's
+   * involvement, so they're always active and must not be overwritten or
+   * removed. The TUI uses this list to surface them as read-only entries.
+   */
+  async listLocalArtifacts(targetDir: string): Promise<LocalArtifacts> {
+    return { skills: scanLocalSkills(targetDir) };
   }
 
   /**

--- a/packages/extensions/adapter-claude/src/scan-local-skills.ts
+++ b/packages/extensions/adapter-claude/src/scan-local-skills.ts
@@ -1,0 +1,101 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { join } from "path";
+import type { LocalSkillEntry } from "@pulsemcp/air-core";
+
+/**
+ * Scan `<targetDir>/.claude/skills/` for user-managed skills and return
+ * one entry per directory containing a `SKILL.md`. Missing or unreadable
+ * directories yield an empty list — this is a best-effort informational
+ * scan, not a validation step.
+ */
+export function scanLocalSkills(targetDir: string): LocalSkillEntry[] {
+  const skillsDir = join(targetDir, ".claude", "skills");
+  if (!existsSync(skillsDir)) return [];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(skillsDir);
+  } catch {
+    return [];
+  }
+
+  const skills: LocalSkillEntry[] = [];
+  for (const name of entries) {
+    if (name.startsWith(".")) continue;
+
+    const skillDir = join(skillsDir, name);
+    let isDir = false;
+    try {
+      isDir = statSync(skillDir).isDirectory();
+    } catch {
+      continue;
+    }
+    if (!isDir) continue;
+
+    const skillMdPath = join(skillDir, "SKILL.md");
+    if (!existsSync(skillMdPath)) continue;
+
+    const frontmatter = readFrontmatter(skillMdPath);
+    const description =
+      pickString(frontmatter, "description") ?? "(local skill — no description)";
+    const title =
+      pickString(frontmatter, "title") ?? pickString(frontmatter, "name");
+
+    skills.push({
+      id: name,
+      description,
+      title,
+      path: skillDir,
+    });
+  }
+
+  skills.sort((a, b) => a.id.localeCompare(b.id));
+  return skills;
+}
+
+/**
+ * Minimal YAML frontmatter reader — parses a leading block delimited by
+ * `---` lines into a flat key/value map. Only handles top-level
+ * `key: value` scalars, which is all SKILL.md frontmatter needs in
+ * practice. Unquoted values have surrounding whitespace trimmed and
+ * matching single/double quotes stripped.
+ */
+function readFrontmatter(path: string): Record<string, string> {
+  let content: string;
+  try {
+    content = readFileSync(path, "utf-8");
+  } catch {
+    return {};
+  }
+
+  const lines = content.split(/\r?\n/);
+  if (lines[0]?.trim() !== "---") return {};
+
+  const result: Record<string, string> = {};
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "---") return result;
+
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$/);
+    if (!match) continue;
+
+    const key = match[1];
+    let value = match[2].trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    result[key] = value;
+  }
+  return {};
+}
+
+function pickString(
+  obj: Record<string, string>,
+  key: string
+): string | undefined {
+  const v = obj[key];
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}

--- a/packages/extensions/adapter-claude/tests/scan-local-skills.test.ts
+++ b/packages/extensions/adapter-claude/tests/scan-local-skills.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { scanLocalSkills } from "../src/scan-local-skills.js";
+
+function createTempDir(): string {
+  const dir = join(
+    tmpdir(),
+    `air-scan-skills-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("scanLocalSkills", () => {
+  const cleanup: string[] = [];
+  afterEach(() => {
+    for (const dir of cleanup) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    cleanup.length = 0;
+  });
+
+  it("returns empty list when .claude/skills does not exist", () => {
+    const dir = createTempDir();
+    cleanup.push(dir);
+    expect(scanLocalSkills(dir)).toEqual([]);
+  });
+
+  it("returns empty list when the target directory does not exist", () => {
+    expect(
+      scanLocalSkills(join(tmpdir(), `air-nonexistent-${Date.now()}`))
+    ).toEqual([]);
+  });
+
+  it("discovers each subdirectory that contains SKILL.md", () => {
+    const dir = createTempDir();
+    cleanup.push(dir);
+    const skillsDir = join(dir, ".claude", "skills");
+    mkdirSync(join(skillsDir, "alpha"), { recursive: true });
+    mkdirSync(join(skillsDir, "beta"), { recursive: true });
+    writeFileSync(
+      join(skillsDir, "alpha", "SKILL.md"),
+      "---\ndescription: Alpha skill\n---\nbody"
+    );
+    writeFileSync(
+      join(skillsDir, "beta", "SKILL.md"),
+      "---\ndescription: Beta skill\n---\nbody"
+    );
+
+    const result = scanLocalSkills(dir);
+    expect(result.map((s) => s.id)).toEqual(["alpha", "beta"]);
+    expect(result[0].description).toBe("Alpha skill");
+    expect(result[1].description).toBe("Beta skill");
+    expect(result[0].path).toBe(join(skillsDir, "alpha"));
+  });
+
+  it("skips directories that do not contain a SKILL.md", () => {
+    const dir = createTempDir();
+    cleanup.push(dir);
+    const skillsDir = join(dir, ".claude", "skills");
+    mkdirSync(join(skillsDir, "with-md"), { recursive: true });
+    mkdirSync(join(skillsDir, "without-md"), { recursive: true });
+    writeFileSync(
+      join(skillsDir, "with-md", "SKILL.md"),
+      "---\ndescription: Present\n---\nbody"
+    );
+
+    const result = scanLocalSkills(dir);
+    expect(result.map((s) => s.id)).toEqual(["with-md"]);
+  });
+
+  it("skips dotfiles in .claude/skills/", () => {
+    const dir = createTempDir();
+    cleanup.push(dir);
+    const skillsDir = join(dir, ".claude", "skills");
+    mkdirSync(join(skillsDir, ".hidden"), { recursive: true });
+    writeFileSync(
+      join(skillsDir, ".hidden", "SKILL.md"),
+      "---\ndescription: Hidden\n---\n"
+    );
+
+    expect(scanLocalSkills(dir)).toEqual([]);
+  });
+
+  it("falls back to a placeholder description when frontmatter is missing", () => {
+    const dir = createTempDir();
+    cleanup.push(dir);
+    const skillsDir = join(dir, ".claude", "skills");
+    mkdirSync(join(skillsDir, "no-meta"), { recursive: true });
+    writeFileSync(
+      join(skillsDir, "no-meta", "SKILL.md"),
+      "no frontmatter at all"
+    );
+
+    const result = scanLocalSkills(dir);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("no-meta");
+    expect(result[0].description).toBe("(local skill — no description)");
+  });
+
+  it("strips matching quotes from frontmatter values", () => {
+    const dir = createTempDir();
+    cleanup.push(dir);
+    const skillsDir = join(dir, ".claude", "skills");
+    mkdirSync(join(skillsDir, "quoted"), { recursive: true });
+    writeFileSync(
+      join(skillsDir, "quoted", "SKILL.md"),
+      `---\ndescription: "A quoted description"\ntitle: 'Quoted Title'\n---\n`
+    );
+
+    const result = scanLocalSkills(dir);
+    expect(result[0].description).toBe("A quoted description");
+    expect(result[0].title).toBe("Quoted Title");
+  });
+
+  it("sorts results alphabetically by id", () => {
+    const dir = createTempDir();
+    cleanup.push(dir);
+    const skillsDir = join(dir, ".claude", "skills");
+    for (const id of ["zulu", "alpha", "mike"]) {
+      mkdirSync(join(skillsDir, id), { recursive: true });
+      writeFileSync(
+        join(skillsDir, id, "SKILL.md"),
+        "---\ndescription: x\n---\n"
+      );
+    }
+
+    const result = scanLocalSkills(dir);
+    expect(result.map((s) => s.id)).toEqual(["alpha", "mike", "zulu"]);
+  });
+});

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.35"
+    "@pulsemcp/air-core": "0.0.36"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.35"
+    "@pulsemcp/air-core": "0.0.36"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.35"
+    "@pulsemcp/air-core": "0.0.36"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.35"
+    "@pulsemcp/air-core": "0.0.36"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.35"
+    "@pulsemcp/air-core": "0.0.36"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -51,6 +51,8 @@ export type {
   StartCommand,
   PrepareSessionOptions as CorePrepareSessionOptions,
   PreparedSession,
+  LocalArtifacts,
+  LocalSkillEntry,
   // Validation types
   ValidationResult,
   ValidationError,

--- a/packages/sdk/src/start.ts
+++ b/packages/sdk/src/start.ts
@@ -8,6 +8,7 @@ import {
   type RootEntry,
   type AgentSessionConfig,
   type StartCommand,
+  type LocalArtifacts,
 } from "@pulsemcp/air-core";
 import { findAdapter, listAvailableAdapters } from "./adapter-registry.js";
 import { loadExtensions } from "./extension-loader.js";
@@ -25,6 +26,12 @@ export interface StartSessionOptions {
    * over the `gitProtocol` field in air.json.
    */
   gitProtocol?: "ssh" | "https";
+  /**
+   * Directory to scan for adapter-owned local artifacts (e.g. skills
+   * checked into `.claude/skills/`). Defaults to `process.cwd()`. Set to
+   * `null` to skip the local scan entirely.
+   */
+  localScanDir?: string | null;
 }
 
 export interface StartSessionResult {
@@ -42,6 +49,13 @@ export interface StartSessionResult {
   adapterDisplayName: string;
   /** Warnings from provider cache freshness checks (e.g., stale GitHub clones). */
   warnings?: string[];
+  /**
+   * Artifacts discovered in the target directory outside of AIR's
+   * management (e.g. skills checked into `.claude/skills/`). Populated
+   * when the adapter implements `listLocalArtifacts` and `localScanDir`
+   * is not set to `null`.
+   */
+  localArtifacts?: LocalArtifacts;
 }
 
 /**
@@ -128,6 +142,16 @@ export async function startSession(
     : undefined;
   const startCommand = adapter.buildStartCommand(sessionConfig);
 
+  let localArtifacts: LocalArtifacts | undefined;
+  if (options?.localScanDir !== null && adapter.listLocalArtifacts) {
+    const scanDir = options?.localScanDir ?? process.cwd();
+    try {
+      localArtifacts = await adapter.listLocalArtifacts(scanDir);
+    } catch {
+      // Best-effort scan — a failure here must not break session startup.
+    }
+  }
+
   return {
     artifacts,
     root,
@@ -136,5 +160,6 @@ export async function startSession(
     startCommand,
     adapterDisplayName: adapter.displayName,
     warnings: warnings.length > 0 ? warnings : undefined,
+    localArtifacts,
   };
 }


### PR DESCRIPTION
## Summary

- Adds an optional `listLocalArtifacts(targetDir)` method on `AgentAdapter` (core) and implements it in the Claude adapter by scanning `.claude/skills/` for any `SKILL.md` the user has committed.
- `startSession()` surfaces those entries as `localArtifacts` on its result; `air start`'s TUI renders them in the Skills tab with a 🔒 marker and skips them on space / `a` / `n` / `o` toggles. A footer hint tells the user to remove the directory to disable.
- Read-only items are excluded from the override set the TUI sends to `prepareSession` so we don't try to validate a local-only ID against the catalog.

Rationale: AIR is already additive-only — it never overwrites local skills. The TUI was the missing piece — users couldn't see what was already active.

The companion "auto-discover repo-level AIR index files" feature is tracked separately in #97.

## Test plan

- [x] Unit tests for the scanner (scan-local-skills.test.ts) — discovery, SKILL.md required, dotfile skip, description fallback, quote stripping, sort order.
- [x] Unit tests for mergeLocalSkills + getSelectedIds — collision with catalog, local-only append, read-only exclusion from overrides, title fallback.
- [x] Render test confirms the footer hint and lock marker show up on the Skills tab.
- [x] Full `npx vitest run` — 586 tests pass.
- [x] Version bump across all 8 packages to v0.0.36 + lockfile + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)