### PR TITLE
feat(cli): add air resolve --json command (v0.0.37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.37] - 2026-04-24
+
+### Added
+- New `air resolve --json` CLI command that loads the active `air.json` (respecting `AIR_CONFIG`), runs configured catalog providers, and prints the full merged `ResolvedArtifacts` tree to stdout as JSON. Enables non-Node consumers (Ruby apps, dashboards, orchestrators) to inspect the resolved artifact tree without reimplementing resolution, providers, or `catalogs` / `gitProtocol` handling.
+- New `resolveFullArtifacts()` helper in `@pulsemcp/air-sdk` that wires provider loading to `resolveArtifacts()`. Used internally by `air resolve --json`; also the programmatic entry point for the same behavior.
+
 ## [0.0.36] - 2026-04-24
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -120,6 +120,50 @@ air list references
 
 Shows ID, title (if available), and description for each artifact. Shows the merged result from all files listed in `air.json`.
 
+### `air resolve --json`
+
+Resolve the active `air.json` and print the full merged artifact tree as JSON to stdout.
+
+```bash
+# Resolve the default ~/.air/air.json
+air resolve --json
+
+# Resolve a specific config
+air resolve --json --config /path/to/air.json
+
+# Via env var
+AIR_CONFIG=/path/to/air.json air resolve --json
+```
+
+Loads `air.json`, runs catalog providers (e.g., `github://`) declared under `extensions`, and emits the merged `ResolvedArtifacts` object — the same structure returned by `resolveArtifacts()` in `@pulsemcp/air-core`. Useful for non-Node consumers (Ruby, Python, orchestrators, dashboards) that need to inspect the resolved artifact tree without reimplementing the resolution pipeline.
+
+**Output shape:**
+
+```json
+{
+  "skills":     { "<id>": { "description": "...", "path": "/abs/path" } },
+  "references": { "<id>": { "description": "...", "path": "/abs/path" } },
+  "mcp":        { "<id>": { "type": "stdio", "command": "...", "args": [] } },
+  "plugins":    { "<id>": { "description": "...", "skills": [], "mcp_servers": [] } },
+  "roots":      { "<id>": { "description": "...", "default_skills": [] } },
+  "hooks":      { "<id>": { "description": "...", "path": "/abs/path" } }
+}
+```
+
+All `path` fields are absolute, making the output self-contained regardless of where the `air.json` lives.
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Emit JSON output (currently the only supported format). |
+| `--config <path>` | Path to `air.json`. Defaults to `AIR_CONFIG` env or `~/.air/air.json`. |
+| `--git-protocol <ssh\|https>` | Protocol used by git-based catalog providers when cloning. Defaults to `ssh`. Overrides the `gitProtocol` field in `air.json` and the `AIR_GIT_PROTOCOL` env var for this invocation. |
+
+**Exit codes:**
+- `0` — resolved successfully; JSON written to stdout
+- `1` — resolution failed (e.g., missing `air.json`, unreachable provider); error on stderr
+
 ## Environment Variables
 
 | Variable | Description |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -122,7 +122,7 @@ Shows ID, title (if available), and description for each artifact. Shows the mer
 
 ### `air resolve --json`
 
-Resolve the active `air.json` and print the full merged artifact tree as JSON to stdout.
+Resolve the active `air.json` and print the full merged artifact tree as JSON to stdout. The `--json` flag is optional (JSON is the default and currently only supported format) — it is accepted for forward compatibility so downstream callers can pin the output format explicitly.
 
 ```bash
 # Resolve the default ~/.air/air.json
@@ -156,7 +156,7 @@ All `path` fields are absolute, making the output self-contained regardless of w
 
 | Flag | Description |
 |------|-------------|
-| `--json` | Emit JSON output (currently the only supported format). |
+| `--json` | Emit JSON output (default and currently the only supported format; accepted for forward-compat). |
 | `--config <path>` | Path to `air.json`. Defaults to `AIR_CONFIG` env or `~/.air/air.json`. |
 | `--git-protocol <ssh\|https>` | Protocol used by git-based catalog providers when cloning. Defaults to `ssh`. Overrides the `gitProtocol` field in `air.json` and the `AIR_GIT_PROTOCOL` env var for this invocation. |
 

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -273,7 +273,7 @@ All `path` fields are absolute, matching what `resolveArtifacts()` returns from 
 | Flag | Description |
 |------|-------------|
 | `--json` | Emit JSON output (currently the only supported format) |
-| `--config <path>` | Path to air.json (default: `~/.air/air.json` or `AIR_CONFIG`) |
+| `--config <path>` | Path to air.json (default: `AIR_CONFIG` env or `~/.air/air.json`) |
 | `--git-protocol <ssh\|https>` | Protocol used by git-based catalog providers when cloning |
 
 ### When to use it

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -238,6 +238,52 @@ air prepare claude --without-hook prevent-secrets-in-context
 air prepare claude --without-defaults --skill deploy-staging --mcp-server github
 ```
 
+## air resolve — inspecting the merged artifact tree
+
+`air resolve --json` loads `air.json`, runs the configured catalog providers, and prints the full merged `ResolvedArtifacts` object to stdout as JSON. It's the read-only companion to `air prepare` for orchestrators, dashboards, and non-Node consumers that need to know *what* artifacts AIR would make available without actually preparing a session.
+
+```bash
+air resolve --json
+```
+
+### What it does
+
+1. Loads `air.json` (respects `AIR_CONFIG` and `--config`, same as `air prepare`)
+2. Loads extensions declared under `extensions` and extracts their catalog providers
+3. Calls `resolveArtifacts()` with those providers — remote URIs like `github://` are resolved in full
+4. Prints the merged `ResolvedArtifacts` JSON to stdout (no filesystem writes)
+
+### Output shape
+
+```json
+{
+  "skills":     { "<id>": { "description": "...", "path": "/abs/path" } },
+  "references": { "<id>": { "description": "...", "path": "/abs/path" } },
+  "mcp":        { "<id>": { "type": "stdio", "command": "...", "args": [] } },
+  "plugins":    { "<id>": { "description": "...", "skills": [], "mcp_servers": [] } },
+  "roots":      { "<id>": { "description": "...", "default_skills": [] } },
+  "hooks":      { "<id>": { "description": "...", "path": "/abs/path" } }
+}
+```
+
+All `path` fields are absolute, matching what `resolveArtifacts()` returns from `@pulsemcp/air-core`. Unused artifact types are emitted as empty objects.
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Emit JSON output (currently the only supported format) |
+| `--config <path>` | Path to air.json (default: `~/.air/air.json` or `AIR_CONFIG`) |
+| `--git-protocol <ssh\|https>` | Protocol used by git-based catalog providers when cloning |
+
+### When to use it
+
+- **Non-Node consumers** (Ruby apps, Python scripts, dashboards) that need the resolved artifact tree without reimplementing composition, providers, or `catalogs` / `gitProtocol` handling
+- **Orchestrators** that show users "what skills/roots are available" before they pick a root for `air prepare`
+- **Debugging** — confirm that `github://` URIs and `catalogs` entries resolve to the expected merged view
+
+For programmatic TypeScript/JavaScript consumers, use `resolveFullArtifacts()` from `@pulsemcp/air-sdk` instead — it returns the same object without spawning a subprocess.
+
 ## air export — building plugin marketplaces
 
 `air export` builds distributable plugin directories from AIR artifacts. It's designed for producing Claude Co-work marketplaces that can be synced via GitHub.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1776986711-a9bbd037",
+  "name": "air-main-1776990967-4abc3610",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -847,9 +847,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.36",
+      "version": "0.0.37",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.36",
+        "@pulsemcp/air-sdk": "0.0.37",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -868,7 +868,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.36",
+      "version": "0.0.37",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -884,9 +884,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.36",
+      "version": "0.0.37",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.36"
+        "@pulsemcp/air-core": "0.0.37"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -899,9 +899,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.0.36",
+      "version": "0.0.37",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.36"
+        "@pulsemcp/air-core": "0.0.37"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -914,9 +914,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.36",
+      "version": "0.0.37",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.36"
+        "@pulsemcp/air-core": "0.0.37"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -929,9 +929,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.36",
+      "version": "0.0.37",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.36"
+        "@pulsemcp/air-core": "0.0.37"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -944,9 +944,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.36",
+      "version": "0.0.37",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.36"
+        "@pulsemcp/air-core": "0.0.37"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -959,9 +959,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.36",
+      "version": "0.0.37",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.36"
+        "@pulsemcp/air-core": "0.0.37"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.36",
+    "@pulsemcp/air-sdk": "0.0.37",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/resolve.ts
+++ b/packages/cli/src/commands/resolve.ts
@@ -13,7 +13,7 @@ export function resolveCommand(): Command {
     )
     .option(
       "--json",
-      "Emit JSON output (currently the only supported format)"
+      "Emit JSON output (default and currently the only supported format; accepted for forward-compat)"
     )
     .option(
       "--git-protocol <protocol>",

--- a/packages/cli/src/commands/resolve.ts
+++ b/packages/cli/src/commands/resolve.ts
@@ -1,0 +1,44 @@
+import { Command } from "commander";
+import { resolveFullArtifacts } from "@pulsemcp/air-sdk";
+import { parseGitProtocolFlag } from "./git-protocol.js";
+
+export function resolveCommand(): Command {
+  const cmd = new Command("resolve")
+    .description(
+      "Resolve the active air.json and print the merged artifact tree as JSON to stdout"
+    )
+    .option(
+      "--config <path>",
+      "Path to air.json (defaults to AIR_CONFIG env or ~/.air/air.json)"
+    )
+    .option(
+      "--json",
+      "Emit JSON output (currently the only supported format)"
+    )
+    .option(
+      "--git-protocol <protocol>",
+      "Protocol used by git-based catalog providers: \"ssh\" (default) or \"https\". Overrides the gitProtocol field in air.json."
+    )
+    .action(
+      async (options: {
+        config?: string;
+        json?: boolean;
+        gitProtocol?: string;
+      }) => {
+        const gitProtocol = parseGitProtocolFlag(options.gitProtocol);
+        try {
+          const artifacts = await resolveFullArtifacts({
+            config: options.config,
+            gitProtocol,
+          });
+          console.log(JSON.stringify(artifacts, null, 2));
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "Unknown error";
+          console.error(`Error: ${message}`);
+          process.exit(1);
+        }
+      }
+    );
+
+  return cmd;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import { installCommand } from "./commands/install.js";
 import { updateCommand } from "./commands/update.js";
 import { upgradeCommand } from "./commands/upgrade.js";
 import { exportCommand } from "./commands/export.js";
+import { resolveCommand } from "./commands/resolve.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json");
@@ -31,5 +32,6 @@ program.addCommand(installCommand());
 program.addCommand(updateCommand());
 program.addCommand(upgradeCommand());
 program.addCommand(exportCommand());
+program.addCommand(resolveCommand());
 
 program.parseAsync();

--- a/packages/cli/tests/resolve-command.test.ts
+++ b/packages/cli/tests/resolve-command.test.ts
@@ -215,6 +215,55 @@ describe("resolve command", () => {
     expect(result.stderr).toContain("Error");
   });
 
+  it("loads extension-provided catalog providers and resolves custom URI schemes", () => {
+    // Stub extension with a catalog provider for a custom `stub://` scheme.
+    // If `resolveFullArtifacts` doesn't load extensions, the URI would fail
+    // with "No catalog provider registered for scheme stub://".
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        extensions: ["./stub-provider-ext.js"],
+        mcp: ["stub://virtual-servers"],
+      },
+      "stub-provider-ext.js": `
+export default {
+  name: "stub-provider-ext",
+  provider: {
+    scheme: "stub",
+    async fileExists() {
+      return true;
+    },
+    async resolve(uri) {
+      // Return synthetic MCP server content so we can assert the provider
+      // was actually invoked (not just loaded).
+      return {
+        "provider-resolved-server": {
+          type: "stdio",
+          command: "echo",
+          args: ["from-stub-provider"],
+        },
+      };
+    },
+    resolveSourceDir() {
+      return "/tmp";
+    },
+  },
+};
+`,
+    });
+
+    const result = tryRun(
+      `resolve --json --config ${join(catalog, "air.json")}`
+    );
+    expect(result.exitCode).toBe(0);
+
+    const output = JSON.parse(result.stdout);
+    expect(output.mcp["provider-resolved-server"]).toBeDefined();
+    expect(output.mcp["provider-resolved-server"].args).toEqual([
+      "from-stub-provider",
+    ]);
+  });
+
   it("expands plugins into their constituent artifacts", () => {
     const catalog = createTemp({
       "air.json": {

--- a/packages/cli/tests/resolve-command.test.ts
+++ b/packages/cli/tests/resolve-command.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { execSync } from "child_process";
+import { resolve, join } from "path";
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+} from "fs";
+import { tmpdir } from "os";
+
+const CLI = resolve(__dirname, "../src/index.ts");
+const run = (args: string, env?: Record<string, string>) =>
+  execSync(`npx tsx ${CLI} ${args}`, {
+    encoding: "utf-8",
+    cwd: resolve(__dirname, "../../.."),
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, ...env },
+  });
+
+const tryRun = (args: string, env?: Record<string, string>) => {
+  try {
+    return { stdout: run(args, env), stderr: "", exitCode: 0 };
+  } catch (err: any) {
+    return {
+      stdout: err.stdout || "",
+      stderr: err.stderr || "",
+      exitCode: err.status,
+    };
+  }
+};
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    if (existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  tempDirs.length = 0;
+});
+
+function createTemp(files: Record<string, unknown>): string {
+  const dir = resolve(
+    tmpdir(),
+    `air-resolve-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  tempDirs.push(dir);
+  for (const [name, content] of Object.entries(files)) {
+    const path = resolve(dir, name);
+    mkdirSync(resolve(path, ".."), { recursive: true });
+    writeFileSync(
+      path,
+      typeof content === "string" ? content : JSON.stringify(content, null, 2)
+    );
+  }
+  return dir;
+}
+
+describe("resolve command", () => {
+  it("prints the merged artifact tree as JSON", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        mcp: ["./mcp.json"],
+        skills: ["./skills.json"],
+        roots: ["./roots.json"],
+      },
+      "mcp.json": {
+        github: {
+          type: "stdio",
+          command: "npx",
+          args: ["-y", "@mcp/github"],
+        },
+      },
+      "skills.json": {
+        "my-skill": {
+          description: "Test skill",
+          path: "skills/my-skill",
+        },
+      },
+      "skills/my-skill/SKILL.md": "# My Skill",
+      "roots.json": {
+        default: {
+          description: "Default root",
+          default_mcp_servers: ["github"],
+          default_skills: ["my-skill"],
+        },
+      },
+    });
+
+    const result = tryRun(
+      `resolve --json --config ${join(catalog, "air.json")}`
+    );
+    expect(result.exitCode).toBe(0);
+
+    const output = JSON.parse(result.stdout);
+
+    // Expected top-level keys for ResolvedArtifacts
+    expect(output).toHaveProperty("skills");
+    expect(output).toHaveProperty("references");
+    expect(output).toHaveProperty("mcp");
+    expect(output).toHaveProperty("plugins");
+    expect(output).toHaveProperty("roots");
+    expect(output).toHaveProperty("hooks");
+
+    // Entries keyed by id
+    expect(output.mcp.github).toBeDefined();
+    expect(output.mcp.github.type).toBe("stdio");
+    expect(output.skills["my-skill"]).toBeDefined();
+    expect(output.roots.default).toBeDefined();
+    expect(output.roots.default.default_mcp_servers).toContain("github");
+  });
+
+  it("returns absolute paths on skill entries", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+      },
+      "skills.json": {
+        "my-skill": {
+          description: "Skill",
+          path: "skills/my-skill",
+        },
+      },
+      "skills/my-skill/SKILL.md": "# Skill",
+    });
+
+    const result = tryRun(
+      `resolve --json --config ${join(catalog, "air.json")}`
+    );
+    expect(result.exitCode).toBe(0);
+
+    const output = JSON.parse(result.stdout);
+    const skillPath = output.skills["my-skill"].path;
+    // Core resolves path fields to absolute paths
+    expect(skillPath.startsWith("/")).toBe(true);
+    expect(skillPath).toContain("skills/my-skill");
+  });
+
+  it("applies later-wins override across multiple index files", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        mcp: ["./base.json", "./override.json"],
+      },
+      "base.json": {
+        github: { type: "stdio", command: "npx", args: ["base-gh"] },
+      },
+      "override.json": {
+        github: { type: "stdio", command: "npx", args: ["override-gh"] },
+      },
+    });
+
+    const result = tryRun(
+      `resolve --json --config ${join(catalog, "air.json")}`
+    );
+    expect(result.exitCode).toBe(0);
+
+    const output = JSON.parse(result.stdout);
+    // Later entry should win by id (full replacement)
+    expect(output.mcp.github.args).toEqual(["override-gh"]);
+  });
+
+  it("respects AIR_CONFIG env var when --config is omitted", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        mcp: ["./mcp.json"],
+      },
+      "mcp.json": {
+        slack: { type: "stdio", command: "npx", args: ["slack-mcp"] },
+      },
+    });
+
+    const result = tryRun(`resolve --json`, {
+      AIR_CONFIG: join(catalog, "air.json"),
+    });
+    expect(result.exitCode).toBe(0);
+
+    const output = JSON.parse(result.stdout);
+    expect(output.mcp.slack).toBeDefined();
+  });
+
+  it("emits empty maps for unused artifact types", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        mcp: ["./mcp.json"],
+      },
+      "mcp.json": {
+        gh: { type: "stdio", command: "npx", args: ["gh"] },
+      },
+    });
+
+    const result = tryRun(
+      `resolve --json --config ${join(catalog, "air.json")}`
+    );
+    expect(result.exitCode).toBe(0);
+
+    const output = JSON.parse(result.stdout);
+    expect(output.skills).toEqual({});
+    expect(output.references).toEqual({});
+    expect(output.plugins).toEqual({});
+    expect(output.roots).toEqual({});
+    expect(output.hooks).toEqual({});
+  });
+
+  it("fails gracefully when air.json is missing", () => {
+    const result = tryRun(`resolve --json --config /nonexistent/air.json`);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("Error");
+  });
+
+  it("expands plugins into their constituent artifacts", () => {
+    const catalog = createTemp({
+      "air.json": {
+        name: "test",
+        mcp: ["./mcp.json"],
+        skills: ["./skills.json"],
+        plugins: ["./plugins.json"],
+      },
+      "mcp.json": {
+        gh: { type: "stdio", command: "npx", args: ["gh"] },
+      },
+      "skills.json": {
+        deploy: {
+          description: "Deploy skill",
+          path: "skills/deploy",
+        },
+      },
+      "skills/deploy/SKILL.md": "# Deploy",
+      "plugins.json": {
+        "my-plugin": {
+          description: "A plugin",
+          skills: ["deploy"],
+          mcp_servers: ["gh"],
+        },
+      },
+    });
+
+    const result = tryRun(
+      `resolve --json --config ${join(catalog, "air.json")}`
+    );
+    expect(result.exitCode).toBe(0);
+
+    const output = JSON.parse(result.stdout);
+    expect(output.plugins["my-plugin"]).toBeDefined();
+    expect(output.plugins["my-plugin"].skills).toContain("deploy");
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.36"
+    "@pulsemcp/air-core": "0.0.37"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.36"
+    "@pulsemcp/air-core": "0.0.37"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.36"
+    "@pulsemcp/air-core": "0.0.37"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.36"
+    "@pulsemcp/air-core": "0.0.37"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.36"
+    "@pulsemcp/air-core": "0.0.37"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.36"
+    "@pulsemcp/air-core": "0.0.37"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -115,6 +115,9 @@ export type {
   ExportMarketplaceResult,
 } from "./export-marketplace.js";
 
+export { resolveFullArtifacts } from "./resolve.js";
+export type { ResolveFullArtifactsOptions } from "./resolve.js";
+
 // Extension installer
 export { installExtensions } from "./install.js";
 export type {

--- a/packages/sdk/src/resolve.ts
+++ b/packages/sdk/src/resolve.ts
@@ -1,0 +1,54 @@
+import { dirname, resolve } from "path";
+import {
+  loadAirConfig,
+  getAirJsonPath,
+  resolveArtifacts,
+  type ResolvedArtifacts,
+} from "@pulsemcp/air-core";
+import { loadExtensions } from "./extension-loader.js";
+
+export interface ResolveFullArtifactsOptions {
+  /** Path to air.json. Uses AIR_CONFIG env or ~/.air/air.json if not set. */
+  config?: string;
+  /**
+   * Git protocol override for git-based catalog providers (e.g., github://).
+   * Takes precedence over the `gitProtocol` field in air.json.
+   */
+  gitProtocol?: "ssh" | "https";
+}
+
+/**
+ * Load the active air.json, load declared extensions to obtain catalog
+ * providers (e.g., github://), and resolve the full merged artifact tree.
+ *
+ * This is the programmatic equivalent of `air resolve --json`: it mirrors
+ * the provider wiring that `prepareSession` does, stopping after
+ * `resolveArtifacts` returns. It does not load adapters, detect roots,
+ * or touch the filesystem beyond reading artifact indexes.
+ *
+ * @throws Error if no air.json is found.
+ */
+export async function resolveFullArtifacts(
+  options: ResolveFullArtifactsOptions = {}
+): Promise<ResolvedArtifacts> {
+  const airJsonPath = options.config ?? getAirJsonPath();
+  if (!airJsonPath) {
+    throw new Error(
+      "No air.json found. Specify a config path or set AIR_CONFIG env var."
+    );
+  }
+
+  const airJsonDir = dirname(resolve(airJsonPath));
+  const airConfig = loadAirConfig(airJsonPath);
+  const loaded = await loadExtensions(airConfig.extensions || [], airJsonDir);
+
+  const providers = loaded.providers
+    .map((ext) => ext.provider!)
+    .filter(Boolean);
+  const providerOptions: Record<string, unknown> = {};
+  if (options.gitProtocol !== undefined) {
+    providerOptions.gitProtocol = options.gitProtocol;
+  }
+
+  return resolveArtifacts(airJsonPath, { providers, providerOptions });
+}

--- a/packages/sdk/src/resolve.ts
+++ b/packages/sdk/src/resolve.ts
@@ -42,9 +42,7 @@ export async function resolveFullArtifacts(
   const airConfig = loadAirConfig(airJsonPath);
   const loaded = await loadExtensions(airConfig.extensions || [], airJsonDir);
 
-  const providers = loaded.providers
-    .map((ext) => ext.provider!)
-    .filter(Boolean);
+  const providers = loaded.providers.map((ext) => ext.provider!);
   const providerOptions: Record<string, unknown> = {};
   if (options.gitProtocol !== undefined) {
     providerOptions.gitProtocol = options.gitProtocol;


### PR DESCRIPTION
## Summary

- Adds a new read-only `air resolve --json` CLI command that loads the active `air.json`, runs configured catalog providers, and prints the full merged `ResolvedArtifacts` tree to stdout as JSON.
- Backed by a new SDK helper, `resolveFullArtifacts()`, that encapsulates extension loading + `resolveArtifacts()` — keeps the CLI a thin wrapper.
- Documents the command in `docs/cli.md` and `docs/guides/running-sessions.md`.

Closes #99.

## Motivation

`@pulsemcp/air-core` already exposes `resolveArtifacts()` programmatically, but the CLI had no dedicated command to emit the merged tree. Downstream consumers (e.g., Agent Orchestrator's Ruby resolver) have been reimplementing JSON parsing + provider resolution + later-wins merge — brittle and duplicative, and already caused one prod outage when a provider extension was missing. `air resolve --json` lets non-Node consumers use the canonical resolution pipeline as a subprocess call, replacing ~230 lines of duplicated Ruby. (Broader design context in pulsemcp/pulsemcp#2860; the retirement tracker is pulsemcp/pulsemcp#2950.)

## Implementation notes

- `packages/sdk/src/resolve.ts` — new `resolveFullArtifacts({ config, gitProtocol })` helper. Mirrors `prepareSession()`'s provider wiring (loads extensions from `air.json`, extracts providers, threads `gitProtocol` into `providerOptions`), stops after `resolveArtifacts()`.
- `packages/cli/src/commands/resolve.ts` — thin Commander wrapper: parses flags, calls the SDK, `console.log(JSON.stringify(...))`, exits 1 on error.
- Command is registered alongside `prepare`, `start`, `update` in `packages/cli/src/index.ts`.
- Respects `AIR_CONFIG` env var and `--config` flag the same way `air prepare` does (delegates to `getAirJsonPath()` from core).
- Absolute `path` fields are already handled by core — no new logic added.
- `--json` is accepted for forward-compat (currently the only supported output format).

## Verification

- [x] **CLI**: ran `air resolve --json` against a fixture `air.json` — output matches the expected shape (top-level `skills`/`references`/`mcp`/`plugins`/`roots`/`hooks` keys; absolute `path`; empty objects for unused types):

  ```json
  {
    "skills": {
      "deploy": {
        "description": "Deploy the app",
        "path": "/tmp/air-resolve-demo/skills/deploy"
      }
    },
    "references": {},
    "mcp": {
      "github": {
        "type": "stdio",
        "command": "npx",
        "args": [
          "-y",
          "@modelcontextprotocol/server-github"
        ]
      }
    },
    "plugins": {},
    "roots": {
      "web-app": {
        "description": "Web application root",
        "default_mcp_servers": ["github"],
        "default_skills": ["deploy"]
      }
    },
    "hooks": {}
  }
  ```

- [x] **Tests**: ran `cd packages/cli && npx vitest run tests/resolve-command.test.ts` — **8/8 new tests pass** covering (1) output shape, (2) absolute paths, (3) later-wins override across multiple index files, (4) `AIR_CONFIG` env var, (5) empty maps for unused types, (6) missing-config error handling, (7) extension-provided catalog providers with custom `stub://` URI scheme, (8) plugin expansion.

- [x] **Docs**: `docs/cli.md` has a new [`air resolve --json` section](https://github.com/pulsemcp/air/blob/feat/resolve-command/docs/cli.md#air-resolve---json) with usage, output shape, options table, and exit codes. `docs/guides/running-sessions.md` has a new [`air resolve` section](https://github.com/pulsemcp/air/blob/feat/resolve-command/docs/guides/running-sessions.md#air-resolve--inspecting-the-merged-artifact-tree) describing when to reach for it vs. `air prepare`.

- [x] **Self-review**: ran a subagent PR review with fresh eyes. 2 should-fix findings (decorative `--json` flag clarified in help + docs; test coverage gap → added extension-provider test) and 2 nits (dead `.filter(Boolean)`; doc precedence wording) all addressed in follow-up commit.

- [x] **CI**: all 5 checks green on latest commit (e2e, test 18/20/22, validate-schemas).

## Scope

- No change to `@pulsemcp/air-core`'s `resolveArtifacts()` behavior — this is a CLI-layer addition wired through a small SDK helper.
- Version bumped `0.0.36 → 0.0.37` across all 8 packages + `CHANGELOG.md` + `package-lock.json` per the `air-version-bump` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)