### PR TITLE
fix(cli): hard-error on deprecated plural artifact flags (v0.0.39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.39] - 2026-04-24
+
+### Changed
+- **Breaking:** `air start` and `air prepare` now exit with code 1 and print a migration error when invoked with the deprecated plural artifact-selection flags (`--plugins`, `--skills`, `--mcp-servers`, `--hooks`, `--without-plugins`, `--without-skills`, `--without-mcp-servers`, `--without-hooks`) that were renamed to their singular variadic forms in v0.0.32. Previously these flags were silently dropped after a stderr warning, which let orchestrators believe the call succeeded while writing a `.mcp.json` missing the requested artifacts. Callers must migrate to the singular flag names — e.g., `--plugin a b` or `--plugin a --plugin b` instead of `--plugins a,b`. See [#95](https://github.com/pulsemcp/air/issues/95).
+
 ## [0.0.38] - 2026-04-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1776991563-2ec84985",
+  "name": "air-main-1776990975-5569dd32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -847,9 +847,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.38",
+      "version": "0.0.39",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.38",
+        "@pulsemcp/air-sdk": "0.0.39",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -868,7 +868,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.38",
+      "version": "0.0.39",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -884,9 +884,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.38",
+      "version": "0.0.39",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.38"
+        "@pulsemcp/air-core": "0.0.39"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -899,9 +899,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.0.38",
+      "version": "0.0.39",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.38"
+        "@pulsemcp/air-core": "0.0.39"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -914,9 +914,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.38",
+      "version": "0.0.39",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.38"
+        "@pulsemcp/air-core": "0.0.39"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -929,9 +929,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.38",
+      "version": "0.0.39",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.38"
+        "@pulsemcp/air-core": "0.0.39"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -944,9 +944,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.38",
+      "version": "0.0.39",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.38"
+        "@pulsemcp/air-core": "0.0.39"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -959,9 +959,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.38",
+      "version": "0.0.39",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.38"
+        "@pulsemcp/air-core": "0.0.39"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.38",
+    "@pulsemcp/air-sdk": "0.0.39",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/deprecated-flags.ts
+++ b/packages/cli/src/commands/deprecated-flags.ts
@@ -10,27 +10,29 @@ const RENAMED_FLAGS: Record<string, string> = {
 };
 
 /**
- * Warns if the user invoked any of the old plural artifact-selection flags
- * (renamed in v0.0.32). Both `air start` and `air prepare` use
- * `.allowUnknownOption(true)` so these would otherwise be silently dropped.
+ * Hard-errors if the user invoked any of the old plural artifact-selection
+ * flags (renamed in v0.0.32). Both `air start` and `air prepare` use
+ * `.allowUnknownOption(true)` so these would otherwise be silently dropped —
+ * see https://github.com/pulsemcp/air/issues/95 for an incident where this
+ * caused a session to spin up missing its plugins.
  *
- * `start` forwards everything after `--` to the agent, so the scan stops there
- * to avoid warning on agent flags that happen to share a name.
+ * `start` forwards everything after `--` to the agent, so the scan stops
+ * there to avoid rejecting agent flags that happen to share a name.
+ *
+ * Exits the process with code 1 on the first deprecated flag encountered.
  */
-export function warnOnDeprecatedArtifactFlags(argv: readonly string[]): void {
+export function rejectDeprecatedArtifactFlags(argv: readonly string[]): void {
   const dashDashIdx = argv.indexOf("--");
   const scan = dashDashIdx === -1 ? argv : argv.slice(0, dashDashIdx);
-  const seen = new Set<string>();
   for (const arg of scan) {
     const base = arg.includes("=") ? arg.slice(0, arg.indexOf("=")) : arg;
     const replacement = RENAMED_FLAGS[base];
-    if (replacement && !seen.has(base)) {
-      seen.add(base);
+    if (replacement) {
       console.error(
-        `Warning: ${base} was renamed to ${replacement} in v0.0.32. ` +
-          `Pass multiple IDs as \`${replacement} a b\` or by repeating the flag. ` +
-          `The old flag is being ignored.`
+        `Error: ${base} was renamed to ${replacement} in v0.0.32 and is no longer accepted.\n` +
+          `       Pass multiple IDs as \`${replacement} a b\` or by repeating the flag (\`${replacement} a ${replacement} b\`).`
       );
+      process.exit(1);
     }
   }
 }

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -6,7 +6,7 @@ import {
   getAirJsonPath,
   loadExtensions,
 } from "@pulsemcp/air-sdk";
-import { warnOnDeprecatedArtifactFlags } from "./deprecated-flags.js";
+import { rejectDeprecatedArtifactFlags } from "./deprecated-flags.js";
 import { parseGitProtocolFlag } from "./git-protocol.js";
 
 /**
@@ -121,7 +121,7 @@ export function prepareCommand(): Command {
         skipValidation?: boolean;
         gitProtocol?: string;
       }) => {
-        warnOnDeprecatedArtifactFlags(process.argv);
+        rejectDeprecatedArtifactFlags(process.argv);
         const gitProtocol = parseGitProtocolFlag(options.gitProtocol);
         try {
           // Load extensions once — pass to SDK to avoid double loading

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -10,7 +10,7 @@ import {
   type RootEntry,
 } from "@pulsemcp/air-sdk";
 import { runInteractiveSelector } from "../tui/interactive-selector.js";
-import { warnOnDeprecatedArtifactFlags } from "./deprecated-flags.js";
+import { rejectDeprecatedArtifactFlags } from "./deprecated-flags.js";
 import { parseGitProtocolFlag } from "./git-protocol.js";
 
 export function startCommand(): Command {
@@ -92,7 +92,7 @@ export function startCommand(): Command {
         const passthroughArgs =
           dashDashIdx !== -1 ? process.argv.slice(dashDashIdx + 1) : [];
 
-        warnOnDeprecatedArtifactFlags(process.argv);
+        rejectDeprecatedArtifactFlags(process.argv);
 
         const gitProtocol = parseGitProtocolFlag(options.gitProtocol);
 

--- a/packages/cli/tests/deprecated-flags.test.ts
+++ b/packages/cli/tests/deprecated-flags.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { spawnSync } from "child_process";
+import { resolve } from "path";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+
+const CLI = resolve(__dirname, "../src/index.ts");
+
+const tryRun = (args: string, env?: Record<string, string>) => {
+  const result = spawnSync(
+    "npx",
+    ["tsx", CLI, ...args.match(/(?:[^\s"]+|"[^"]*")+/g)!.map((s) => s.replace(/^"|"$/g, ""))],
+    {
+      encoding: "utf-8",
+      cwd: resolve(__dirname, "../../.."),
+      env: { ...process.env, ...env },
+    }
+  );
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    exitCode: result.status ?? 1,
+  };
+};
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    if (existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  tempDirs.length = 0;
+});
+
+function createTemp(files: Record<string, unknown>): string {
+  const dir = resolve(
+    tmpdir(),
+    `air-deprecated-flags-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  tempDirs.push(dir);
+  for (const [name, content] of Object.entries(files)) {
+    const path = resolve(dir, name);
+    mkdirSync(resolve(path, ".."), { recursive: true });
+    writeFileSync(
+      path,
+      typeof content === "string" ? content : JSON.stringify(content, null, 2)
+    );
+  }
+  return dir;
+}
+
+function makeCatalog(): string {
+  return createTemp({
+    "air.json": {
+      name: "test",
+      skills: ["./skills.json"],
+      mcp: ["./mcp.json"],
+      hooks: ["./hooks.json"],
+      plugins: ["./plugins.json"],
+      roots: ["./roots.json"],
+    },
+    "skills.json": {
+      "skill-a": { description: "Skill A", path: "skills/skill-a" },
+    },
+    "skills/skill-a/SKILL.md": "# A",
+    "mcp.json": {
+      "mcp-a": { type: "stdio", command: "echo", args: ["hello"] },
+    },
+    "hooks.json": {
+      "hook-a": {
+        description: "Hook A",
+        events: { Stop: [{ matcher: "*", hooks: [{ type: "command", command: "echo" }] }] },
+      },
+    },
+    "plugins.json": {
+      "plugin-a": { description: "Plugin A" },
+    },
+    "roots.json": {
+      myroot: {
+        description: "Test root",
+        default_skills: ["skill-a"],
+        default_mcp_servers: ["mcp-a"],
+        default_hooks: ["hook-a"],
+        default_plugins: ["plugin-a"],
+      },
+    },
+  });
+}
+
+const DEPRECATED_FLAGS: Array<[string, string]> = [
+  ["--skills", "--skill"],
+  ["--mcp-servers", "--mcp-server"],
+  ["--hooks", "--hook"],
+  ["--plugins", "--plugin"],
+  ["--without-skills", "--without-skill"],
+  ["--without-mcp-servers", "--without-mcp-server"],
+  ["--without-hooks", "--without-hook"],
+  ["--without-plugins", "--without-plugin"],
+];
+
+describe("deprecated artifact flags — air prepare hard-errors", () => {
+  for (const [oldFlag, newFlag] of DEPRECATED_FLAGS) {
+    it(`rejects ${oldFlag} with exit 1 and an error pointing to ${newFlag}`, () => {
+      const catalog = makeCatalog();
+      const target = createTemp({});
+
+      const result = tryRun(
+        `prepare claude --root myroot --target ${target} ${oldFlag} something`,
+        { AIR_CONFIG: resolve(catalog, "air.json") }
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(`${oldFlag} was renamed to ${newFlag}`);
+      expect(result.stderr).toContain("v0.0.32");
+      expect(result.stderr).toContain("no longer accepted");
+      // .mcp.json must NOT be written when we hard-error early
+      expect(existsSync(resolve(target, ".mcp.json"))).toBe(false);
+    });
+
+    it(`rejects ${oldFlag}=value (= syntax) with exit 1`, () => {
+      const catalog = makeCatalog();
+      const target = createTemp({});
+
+      const result = tryRun(
+        `prepare claude --root myroot --target ${target} ${oldFlag}=something`,
+        { AIR_CONFIG: resolve(catalog, "air.json") }
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(`${oldFlag} was renamed to ${newFlag}`);
+      expect(existsSync(resolve(target, ".mcp.json"))).toBe(false);
+    });
+  }
+});
+
+describe("deprecated artifact flags — air start hard-errors", () => {
+  for (const [oldFlag, newFlag] of DEPRECATED_FLAGS) {
+    it(`rejects ${oldFlag} with exit 1 and an error pointing to ${newFlag}`, () => {
+      const catalog = makeCatalog();
+
+      const result = tryRun(
+        `start claude --root myroot --dry-run ${oldFlag} something`,
+        { AIR_CONFIG: resolve(catalog, "air.json") }
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(`${oldFlag} was renamed to ${newFlag}`);
+      expect(result.stderr).toContain("v0.0.32");
+      expect(result.stderr).toContain("no longer accepted");
+    });
+  }
+
+  it("does not reject when an agent passthrough arg after -- happens to match an old flag name", () => {
+    const catalog = makeCatalog();
+
+    const result = tryRun(
+      `start claude --root myroot --dry-run -- --skills something-else`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("no longer accepted");
+    expect(result.stderr).not.toContain("was renamed to");
+  });
+
+  it("does not reject a similarly-named flag that is not on the deprecated list", () => {
+    const catalog = makeCatalog();
+
+    // --skills-other-name is NOT one of the deprecated flags. The matcher must
+    // do exact-base lookup on RENAMED_FLAGS, not substring/prefix matching, or
+    // a future refactor that introduces regex matching could regress.
+    // start uses .allowUnknownOption(true) so this falls through harmlessly.
+    const result = tryRun(
+      `start claude --root myroot --dry-run --skills-other-name foo`,
+      { AIR_CONFIG: resolve(catalog, "air.json") }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("no longer accepted");
+    expect(result.stderr).not.toContain("was renamed to");
+  });
+});

--- a/packages/cli/tests/start-command.test.ts
+++ b/packages/cli/tests/start-command.test.ts
@@ -432,7 +432,7 @@ describe("start command — CLI artifact selection flags", () => {
     expect(result.stdout).not.toMatch(/\u2022 skill-a\b/);
   });
 
-  it("emits a deprecation warning when the old plural --skills flag is used", () => {
+  it("rejects the old plural --skills flag with a non-zero exit and migration error", () => {
     const catalog = createTemp({
       "air.json": {
         name: "test",
@@ -456,9 +456,10 @@ describe("start command — CLI artifact selection flags", () => {
       { AIR_CONFIG: resolve(catalog, "air.json") }
     );
 
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("--skills was renamed to --skill");
     expect(result.stderr).toContain("v0.0.32");
+    expect(result.stderr).toContain("no longer accepted");
   });
 
   it("does not warn when an agent passthrough arg after -- happens to match an old flag name", () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.38"
+    "@pulsemcp/air-core": "0.0.39"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.38"
+    "@pulsemcp/air-core": "0.0.39"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.38"
+    "@pulsemcp/air-core": "0.0.39"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.38"
+    "@pulsemcp/air-core": "0.0.39"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.38"
+    "@pulsemcp/air-core": "0.0.39"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.38"
+    "@pulsemcp/air-core": "0.0.39"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
Closes #95.

## Summary

Replaces the warn-and-ignore behavior in `packages/cli/src/commands/deprecated-flags.ts` with a hard error. When `air start` or `air prepare` is invoked with any of the v0.0.32-deprecated plural flags — `--plugins`, `--skills`, `--mcp-servers`, `--hooks`, `--without-plugins`, `--without-skills`, `--without-mcp-servers`, `--without-hooks` — the CLI now prints an explanatory error naming the new singular flag and exits with code 1 *before* writing anything.

`warnOnDeprecatedArtifactFlags` is renamed to `rejectDeprecatedArtifactFlags` to reflect the new semantics. Both `prepare.ts` and `start.ts` are updated to call the renamed function.

The agent-passthrough exemption (anything after `--`) is preserved, so `air start claude … -- --skills foo` still passes `--skills foo` through to Claude untouched.

## Why this approach

The issue proposed two options: hard-error or transparent forwarding. I chose **hard-error**, matching the issue author's stated preference. Rationale:

- The trigger incident (AO #4137) was a *silent* failure — the orchestrator had no way to know its `--plugins` value was dropped because AIR exited 0. Forwarding would still "work," but if the value's serialization differs from what the new flag expects (e.g., comma-splitting edge cases), we'd just trade silent-drop for silent-corruption.
- Loudly failing is a one-shot disruption that surfaces the migration immediately. Quiet forwarding is an indefinite source of confusion.
- The plural flags were deprecated in v0.0.32 (2026-04-23) and zero docs in `docs/guides/` reference them — every user-facing example already uses the singular form.

## Breaking change — migration guidance

This is a **breaking change** for any caller still passing the old plural flag names. Migration is mechanical:

| Old (rejected, exit 1) | New (current) |
|---|---|
| `--plugins a,b` | `--plugin a b` *or* `--plugin a --plugin b` |
| `--skills a,b` | `--skill a b` *or* `--skill a --skill b` |
| `--mcp-servers a,b` | `--mcp-server a b` *or* `--mcp-server a --mcp-server b` |
| `--hooks a,b` | `--hook a b` *or* `--hook a --hook b` |
| `--without-plugins a,b` | `--without-plugin a b` *or* repeat |
| `--without-skills a,b` | `--without-skill a b` *or* repeat |
| `--without-mcp-servers a,b` | `--without-mcp-server a b` *or* repeat |
| `--without-hooks a,b` | `--without-hook a b` *or* repeat |

Note the old flags accepted comma-separated values; the new singular flags accept space-separated variadic values or repetition — they do **not** comma-split.

Known consumer to migrate: agent-orchestrator (see [pulsemcp/pulsemcp#2934](https://github.com/pulsemcp/pulsemcp/issues/2934) for the AO-side context).

## Verification

- [x] **Live `air prepare claude --plugins foo` exits non-zero with a clear error** — actual command output, captured locally:

  ```
  $ AIR_CONFIG=… npx tsx packages/cli/src/index.ts prepare claude --root r --target /tmp/air-live-target --plugins foo
  Error: --plugins was renamed to --plugin in v0.0.32 and is no longer accepted.
         Pass multiple IDs as `--plugin a b` or by repeating the flag (`--plugin a --plugin b`).
  --- Exit: 1 ---
  ```

  And the singular form continues to work — same setup, replacing `--plugins foo` with `--plugin foo` produced a valid `.mcp.json` and exited 0.

- [x] **Unit tests added covering all 8 deprecated flag names** — new file `packages/cli/tests/deprecated-flags.test.ts` (26 tests total): for each of the 8 flags, one test for `--flag value` and one for `--flag=value` syntax under `air prepare` (16 tests), one test under `air start --dry-run` (8 tests), one regression test confirming agent-passthrough args after `--` are not rejected, and one negative test confirming similarly-named flags (`--skills-other-name`) are NOT falsely matched. All 26 pass.

  The `air prepare` tests also assert that `.mcp.json` is **not** written when the deprecated flag is rejected — proving the early-exit prevents the silent-drop scenario from #95.

- [x] **Existing test that asserted warn-and-continue behavior was updated** — `packages/cli/tests/start-command.test.ts:435` previously expected exit 0 + a warning; now expects exit 1 + the new error message.

- [x] **Full CLI test suite passes after rebase onto current main (which now includes v0.0.37 and v0.0.38)** — `npx vitest run packages/cli`:

  ```
  Test Files  11 passed (11)
       Tests  136 passed (136)
  ```

  (Pre-rebase, also ran the full repo unit suite: `33 files / 588 tests passed`. e2e suite: `23 tests passed`.)

- [x] **Version bumped to 0.0.39 across all 8 packages, CHANGELOG updated, lockfile regenerated** — see commit. CHANGELOG entry categorizes this under `### Changed` (Breaking) since it changes the exit code and behavior of CLI flags. Bumped from 0.0.38 (the latest as of rebase) to 0.0.39 because v0.0.37 and v0.0.38 were already taken by other PRs that landed during this work.

- [x] **Docs reviewed via air-update-docs skill** — no `docs/guides/` files reference the deprecated plural flag names; all examples already use the singular forms established in v0.0.32. No doc updates needed.

- [x] **Self-review by a fresh-eyes subagent** — verdict: ready to merge, no blocking issues. The reviewer's two highest-value polish suggestions (negative-match test for similarly-named flags, plus restating that no `.mcp.json` is written on rejection) were incorporated; the remaining suggestions were stylistic / symmetry items that don't affect correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)