### PR TITLE
Track AIR-managed artifacts in a per-target manifest (v0.0.41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.41] - 2026-04-24
+
+### Added
+- New `manifest` module in `@pulsemcp/air-core` that tracks AIR-managed artifact IDs (skills, hooks, MCP servers) per target directory. Persisted at `<airHome>/manifests/<sha256(targetDir)>.json` (default `airHome` is `~/.air`, overridable via `AIR_HOME` for sandboxed tests). Exports `MANIFEST_VERSION`, `buildManifest`, `loadManifest`, `writeManifest`, `diffManifest`, `getManifestPath`, `getDefaultAirHome`, and the `Manifest` / `ManifestSelection` / `ManifestDiff` types. Re-exported from `@pulsemcp/air-sdk`.
+
+### Fixed
+- **`@pulsemcp/air-adapter-claude`: `prepareSession` now cleans up stale artifacts between runs.** On every run, the adapter diffs the prior manifest against the new selection and removes artifacts that were previously AIR-written but are no longer selected — `.claude/skills/<id>/`, `.claude/hooks/<id>/`, and the corresponding entry in `.mcp.json`. User-authored entries in `.mcp.json` and user-authored settings hooks are preserved. Previously, selecting a smaller set on a re-run left orphaned artifacts behind.
+- **`@pulsemcp/air-adapter-claude`: `.mcp.json` is now merged instead of overwritten.** User-added `mcpServers` keys are preserved across runs; only AIR-managed keys are replaced or removed.
+- **`@pulsemcp/air-adapter-claude`: settings.json hook registrations no longer accumulate duplicates.** Each AIR-written hook entry carries an `_airHookId` marker that identifies ownership, so re-runs prune and re-register cleanly without touching user-authored hook entries.
+
 ## [0.0.40] - 2026-04-24
 
 ### Fixed

--- a/docs/guides/configuring-mcp-servers.md
+++ b/docs/guides/configuring-mcp-servers.md
@@ -184,6 +184,8 @@ For Claude Code, AIR writes a `.mcp.json` file with servers wrapped in a `mcpSer
 
 The `title` and `description` fields are stripped during translation (they're AIR metadata, not part of the agent's config format). The `streamable-http` type is translated to `http` for Claude Code compatibility.
 
+If `.mcp.json` already exists, AIR merges rather than overwrites. Keys AIR manages (those AIR wrote on a prior run, tracked in the per-target manifest) are replaced with the current selection — keys that are no longer selected are removed. Any other `mcpServers` keys and top-level fields pass through untouched, so user-added entries survive across runs. See [Cleanup between runs](running-sessions.md#cleanup-between-runs) for details.
+
 ### Selecting specific servers
 
 Add or remove servers when running `air prepare`:

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -246,7 +246,8 @@ Produces this entry in `.claude/settings.json`:
           {
             "type": "command",
             "command": "npx lint-staged",
-            "timeout": 30
+            "timeout": 30,
+            "_airHookId": "lint-staged"
           }
         ]
       }
@@ -255,7 +256,9 @@ Produces this entry in `.claude/settings.json`:
 }
 ```
 
-If `.claude/settings.json` already exists, new hook entries are merged — existing settings and hooks are preserved.
+If `.claude/settings.json` already exists, new hook entries are merged — existing settings and hooks are preserved. The `_airHookId` marker identifies which entries AIR wrote; entries without the marker (or with an unknown ID) are considered user-authored and are never modified.
+
+On re-runs, AIR uses the `_airHookId` marker plus the per-target manifest to prune its prior entries before re-registering the current selection. This prevents duplicate registrations and removes entries for hooks that were dropped from the selection. See [Cleanup between runs](running-sessions.md#cleanup-between-runs) for details.
 
 **Limitations:**
 - The `env` field from `HOOK.json` is not forwarded to Claude Code hooks. Environment variables must be set in the shell environment before starting the session.

--- a/docs/guides/managing-skills.md
+++ b/docs/guides/managing-skills.md
@@ -173,6 +173,7 @@ When you run `air start` or `air prepare`, the adapter:
 2. Copies each skill's directory into the agent workspace (e.g., `.claude/skills/{skill-id}/`)
 3. Copies any referenced documents into `references/` within the skill directory
 4. Skills already present in the workspace are not overwritten (local takes priority)
+5. Skills that AIR wrote on a prior run but are no longer in the selection are removed (the adapter tracks them in a per-target manifest). User-authored skills under `.claude/skills/` are never touched. See [Cleanup between runs](running-sessions.md#cleanup-between-runs) for details.
 
 ### Local skills tracked in the repo
 

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -152,14 +152,16 @@ The adapter argument is required — it specifies which agent adapter to use (e.
 2. Resolves artifacts (including remote URIs via providers)
 3. Auto-detects the root from the target directory's git context (or uses `--root`)
 4. Calls the adapter's `prepareSession()`:
-   - Writes `.mcp.json` to the target directory
+   - Loads the prior-run manifest (if any) and cleans up stale artifacts — see [Cleanup between runs](#cleanup-between-runs)
+   - Writes `.mcp.json` to the target directory (merges with existing user-added entries; replaces AIR-managed ones)
    - Copies skills into the agent's skill directory
    - Copies hook directories into the agent's hook directory
    - Copies referenced documents
 5. Runs transforms on `.mcp.json` and `HOOK.json` files (e.g., secrets injection)
-6. Registers hooks in the agent's settings (e.g., `.claude/settings.json`)
-7. Validates no `${VAR}` patterns remain unresolved in `.mcp.json` or `HOOK.json`
-8. Outputs structured JSON to stdout
+6. Registers hooks in the agent's settings (e.g., `.claude/settings.json`), tagging each AIR-written entry with `_airHookId` so future runs can identify it
+7. Writes an updated manifest recording the artifact IDs AIR owns in this run
+8. Validates no `${VAR}` patterns remain unresolved in `.mcp.json` or `HOOK.json`
+9. Outputs structured JSON to stdout
 
 ### Options
 
@@ -237,6 +239,18 @@ air prepare claude --without-hook prevent-secrets-in-context
 # Start from empty and include only what you list
 air prepare claude --without-defaults --skill deploy-staging --mcp-server github
 ```
+
+### Cleanup between runs
+
+AIR records which artifact IDs it wrote to each target directory in a per-user manifest at `~/.air/manifests/<hash>.json` (the filename is the SHA-256 of the absolute target path). On every subsequent `air prepare` or `air start` into the same directory, the adapter diffs the new selection against the prior manifest and removes artifacts that are no longer selected:
+
+- **Skills** — `.claude/skills/<id>/` directories are deleted for IDs dropped from the selection
+- **Hooks** — `.claude/hooks/<id>/` directories are deleted, and their entries in `.claude/settings.json` (identified by the `_airHookId` marker the adapter writes alongside each entry) are removed
+- **MCP servers** — the corresponding keys in `.mcp.json` are deleted; user-added keys and other top-level fields pass through unchanged
+
+Artifacts AIR didn't write are never touched. If you manually place a `.claude/skills/<id>/` or `.claude/hooks/<id>/` directory before the first `air prepare` run, AIR recognizes it as user-authored and leaves it alone — both the files and any `.claude/settings.json` hook registrations that reference it.
+
+If the manifest is missing or unreadable, the current run is treated as "no prior state" — nothing is cleaned up, and a fresh manifest is written at the end. You can point AIR at a different state directory for testing by setting `AIR_HOME` (defaults to `~/.air`).
 
 ## air resolve — inspecting the merged artifact tree
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1776997393-2f58612c",
+  "name": "air-main-1776990978-79cb4d94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -105,16 +105,18 @@
     },
     "node_modules/@types/proper-lockfile": {
       "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/retry": "*"
       }
     },
     "node_modules/@types/retry": {
       "version": "0.12.5",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
+      "dev": true
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -413,7 +415,8 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -501,7 +504,8 @@
     },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "retry": "^0.12.0",
@@ -525,7 +529,8 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "engines": {
         "node": ">= 4"
       }
@@ -580,7 +585,8 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -884,9 +890,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.40",
+      "version": "0.0.41",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.40",
+        "@pulsemcp/air-sdk": "0.0.41",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -905,7 +911,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.40",
+      "version": "0.0.41",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -921,9 +927,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.40",
+      "version": "0.0.41",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.40"
+        "@pulsemcp/air-core": "0.0.41"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -936,9 +942,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.0.40",
+      "version": "0.0.41",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.40"
+        "@pulsemcp/air-core": "0.0.41"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -951,9 +957,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.40",
+      "version": "0.0.41",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.40",
+        "@pulsemcp/air-core": "0.0.41",
         "proper-lockfile": "^4.1.2"
       },
       "devDependencies": {
@@ -968,9 +974,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.40",
+      "version": "0.0.41",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.40"
+        "@pulsemcp/air-core": "0.0.41"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -983,9 +989,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.40",
+      "version": "0.0.41",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.40"
+        "@pulsemcp/air-core": "0.0.41"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -998,9 +1004,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.40",
+      "version": "0.0.41",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.40"
+        "@pulsemcp/air-core": "0.0.41"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.40",
+    "@pulsemcp/air-sdk": "0.0.41",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,3 +63,19 @@ export {
   isValidSchemaType,
 } from "./schemas.js";
 export type { SchemaType } from "./schemas.js";
+
+// Manifest — tracks air-managed artifacts per target directory
+export {
+  MANIFEST_VERSION,
+  getDefaultAirHome,
+  getManifestPath,
+  loadManifest,
+  writeManifest,
+  buildManifest,
+  diffManifest,
+} from "./manifest.js";
+export type {
+  Manifest,
+  ManifestSelection,
+  ManifestDiff,
+} from "./manifest.js";

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -54,16 +54,23 @@ export interface ManifestDiff {
 /**
  * Default root of AIR's per-user state directory (contains air.json,
  * manifests/, etc). Honors `AIR_HOME` for relocation (primarily for tests
- * and sandboxed environments), then HOME/USERPROFILE, falling back to "~".
+ * and sandboxed environments), then HOME/USERPROFILE.
+ *
+ * Throws if no suitable home directory can be determined — falling back
+ * to a relative path would silently write state into the current working
+ * directory, which is almost always wrong and hard to diagnose.
  */
 export function getDefaultAirHome(): string {
   if (process.env.AIR_HOME) {
     return resolve(process.env.AIR_HOME);
   }
-  return resolve(
-    process.env.HOME || process.env.USERPROFILE || "~",
-    ".air"
-  );
+  const home = process.env.HOME || process.env.USERPROFILE;
+  if (!home) {
+    throw new Error(
+      "Cannot determine AIR home directory: neither AIR_HOME, HOME, nor USERPROFILE is set."
+    );
+  }
+  return resolve(home, ".air");
 }
 
 /**
@@ -121,14 +128,30 @@ function isManifestShape(value: unknown): value is Manifest {
   const m = value as Record<string, unknown>;
   if (typeof m.version !== "number") return false;
   if (typeof m.target !== "string") return false;
-  if (!isStringArray(m.skills)) return false;
-  if (!isStringArray(m.hooks)) return false;
-  if (!isStringArray(m.mcpServers)) return false;
+  if (!isSafeIdArray(m.skills)) return false;
+  if (!isSafeIdArray(m.hooks)) return false;
+  if (!isSafeIdArray(m.mcpServers)) return false;
   return true;
 }
 
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((v) => typeof v === "string");
+/**
+ * Accept only strings safe to use as path segments for cleanup. A manifest
+ * whose IDs contain path separators, `..`, or absolute-path shapes could
+ * cause `join(targetDir, ".claude/skills", id)` to escape the target tree
+ * during `rmSync`. The file lives in the user's home, so this is defense
+ * in depth; still cheaper to enforce here than to trust every caller.
+ */
+function isSafeIdArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(isSafeId);
+}
+
+function isSafeId(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  if (value.length === 0) return false;
+  if (value === "." || value === "..") return false;
+  if (value.includes("/") || value.includes("\\")) return false;
+  if (value.includes("\0")) return false;
+  return true;
 }
 
 /**

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -1,0 +1,185 @@
+import { createHash } from "crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "fs";
+import { dirname, resolve } from "path";
+
+/**
+ * Manifest schema version. Incrementing this is a breaking change to the
+ * on-disk format; future versions should be tolerant of older manifests
+ * (treat unrecognized shapes as empty, same as the corrupt-manifest path).
+ */
+export const MANIFEST_VERSION = 1;
+
+/**
+ * The on-disk record of artifacts AIR has written to a single target
+ * directory. Persisted at `<airHome>/manifests/<sha256(targetDir)>.json`.
+ */
+export interface Manifest {
+  version: number;
+  /** Absolute target directory this manifest describes. */
+  target: string;
+  /** Skill IDs whose `.claude/skills/<id>/` (or adapter equivalent) AIR owns. */
+  skills: string[];
+  /** Hook IDs whose `.claude/hooks/<id>/` (or adapter equivalent) AIR owns. */
+  hooks: string[];
+  /** MCP server IDs whose key in `.mcp.json` (or adapter equivalent) AIR owns. */
+  mcpServers: string[];
+}
+
+/**
+ * The current selection of artifacts for a target directory — what should
+ * exist on disk after this run. Any ID present in a previous manifest but
+ * absent here is stale and should be cleaned up.
+ */
+export interface ManifestSelection {
+  skills?: string[];
+  hooks?: string[];
+  mcpServers?: string[];
+}
+
+/**
+ * IDs present in the previous manifest but not in the current selection.
+ * These are the artifacts an adapter should remove before writing new ones.
+ */
+export interface ManifestDiff {
+  staleSkills: string[];
+  staleHooks: string[];
+  staleMcpServers: string[];
+}
+
+/**
+ * Default root of AIR's per-user state directory (contains air.json,
+ * manifests/, etc). Honors `AIR_HOME` for relocation (primarily for tests
+ * and sandboxed environments), then HOME/USERPROFILE, falling back to "~".
+ */
+export function getDefaultAirHome(): string {
+  if (process.env.AIR_HOME) {
+    return resolve(process.env.AIR_HOME);
+  }
+  return resolve(
+    process.env.HOME || process.env.USERPROFILE || "~",
+    ".air"
+  );
+}
+
+/**
+ * Absolute path to the manifest file for a given target directory.
+ *
+ * The filename is the SHA-256 of the absolute, normalized target path,
+ * so manifests live outside the project (invisible to the user, no
+ * .gitignore management) and are keyed deterministically per-project.
+ */
+export function getManifestPath(
+  targetDir: string,
+  options?: { airHome?: string }
+): string {
+  const airHome = options?.airHome ?? getDefaultAirHome();
+  const absTarget = resolve(targetDir);
+  const hash = createHash("sha256").update(absTarget).digest("hex");
+  return resolve(airHome, "manifests", `${hash}.json`);
+}
+
+/**
+ * Load the manifest for `targetDir`.
+ *
+ * Returns `null` if the manifest is missing, unreadable, not valid JSON,
+ * or doesn't match the expected shape. Callers should treat `null` as
+ * "no prior state" and skip cleanup — this is the documented behavior
+ * for missing / corrupt manifests.
+ */
+export function loadManifest(
+  targetDir: string,
+  options?: { airHome?: string }
+): Manifest | null {
+  const path = getManifestPath(targetDir, options);
+  if (!existsSync(path)) return null;
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!isManifestShape(parsed)) return null;
+  return parsed;
+}
+
+function isManifestShape(value: unknown): value is Manifest {
+  if (!value || typeof value !== "object") return false;
+  const m = value as Record<string, unknown>;
+  if (typeof m.version !== "number") return false;
+  if (typeof m.target !== "string") return false;
+  if (!isStringArray(m.skills)) return false;
+  if (!isStringArray(m.hooks)) return false;
+  if (!isStringArray(m.mcpServers)) return false;
+  return true;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+/**
+ * Persist `manifest` to disk at the path determined by its `target` field.
+ * Creates the parent directory as needed.
+ */
+export function writeManifest(
+  manifest: Manifest,
+  options?: { airHome?: string }
+): string {
+  const path = getManifestPath(manifest.target, options);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(manifest, null, 2) + "\n");
+  return path;
+}
+
+/**
+ * Build a fresh manifest from the current target and selection.
+ * Undefined category fields in the selection are normalized to `[]`.
+ */
+export function buildManifest(
+  targetDir: string,
+  selection: ManifestSelection
+): Manifest {
+  return {
+    version: MANIFEST_VERSION,
+    target: resolve(targetDir),
+    skills: [...(selection.skills ?? [])],
+    hooks: [...(selection.hooks ?? [])],
+    mcpServers: [...(selection.mcpServers ?? [])],
+  };
+}
+
+/**
+ * Compute IDs that are in the previous manifest but not in the current
+ * selection. A null `prev` means "no prior state" — nothing is stale.
+ */
+export function diffManifest(
+  prev: Manifest | null,
+  next: ManifestSelection
+): ManifestDiff {
+  if (!prev) {
+    return { staleSkills: [], staleHooks: [], staleMcpServers: [] };
+  }
+  const nextSkills = new Set(next.skills ?? []);
+  const nextHooks = new Set(next.hooks ?? []);
+  const nextMcpServers = new Set(next.mcpServers ?? []);
+
+  return {
+    staleSkills: prev.skills.filter((id) => !nextSkills.has(id)),
+    staleHooks: prev.hooks.filter((id) => !nextHooks.has(id)),
+    staleMcpServers: prev.mcpServers.filter((id) => !nextMcpServers.has(id)),
+  };
+}

--- a/packages/core/tests/manifest.test.ts
+++ b/packages/core/tests/manifest.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { dirname, resolve } from "path";
+import {
+  MANIFEST_VERSION,
+  buildManifest,
+  diffManifest,
+  getDefaultAirHome,
+  getManifestPath,
+  loadManifest,
+  writeManifest,
+  type Manifest,
+} from "../src/manifest.js";
+
+describe("manifest", () => {
+  let airHome: string;
+  let targetDir: string;
+  let originalAirHome: string | undefined;
+
+  beforeEach(() => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    airHome = resolve(tmpdir(), `air-home-${suffix}`);
+    targetDir = resolve(tmpdir(), `air-target-${suffix}`);
+    mkdirSync(airHome, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+    originalAirHome = process.env.AIR_HOME;
+    process.env.AIR_HOME = airHome;
+  });
+
+  afterEach(() => {
+    if (existsSync(airHome)) rmSync(airHome, { recursive: true, force: true });
+    if (existsSync(targetDir)) rmSync(targetDir, { recursive: true, force: true });
+    if (originalAirHome === undefined) {
+      delete process.env.AIR_HOME;
+    } else {
+      process.env.AIR_HOME = originalAirHome;
+    }
+  });
+
+  describe("getDefaultAirHome", () => {
+    it("honors AIR_HOME env var when set", () => {
+      expect(getDefaultAirHome()).toBe(resolve(airHome));
+    });
+
+    it("falls back to ~/.air when AIR_HOME is not set", () => {
+      delete process.env.AIR_HOME;
+      const original = process.env.HOME;
+      process.env.HOME = "/tmp/not-a-real-home";
+      try {
+        expect(getDefaultAirHome()).toBe("/tmp/not-a-real-home/.air");
+      } finally {
+        process.env.HOME = original;
+      }
+    });
+  });
+
+  describe("getManifestPath", () => {
+    it("produces a stable SHA-256-based filename in the manifests/ subdir", () => {
+      const path = getManifestPath(targetDir);
+      expect(path.startsWith(resolve(airHome, "manifests") + "/")).toBe(true);
+      expect(/[0-9a-f]{64}\.json$/.test(path)).toBe(true);
+    });
+
+    it("is deterministic for the same absolute target", () => {
+      expect(getManifestPath(targetDir)).toBe(getManifestPath(targetDir));
+    });
+
+    it("differs for different target directories", () => {
+      const a = getManifestPath(resolve(tmpdir(), "a"));
+      const b = getManifestPath(resolve(tmpdir(), "b"));
+      expect(a).not.toBe(b);
+    });
+
+    it("normalizes target paths so equivalent inputs map to the same manifest", () => {
+      const a = getManifestPath(targetDir);
+      const b = getManifestPath(targetDir + "/./");
+      expect(a).toBe(b);
+    });
+
+    it("honors an explicit airHome option over the env var", () => {
+      const custom = resolve(tmpdir(), `air-custom-${Date.now()}`);
+      const path = getManifestPath(targetDir, { airHome: custom });
+      expect(path.startsWith(resolve(custom, "manifests") + "/")).toBe(true);
+    });
+  });
+
+  describe("loadManifest / writeManifest round-trip", () => {
+    it("returns null when no manifest exists", () => {
+      expect(loadManifest(targetDir)).toBeNull();
+    });
+
+    it("writes and reads back the same content", () => {
+      const manifest = buildManifest(targetDir, {
+        skills: ["a", "b"],
+        hooks: ["c"],
+        mcpServers: ["d", "e"],
+      });
+      const path = writeManifest(manifest);
+      expect(existsSync(path)).toBe(true);
+
+      const loaded = loadManifest(targetDir);
+      expect(loaded).toEqual(manifest);
+    });
+
+    it("creates the manifests/ directory on first write", () => {
+      expect(existsSync(resolve(airHome, "manifests"))).toBe(false);
+      writeManifest(buildManifest(targetDir, {}));
+      expect(existsSync(resolve(airHome, "manifests"))).toBe(true);
+    });
+
+    it("returns null for a corrupt manifest file", () => {
+      const path = getManifestPath(targetDir);
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, "{ not valid json");
+      expect(loadManifest(targetDir)).toBeNull();
+    });
+
+    it("returns null for a manifest with wrong shape (missing fields)", () => {
+      const path = getManifestPath(targetDir);
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, JSON.stringify({ version: 1, target: targetDir }));
+      expect(loadManifest(targetDir)).toBeNull();
+    });
+
+    it("returns null for a manifest with non-string-array fields", () => {
+      const path = getManifestPath(targetDir);
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(
+        path,
+        JSON.stringify({
+          version: 1,
+          target: targetDir,
+          skills: [1, 2, 3],
+          hooks: [],
+          mcpServers: [],
+        })
+      );
+      expect(loadManifest(targetDir)).toBeNull();
+    });
+
+    it("preserves the version field on round-trip", () => {
+      const manifest = buildManifest(targetDir, { skills: ["x"] });
+      writeManifest(manifest);
+      const raw = readFileSync(getManifestPath(targetDir), "utf-8");
+      expect(JSON.parse(raw).version).toBe(MANIFEST_VERSION);
+    });
+  });
+
+  describe("buildManifest", () => {
+    it("normalizes undefined selection fields to empty arrays", () => {
+      const manifest = buildManifest(targetDir, {});
+      expect(manifest.skills).toEqual([]);
+      expect(manifest.hooks).toEqual([]);
+      expect(manifest.mcpServers).toEqual([]);
+    });
+
+    it("stores the resolved absolute target path", () => {
+      const manifest = buildManifest(targetDir + "/./", {});
+      expect(manifest.target).toBe(resolve(targetDir));
+    });
+
+    it("copies the arrays so later mutation of the input doesn't mutate the manifest", () => {
+      const skills = ["a"];
+      const manifest = buildManifest(targetDir, { skills });
+      skills.push("b");
+      expect(manifest.skills).toEqual(["a"]);
+    });
+  });
+
+  describe("diffManifest", () => {
+    const prev: Manifest = {
+      version: 1,
+      target: "/tmp/x",
+      skills: ["s1", "s2", "s3"],
+      hooks: ["h1", "h2"],
+      mcpServers: ["m1", "m2"],
+    };
+
+    it("returns all empty when prev is null", () => {
+      const diff = diffManifest(null, {
+        skills: ["s1"],
+        hooks: ["h1"],
+        mcpServers: ["m1"],
+      });
+      expect(diff).toEqual({
+        staleSkills: [],
+        staleHooks: [],
+        staleMcpServers: [],
+      });
+    });
+
+    it("returns IDs removed from the new selection", () => {
+      const diff = diffManifest(prev, {
+        skills: ["s1"],
+        hooks: [],
+        mcpServers: ["m1", "m2", "m3"],
+      });
+      expect(diff.staleSkills).toEqual(["s2", "s3"]);
+      expect(diff.staleHooks).toEqual(["h1", "h2"]);
+      expect(diff.staleMcpServers).toEqual([]);
+    });
+
+    it("treats undefined new-selection fields as empty (everything stale)", () => {
+      const diff = diffManifest(prev, {});
+      expect(diff.staleSkills).toEqual(["s1", "s2", "s3"]);
+      expect(diff.staleHooks).toEqual(["h1", "h2"]);
+      expect(diff.staleMcpServers).toEqual(["m1", "m2"]);
+    });
+
+    it("returns empty arrays when selection is a superset", () => {
+      const diff = diffManifest(prev, {
+        skills: ["s1", "s2", "s3", "s4"],
+        hooks: ["h1", "h2"],
+        mcpServers: ["m1", "m2", "m3"],
+      });
+      expect(diff).toEqual({
+        staleSkills: [],
+        staleHooks: [],
+        staleMcpServers: [],
+      });
+    });
+  });
+});

--- a/packages/core/tests/manifest.test.ts
+++ b/packages/core/tests/manifest.test.ts
@@ -59,6 +59,20 @@ describe("manifest", () => {
         process.env.HOME = original;
       }
     });
+
+    it("throws when neither AIR_HOME nor HOME nor USERPROFILE is set", () => {
+      delete process.env.AIR_HOME;
+      const originalHome = process.env.HOME;
+      const originalProfile = process.env.USERPROFILE;
+      delete process.env.HOME;
+      delete process.env.USERPROFILE;
+      try {
+        expect(() => getDefaultAirHome()).toThrow(/AIR home/);
+      } finally {
+        if (originalHome !== undefined) process.env.HOME = originalHome;
+        if (originalProfile !== undefined) process.env.USERPROFILE = originalProfile;
+      }
+    });
   });
 
   describe("getManifestPath", () => {
@@ -138,6 +152,31 @@ describe("manifest", () => {
           version: 1,
           target: targetDir,
           skills: [1, 2, 3],
+          hooks: [],
+          mcpServers: [],
+        })
+      );
+      expect(loadManifest(targetDir)).toBeNull();
+    });
+
+    it.each([
+      "../escape",
+      "..",
+      ".",
+      "a/b",
+      "a\\b",
+      "/abs",
+      "with\0null",
+      "",
+    ])("rejects manifests whose IDs would escape the target dir: %s", (badId) => {
+      const path = getManifestPath(targetDir);
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(
+        path,
+        JSON.stringify({
+          version: 1,
+          target: targetDir,
+          skills: [badId],
           hooks: [],
           mcpServers: [],
         })

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.40"
+    "@pulsemcp/air-core": "0.0.41"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/adapter-claude/src/claude-adapter.ts
+++ b/packages/extensions/adapter-claude/src/claude-adapter.ts
@@ -270,6 +270,7 @@ export class ClaudeAdapter implements AgentAdapter {
       this.validateIds(artifacts.hooks, hookIds, "hook");
     }
     const prevHookIds = new Set(prevManifest?.hooks ?? []);
+    const registeredHookIds: string[] = [];
     for (const hookId of hookIds) {
       const hook = artifacts.hooks[hookId];
 
@@ -286,22 +287,31 @@ export class ClaudeAdapter implements AgentAdapter {
       // want it registered in settings.json on this run.
       if (!alreadyExists) {
         const hookSourceDir = hook.path;
-        if (existsSync(hookSourceDir)) {
-          this.copyDirRecursive(hookSourceDir, hookTargetDir);
+        if (!existsSync(hookSourceDir)) {
+          // Source is gone — don't register the hook or track it in the
+          // manifest. Otherwise the ID gets recorded as "AIR-owned" with
+          // nothing backing it, and a later user-created dir at the same
+          // path would be mis-identified as stale on the next run.
+          continue;
         }
+        this.copyDirRecursive(hookSourceDir, hookTargetDir);
         if (hook.references && hook.references.length > 0) {
           this.copyReferences(hook.references, hookTargetDir, artifacts);
         }
       }
 
       hookPaths.push(hookTargetDir);
+      registeredHookIds.push(hookId);
     }
 
     // 6. Register AIR-owned hooks in .claude/settings.json.
     //    Always prune settings entries that AIR previously wrote (stale +
     //    current) so that re-runs don't accumulate duplicates and stale
     //    entries are cleaned up even when no current hooks are active.
-    const managedHookIds = new Set<string>([...diff.staleHooks, ...hookIds]);
+    const managedHookIds = new Set<string>([
+      ...diff.staleHooks,
+      ...registeredHookIds,
+    ]);
     const settingsPath = this.reconcileSettingsHooks(
       targetDir,
       hookPaths,
@@ -312,10 +322,11 @@ export class ClaudeAdapter implements AgentAdapter {
     }
 
     // 7. Persist the updated manifest so the next run can reconcile against it.
+    //    Only IDs that AIR actually wrote/touched go into the manifest.
     writeManifest(
       buildManifest(targetDir, {
         skills: skillIds,
-        hooks: hookIds,
+        hooks: registeredHookIds,
         mcpServers: finalMcpServerIds,
       })
     );

--- a/packages/extensions/adapter-claude/src/claude-adapter.ts
+++ b/packages/extensions/adapter-claude/src/claude-adapter.ts
@@ -6,6 +6,7 @@ import {
   readFileSync,
   readdirSync,
   copyFileSync,
+  rmSync,
   statSync,
 } from "fs";
 import { join, dirname, relative } from "path";
@@ -21,6 +22,12 @@ import type {
   PrepareSessionOptions,
   PreparedSession,
   LocalArtifacts,
+} from "@pulsemcp/air-core";
+import {
+  buildManifest,
+  diffManifest,
+  loadManifest,
+  writeManifest,
 } from "@pulsemcp/air-core";
 import { scanLocalSkills } from "./scan-local-skills.js";
 
@@ -129,6 +136,13 @@ export class ClaudeAdapter implements AgentAdapter {
     const skillPaths: string[] = [];
     const hookPaths: string[] = [];
 
+    // Load the manifest that records which artifacts this adapter wrote on
+    // the previous run. IDs present here but not in the new selection are
+    // stale and get cleaned up before we write. Missing or corrupt manifests
+    // yield null — that's treated as "no prior state" so the current run is
+    // purely additive.
+    const prevManifest = loadManifest(targetDir);
+
     // 1. Resolve which artifacts to activate (overrides take precedence over root defaults)
     let mcpServerIds = options?.mcpServerOverrides
       ?? root?.default_mcp_servers
@@ -188,9 +202,39 @@ export class ClaudeAdapter implements AgentAdapter {
     // 2. Validate skill IDs
     this.validateIds(artifacts.skills, skillIds, "skill");
 
-    // 3. Write .mcp.json (${VAR} patterns are left as-is for transforms to resolve)
-    const mcpConfig = this.translateMcpServers(mcpServers);
+    // 2a. Reconcile against prior manifest — remove stale artifacts before
+    //     writing new ones. Only IDs previously written by AIR are candidates;
+    //     user-authored content is left untouched.
+    const finalMcpServerIds = [...(mcpServerIds ?? [])];
+    const diff = diffManifest(prevManifest, {
+      skills: skillIds,
+      hooks: hookIds,
+      mcpServers: finalMcpServerIds,
+    });
+
+    for (const staleSkillId of diff.staleSkills) {
+      const staleDir = join(targetDir, ".claude", "skills", staleSkillId);
+      if (existsSync(staleDir)) {
+        rmSync(staleDir, { recursive: true, force: true });
+      }
+    }
+
+    for (const staleHookId of diff.staleHooks) {
+      const staleDir = join(targetDir, ".claude", "hooks", staleHookId);
+      if (existsSync(staleDir)) {
+        rmSync(staleDir, { recursive: true, force: true });
+      }
+    }
+
+    // 3. Write .mcp.json (${VAR} patterns are left as-is for transforms to resolve).
+    //    Preserve any mcpServers keys not managed by AIR (user-authored),
+    //    remove keys for stale IDs, and replace keys for the current selection.
     const mcpConfigPath = join(targetDir, ".mcp.json");
+    const mcpConfig = this.mergeMcpConfig(
+      mcpConfigPath,
+      this.translateMcpServers(mcpServers),
+      diff.staleMcpServers
+    );
     writeFileSync(mcpConfigPath, JSON.stringify(mcpConfig, null, 2) + "\n");
     configFiles.push(mcpConfigPath);
 
@@ -216,44 +260,73 @@ export class ClaudeAdapter implements AgentAdapter {
       }
     }
 
-    // 5. Validate and inject path-based hooks into .claude/hooks/
+    // 5. Validate and inject path-based hooks into .claude/hooks/.
+    //    A hook is "AIR-registered" iff AIR wrote (or previously wrote) its
+    //    directory — i.e. the dir didn't pre-exist as user content before any
+    //    AIR run touched it. `hookPaths` collects dirs to register in
+    //    settings.json (includes both freshly-written dirs and ones carried
+    //    over from the prior manifest run).
     if (hookIds.length > 0) {
       this.validateIds(artifacts.hooks, hookIds, "hook");
     }
+    const prevHookIds = new Set(prevManifest?.hooks ?? []);
     for (const hookId of hookIds) {
       const hook = artifacts.hooks[hookId];
 
       const hookTargetDir = join(targetDir, ".claude", "hooks", hookId);
+      const alreadyExists = existsSync(hookTargetDir);
 
-      // Skip if hook already exists locally (local takes priority)
-      if (existsSync(hookTargetDir)) continue;
-
-      // Copy hook directory contents (paths are absolute from resolveArtifacts)
-      const hookSourceDir = hook.path;
-      if (existsSync(hookSourceDir)) {
-        this.copyDirRecursive(hookSourceDir, hookTargetDir);
-        hookPaths.push(hookTargetDir);
+      // A dir that already exists and was NOT tracked in the prior manifest
+      // is user-authored — preserve it and skip both copy and registration.
+      if (alreadyExists && !prevHookIds.has(hookId)) {
+        continue;
       }
 
-      // Copy referenced documents
-      if (hook.references && hook.references.length > 0) {
-        this.copyReferences(hook.references, hookTargetDir, artifacts);
+      // AIR-owned dir: copy (fresh) or re-register (carried over). We always
+      // want it registered in settings.json on this run.
+      if (!alreadyExists) {
+        const hookSourceDir = hook.path;
+        if (existsSync(hookSourceDir)) {
+          this.copyDirRecursive(hookSourceDir, hookTargetDir);
+        }
+        if (hook.references && hook.references.length > 0) {
+          this.copyReferences(hook.references, hookTargetDir, artifacts);
+        }
       }
+
+      hookPaths.push(hookTargetDir);
     }
 
-    // 6. Register copied hooks in .claude/settings.json
-    if (hookPaths.length > 0) {
-      const settingsPath = this.registerHooksInSettings(targetDir, hookPaths);
+    // 6. Register AIR-owned hooks in .claude/settings.json.
+    //    Always prune settings entries that AIR previously wrote (stale +
+    //    current) so that re-runs don't accumulate duplicates and stale
+    //    entries are cleaned up even when no current hooks are active.
+    const managedHookIds = new Set<string>([...diff.staleHooks, ...hookIds]);
+    const settingsPath = this.reconcileSettingsHooks(
+      targetDir,
+      hookPaths,
+      managedHookIds
+    );
+    if (settingsPath) {
       configFiles.push(settingsPath);
     }
 
-    // 7. Generate ephemeral subagent context for system prompt
+    // 7. Persist the updated manifest so the next run can reconcile against it.
+    writeManifest(
+      buildManifest(targetDir, {
+        skills: skillIds,
+        hooks: hookIds,
+        mcpServers: finalMcpServerIds,
+      })
+    );
+
+    // 8. Generate ephemeral subagent context for system prompt
     let subagentContext: string | undefined;
     if (subagentRoots.length > 0) {
       subagentContext = this.buildSubagentContext(subagentRoots);
     }
 
-    // 8. Build start command (include --append-system-prompt if subagent context exists)
+    // 9. Build start command (include --append-system-prompt if subagent context exists)
     // Pass undefined as root — prepareSession already handled all filtering/validation above.
     // Passing root here would cause generateConfig to re-validate with the original (pre-merge)
     // root defaults, which is both redundant and fragile.
@@ -476,21 +549,70 @@ export class ClaudeAdapter implements AgentAdapter {
   }
 
   /**
-   * Read HOOK.json from each copied hook directory and register the hooks
-   * in Claude Code's .claude/settings.json under the mapped event name.
-   * Merges with any existing settings; multiple hooks on the same event
-   * are appended to the event's array.
+   * Reconcile `.claude/settings.json` with the current hook selection.
+   *
+   * Removes any hook entries previously written by AIR (identified via the
+   * `_airHookId` marker on each entry) whose ID is in `managedHookIds`,
+   * leaving user-authored entries untouched. Then registers the hooks in
+   * `newHookPaths` for each mapped event, tagging each new entry with its
+   * hook ID so future runs can identify it.
+   *
+   * Returns the settings path if it was touched (written or an existing file
+   * pruned), otherwise `null` — callers include the path in configFiles only
+   * when relevant.
    */
-  private registerHooksInSettings(targetDir: string, hookPaths: string[]): string {
+  private reconcileSettingsHooks(
+    targetDir: string,
+    newHookPaths: string[],
+    managedHookIds: Set<string>
+  ): string | null {
     const settingsPath = join(targetDir, ".claude", "settings.json");
+    const settingsExists = existsSync(settingsPath);
+
+    // No settings file and nothing to write — nothing to do.
+    if (!settingsExists && newHookPaths.length === 0) {
+      return null;
+    }
+
     let settings: Record<string, unknown> = {};
-    if (existsSync(settingsPath)) {
-      settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    if (settingsExists) {
+      try {
+        settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+      } catch {
+        // Treat an unparseable settings.json as empty — same contract as
+        // the manifest's corrupt-file fallback. The adapter never silently
+        // mangles user state; it just rewrites with the new selection.
+        settings = {};
+      }
     }
 
     const hooks = (settings.hooks ?? {}) as Record<string, unknown[]>;
 
-    for (const hookPath of hookPaths) {
+    for (const event of Object.keys(hooks)) {
+      const matcherGroups = hooks[event];
+      if (!Array.isArray(matcherGroups)) continue;
+      const prunedGroups: unknown[] = [];
+      for (const group of matcherGroups) {
+        if (!group || typeof group !== "object") {
+          prunedGroups.push(group);
+          continue;
+        }
+        const g = group as Record<string, unknown>;
+        const inner = Array.isArray(g.hooks) ? (g.hooks as unknown[]) : [];
+        const keptInner = inner.filter(
+          (h) => !this.isManagedHookEntry(h, managedHookIds)
+        );
+        if (keptInner.length === 0) continue;
+        prunedGroups.push({ ...g, hooks: keptInner });
+      }
+      if (prunedGroups.length === 0) {
+        delete hooks[event];
+      } else {
+        hooks[event] = prunedGroups;
+      }
+    }
+
+    for (const hookPath of newHookPaths) {
       const hookJsonPath = join(hookPath, "HOOK.json");
       if (!existsSync(hookJsonPath)) continue;
 
@@ -510,9 +632,13 @@ export class ClaudeAdapter implements AgentAdapter {
         hookJson.args as string[] | undefined
       );
 
+      // hookPath is .claude/hooks/<id>/, so the last path segment is the id.
+      const hookId = hookPath.split(/[\\/]/).filter(Boolean).pop() || "";
+
       const hookEntry: Record<string, unknown> = {
         type: "command",
         command,
+        _airHookId: hookId,
       };
       if (hookJson.timeout_seconds != null) {
         hookEntry.timeout = hookJson.timeout_seconds;
@@ -529,10 +655,73 @@ export class ClaudeAdapter implements AgentAdapter {
       (hooks[claudeEvent] as unknown[]).push(matcherGroup);
     }
 
-    settings.hooks = hooks;
+    // When the adapter was asked to register new hooks, keep `settings.hooks`
+    // present (even if all registrations were skipped — unknown events,
+    // malformed HOOK.json, etc.) so downstream consumers see a stable shape.
+    // When we're only pruning stale entries, drop an empty hooks object.
+    if (newHookPaths.length > 0 || Object.keys(hooks).length > 0) {
+      settings.hooks = hooks;
+    } else {
+      delete settings.hooks;
+    }
+
     mkdirSync(dirname(settingsPath), { recursive: true });
     writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
     return settingsPath;
+  }
+
+  /**
+   * Check whether a settings hook entry was written by AIR — i.e., carries
+   * an `_airHookId` marker whose value is in the managed set. User-authored
+   * entries (no marker, or a marker AIR doesn't know about) are left alone.
+   */
+  private isManagedHookEntry(entry: unknown, managedHookIds: Set<string>): boolean {
+    if (!entry || typeof entry !== "object") return false;
+    const id = (entry as Record<string, unknown>)._airHookId;
+    if (typeof id !== "string") return false;
+    return managedHookIds.has(id);
+  }
+
+  /**
+   * Merge translated MCP server config with an existing `.mcp.json`,
+   * preserving user-authored keys. Keys listed in `staleIds` are deleted
+   * (they were written by a prior AIR run and are no longer selected),
+   * and keys from `translated.mcpServers` are set/replaced for the current
+   * selection. Other top-level fields in the existing file pass through.
+   */
+  private mergeMcpConfig(
+    mcpConfigPath: string,
+    translated: Record<string, unknown>,
+    staleIds: string[]
+  ): Record<string, unknown> {
+    const translatedServers =
+      (translated.mcpServers as Record<string, unknown>) ?? {};
+
+    let existing: Record<string, unknown> = {};
+    if (existsSync(mcpConfigPath)) {
+      try {
+        existing = JSON.parse(readFileSync(mcpConfigPath, "utf-8"));
+      } catch {
+        // Unparseable existing file — start fresh rather than mangle it.
+        existing = {};
+      }
+    }
+
+    const existingServers =
+      (existing.mcpServers as Record<string, unknown>) ?? {};
+
+    const mergedServers: Record<string, unknown> = { ...existingServers };
+    for (const id of staleIds) {
+      delete mergedServers[id];
+    }
+    for (const [id, config] of Object.entries(translatedServers)) {
+      mergedServers[id] = config;
+    }
+
+    return {
+      ...existing,
+      mcpServers: mergedServers,
+    };
   }
 
   /**

--- a/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
+++ b/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "fs";
 import { resolve, join } from "path";
 import { tmpdir } from "os";
@@ -265,6 +265,8 @@ describe("ClaudeAdapter", () => {
 
   describe("prepareSession", () => {
     let tempDir: string;
+    let airHomeDir: string;
+    let originalAirHome: string | undefined;
 
     function createTempDir(): string {
       tempDir = resolve(
@@ -275,9 +277,27 @@ describe("ClaudeAdapter", () => {
       return tempDir;
     }
 
+    beforeEach(() => {
+      // Sandbox the per-user AIR home so manifest writes don't pollute ~/.air/
+      airHomeDir = resolve(
+        tmpdir(),
+        `air-home-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      );
+      originalAirHome = process.env.AIR_HOME;
+      process.env.AIR_HOME = airHomeDir;
+    });
+
     afterEach(() => {
       if (tempDir && existsSync(tempDir)) {
         rmSync(tempDir, { recursive: true, force: true });
+      }
+      if (airHomeDir && existsSync(airHomeDir)) {
+        rmSync(airHomeDir, { recursive: true, force: true });
+      }
+      if (originalAirHome === undefined) {
+        delete process.env.AIR_HOME;
+      } else {
+        process.env.AIR_HOME = originalAirHome;
       }
     });
 
@@ -2052,6 +2072,248 @@ describe("ClaudeAdapter", () => {
 
         const mcpJson = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
         expect(Object.keys(mcpJson.mcpServers)).toEqual(["github"]);
+      });
+    });
+
+    describe("manifest-based reconciliation", () => {
+      // End-to-end: run prepareSession twice with different selections and
+      // assert that artifacts removed from the selection are cleaned up,
+      // while user-authored artifacts and pre-existing .mcp.json keys are
+      // preserved. This exercises the full manifest round-trip: build →
+      // write → load → diff → cleanup.
+
+      function writeSkillSrc(dir: string, id: string): string {
+        const src = join(dir, "..", `src-${id}`, "skills", id);
+        mkdirSync(src, { recursive: true });
+        writeFileSync(join(src, "SKILL.md"), `---\nname: ${id}\n---\n# ${id}`);
+        return resolve(src);
+      }
+
+      function writeHookSrc(dir: string, id: string, command: string): string {
+        const src = join(dir, "..", `src-${id}`, "hooks", id);
+        mkdirSync(src, { recursive: true });
+        writeFileSync(
+          join(src, "HOOK.json"),
+          JSON.stringify({ event: "session_start", command })
+        );
+        return resolve(src);
+      }
+
+      it("removes stale skills, hooks, and MCP servers on re-run with a different selection", async () => {
+        const dir = createTempDir();
+
+        const artifacts = emptyArtifacts();
+        artifacts.skills["skill-a"] = {
+          description: "A",
+          path: writeSkillSrc(dir, "skill-a"),
+        };
+        artifacts.skills["skill-b"] = {
+          description: "B",
+          path: writeSkillSrc(dir, "skill-b"),
+        };
+        artifacts.hooks["hook-a"] = {
+          description: "A",
+          path: writeHookSrc(dir, "hook-a", "cmd-a"),
+        };
+        artifacts.hooks["hook-b"] = {
+          description: "B",
+          path: writeHookSrc(dir, "hook-b", "cmd-b"),
+        };
+        artifacts.mcp["mcp-a"] = { type: "stdio", command: "cmd-a" };
+        artifacts.mcp["mcp-b"] = { type: "stdio", command: "cmd-b" };
+
+        // First run: selection A (everything).
+        await adapter.prepareSession(artifacts, dir, {
+          root: {
+            description: "Test",
+            default_skills: ["skill-a", "skill-b"],
+            default_hooks: ["hook-a", "hook-b"],
+            default_mcp_servers: ["mcp-a", "mcp-b"],
+          },
+        });
+
+        expect(existsSync(join(dir, ".claude", "skills", "skill-a"))).toBe(true);
+        expect(existsSync(join(dir, ".claude", "skills", "skill-b"))).toBe(true);
+        expect(existsSync(join(dir, ".claude", "hooks", "hook-a"))).toBe(true);
+        expect(existsSync(join(dir, ".claude", "hooks", "hook-b"))).toBe(true);
+        {
+          const mcp = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
+          expect(Object.keys(mcp.mcpServers).sort()).toEqual(["mcp-a", "mcp-b"]);
+          const settings = JSON.parse(
+            readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
+          );
+          expect(settings.hooks.SessionStart).toHaveLength(2);
+        }
+
+        // Second run: selection B (drops -b of each type).
+        await adapter.prepareSession(artifacts, dir, {
+          root: {
+            description: "Test",
+            default_skills: ["skill-a"],
+            default_hooks: ["hook-a"],
+            default_mcp_servers: ["mcp-a"],
+          },
+        });
+
+        expect(existsSync(join(dir, ".claude", "skills", "skill-a"))).toBe(true);
+        expect(existsSync(join(dir, ".claude", "skills", "skill-b"))).toBe(false);
+        expect(existsSync(join(dir, ".claude", "hooks", "hook-a"))).toBe(true);
+        expect(existsSync(join(dir, ".claude", "hooks", "hook-b"))).toBe(false);
+
+        const mcp = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
+        expect(Object.keys(mcp.mcpServers)).toEqual(["mcp-a"]);
+
+        const settings = JSON.parse(
+          readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
+        );
+        expect(settings.hooks.SessionStart).toHaveLength(1);
+        expect(settings.hooks.SessionStart[0].hooks[0].command).toBe("cmd-a");
+      });
+
+      it("preserves user-authored MCP servers and settings hooks across re-runs", async () => {
+        const dir = createTempDir();
+
+        const artifacts = emptyArtifacts();
+        artifacts.hooks["hook-a"] = {
+          description: "A",
+          path: writeHookSrc(dir, "hook-a", "cmd-a"),
+        };
+        artifacts.mcp["mcp-a"] = { type: "stdio", command: "cmd-a" };
+
+        // Seed .mcp.json and .claude/settings.json with user-authored entries
+        // that AIR must never touch.
+        mkdirSync(join(dir, ".claude"), { recursive: true });
+        writeFileSync(
+          join(dir, ".mcp.json"),
+          JSON.stringify({
+            mcpServers: {
+              "user-mcp": { type: "stdio", command: "user-cmd" },
+            },
+          })
+        );
+        writeFileSync(
+          join(dir, ".claude", "settings.json"),
+          JSON.stringify({
+            permissions: { allow: ["Bash(*)"] },
+            hooks: {
+              SessionStart: [
+                {
+                  matcher: "",
+                  hooks: [{ type: "command", command: "user-hook.sh" }],
+                },
+              ],
+            },
+          })
+        );
+
+        // First run: AIR adds mcp-a and hook-a.
+        await adapter.prepareSession(artifacts, dir, {
+          root: {
+            description: "Test",
+            default_hooks: ["hook-a"],
+            default_mcp_servers: ["mcp-a"],
+          },
+        });
+
+        // Second run: AIR removes mcp-a and hook-a. User entries must remain.
+        await adapter.prepareSession(artifacts, dir, {
+          root: {
+            description: "Test",
+            default_hooks: [],
+            default_mcp_servers: [],
+          },
+        });
+
+        const mcp = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf-8"));
+        expect(mcp.mcpServers["user-mcp"]).toEqual({
+          type: "stdio",
+          command: "user-cmd",
+        });
+        expect(mcp.mcpServers["mcp-a"]).toBeUndefined();
+
+        const settings = JSON.parse(
+          readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
+        );
+        expect(settings.permissions).toEqual({ allow: ["Bash(*)"] });
+        expect(settings.hooks.SessionStart).toHaveLength(1);
+        expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(
+          "user-hook.sh"
+        );
+        expect(existsSync(join(dir, ".claude", "hooks", "hook-a"))).toBe(false);
+      });
+
+      it("treats a missing manifest as no prior state (no cleanup, no error)", async () => {
+        const dir = createTempDir();
+
+        const artifacts = emptyArtifacts();
+        artifacts.skills["skill-a"] = {
+          description: "A",
+          path: writeSkillSrc(dir, "skill-a"),
+        };
+
+        // No prior manifest on disk → first run should just write artifacts.
+        await adapter.prepareSession(artifacts, dir, {
+          root: { description: "Test", default_skills: ["skill-a"] },
+        });
+
+        expect(existsSync(join(dir, ".claude", "skills", "skill-a"))).toBe(true);
+      });
+
+      it("treats a corrupt manifest as no prior state (falls back cleanly)", async () => {
+        const dir = createTempDir();
+
+        const artifacts = emptyArtifacts();
+        artifacts.skills["skill-a"] = {
+          description: "A",
+          path: writeSkillSrc(dir, "skill-a"),
+        };
+
+        // Write a corrupt manifest file at the exact path the adapter will
+        // try to load. diffManifest should see `null` and do nothing stale.
+        const { getManifestPath } = await import("@pulsemcp/air-core");
+        const manifestPath = getManifestPath(dir);
+        mkdirSync(join(manifestPath, "..").replace(/\/+$/, "") || "/", {
+          recursive: true,
+        });
+        writeFileSync(manifestPath, "{ not valid json");
+
+        await expect(
+          adapter.prepareSession(artifacts, dir, {
+            root: { description: "Test", default_skills: ["skill-a"] },
+          })
+        ).resolves.toBeDefined();
+
+        expect(existsSync(join(dir, ".claude", "skills", "skill-a"))).toBe(true);
+      });
+
+      it("does not error when user has already deleted a previously-managed artifact", async () => {
+        const dir = createTempDir();
+
+        const artifacts = emptyArtifacts();
+        artifacts.skills["skill-a"] = {
+          description: "A",
+          path: writeSkillSrc(dir, "skill-a"),
+        };
+
+        // First run: writes skill-a and records it in the manifest.
+        await adapter.prepareSession(artifacts, dir, {
+          root: { description: "Test", default_skills: ["skill-a"] },
+        });
+        expect(existsSync(join(dir, ".claude", "skills", "skill-a"))).toBe(true);
+
+        // User manually deletes the skill between runs.
+        rmSync(join(dir, ".claude", "skills", "skill-a"), {
+          recursive: true,
+          force: true,
+        });
+
+        // Second run with an empty selection: cleanup should be a no-op,
+        // not throw on the missing directory.
+        await expect(
+          adapter.prepareSession(artifacts, dir, {
+            root: { description: "Test", default_skills: [] },
+          })
+        ).resolves.toBeDefined();
       });
     });
   });

--- a/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
+++ b/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "fs";
-import { resolve, join } from "path";
+import { resolve, join, dirname } from "path";
 import { tmpdir } from "os";
 import { ClaudeAdapter } from "../src/claude-adapter.js";
 import type {
@@ -2272,9 +2272,7 @@ describe("ClaudeAdapter", () => {
         // try to load. diffManifest should see `null` and do nothing stale.
         const { getManifestPath } = await import("@pulsemcp/air-core");
         const manifestPath = getManifestPath(dir);
-        mkdirSync(join(manifestPath, "..").replace(/\/+$/, "") || "/", {
-          recursive: true,
-        });
+        mkdirSync(dirname(manifestPath), { recursive: true });
         writeFileSync(manifestPath, "{ not valid json");
 
         await expect(
@@ -2314,6 +2312,55 @@ describe("ClaudeAdapter", () => {
             root: { description: "Test", default_skills: [] },
           })
         ).resolves.toBeDefined();
+      });
+
+      it("preserves a user-authored .claude/hooks/<id>/ dir when an AIR hook with the same id is selected", async () => {
+        const dir = createTempDir();
+
+        // User pre-populates .claude/hooks/hook-a/ with their own content
+        // BEFORE any AIR run touches this target. The prior manifest is
+        // therefore empty/missing, so the adapter must treat this dir as
+        // user-authored: do not overwrite it and do not register it in
+        // settings.json (the user's HOOK.json may not exist or may differ).
+        const userHookDir = join(dir, ".claude", "hooks", "hook-a");
+        mkdirSync(userHookDir, { recursive: true });
+        writeFileSync(join(userHookDir, "marker.txt"), "user-content");
+
+        const artifacts = emptyArtifacts();
+        artifacts.hooks["hook-a"] = {
+          description: "A",
+          path: writeHookSrc(dir, "hook-a", "air-cmd"),
+        };
+
+        await adapter.prepareSession(artifacts, dir, {
+          root: { description: "Test", default_hooks: ["hook-a"] },
+        });
+
+        // User's content survives — the catalog version was NOT copied over.
+        expect(
+          readFileSync(join(userHookDir, "marker.txt"), "utf-8")
+        ).toBe("user-content");
+        expect(existsSync(join(userHookDir, "HOOK.json"))).toBe(false);
+
+        // The hook was NOT registered in settings.json: the user's dir
+        // is theirs to register however they like.
+        const settingsPath = join(dir, ".claude", "settings.json");
+        if (existsSync(settingsPath)) {
+          const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+          const sessionStart = settings.hooks?.SessionStart ?? [];
+          const airEntries = sessionStart.flatMap(
+            (g: { hooks?: Array<{ _airHookId?: string }> }) =>
+              (g.hooks ?? []).filter((h) => h._airHookId === "hook-a")
+          );
+          expect(airEntries).toHaveLength(0);
+        }
+
+        // The next run with an empty selection must NOT delete the user's
+        // dir — it isn't in the manifest, so it isn't a cleanup candidate.
+        await adapter.prepareSession(artifacts, dir, {
+          root: { description: "Test", default_hooks: [] },
+        });
+        expect(existsSync(join(userHookDir, "marker.txt"))).toBe(true);
       });
     });
   });

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.40"
+    "@pulsemcp/air-core": "0.0.41"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.40",
+    "@pulsemcp/air-core": "0.0.41",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.40"
+    "@pulsemcp/air-core": "0.0.41"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.40"
+    "@pulsemcp/air-core": "0.0.41"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.40"
+    "@pulsemcp/air-core": "0.0.41"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -18,6 +18,14 @@ export {
   detectSchemaFromValue,
   getAllSchemaTypes,
   isValidSchemaType,
+  // Manifest
+  MANIFEST_VERSION,
+  getDefaultAirHome,
+  getManifestPath,
+  loadManifest,
+  writeManifest,
+  buildManifest,
+  diffManifest,
 } from "@pulsemcp/air-core";
 
 // Re-export core types
@@ -60,6 +68,10 @@ export type {
   ResolveOptions,
   // Schema types
   SchemaType,
+  // Manifest types
+  Manifest,
+  ManifestSelection,
+  ManifestDiff,
 } from "@pulsemcp/air-core";
 
 // Adapter registry


### PR DESCRIPTION
## Summary

- Adds a per-target manifest at `~/.air/manifests/<sha256(absolute target dir)>.json` that records the skill, hook, and MCP server IDs AIR wrote on each `prepareSession` run.
- The Claude adapter now diffs the prior manifest against the new selection and cleans up stale artifacts: removes `.claude/skills/<id>/` and `.claude/hooks/<id>/` dirs, deletes the `mcpServers.<id>` key from `.mcp.json`, and prunes matching hook entries in `.claude/settings.json`. User-authored artifacts are never touched.
- Hook entries in `.claude/settings.json` now carry an `_airHookId` marker so future runs can identify AIR-owned entries without a path-prefix heuristic. Fixes a duplicate-registration bug on re-runs when the hook dir already existed.
- `.mcp.json` write is now a merge: user-added `mcpServers` keys and other top-level fields pass through unchanged across runs.

Closes #87

## Changes

- `packages/core/src/manifest.ts` (new): `loadManifest`, `writeManifest`, `buildManifest`, `diffManifest`, and `getManifestPath` helpers. Honors `AIR_HOME` env var for state-dir relocation. `getDefaultAirHome` throws when neither `AIR_HOME`, `HOME`, nor `USERPROFILE` is set (rather than silently writing into the cwd). Manifest parser rejects IDs containing path separators, `..`, `.`, null bytes, or empty strings — defense in depth against path traversal during cleanup.
- `packages/extensions/adapter-claude/src/claude-adapter.ts`: manifest read → diff → cleanup → selection copy → manifest write, with local-priority guard that uses the prior manifest as the source of truth for AIR ownership. Hooks whose source directory doesn't exist on disk are now skipped (not registered and not recorded in the new manifest), matching the existing behavior for skills and MCP servers.
- Docs updated in `docs/guides/{running-sessions,hooks,configuring-mcp-servers,managing-skills}.md`.
- Version bumped 0.0.40 → 0.0.41 across all packages; CHANGELOG entry added.

## Verification

- [x] Tests added and passing: 21 manifest unit tests (including 8 new path-traversal rejection cases) + 6 adapter integration tests (including a new user-authored hook dir preservation case); full suite 669 passing locally
- [x] Self-review of diff complete
- [x] Subagent PR review with fresh eyes; feedback addressed (see "Review fixes" below)
- [x] Docs updated (`air-update-docs` skill)
- [x] Version bumped in lockstep (`air-version-bump` skill) — 0.0.41 after rebase onto main
- [x] Rebased onto latest `main` (which published 0.0.37–0.0.40 while this PR was open); conflicts resolved cleanly with both sets of changes preserved
- [x] CI green (confirmed via `wait-for-ci` after push — see checks below)

### Review fixes

From the subagent fresh-eyes review, I addressed:

- **C1 (critical):** Manifest parser now rejects IDs that would escape the target dir during cleanup (path separators, `..`, absolute paths, null bytes, empty strings). The manifest file lives in the user's home so this is defense in depth, but cheap to enforce.
- **N1:** `getDefaultAirHome` throws when no home can be determined instead of returning `".air"` relative to cwd — prevents silently writing state into arbitrary working directories.
- **W1:** Hooks whose source directory is missing are now skipped (not registered, not manifested), matching skill and MCP server behavior. Prevents partially-populated manifests when catalogs are stale.
- **W4:** Test helper uses `dirname(manifestPath)` instead of a hand-rolled path slicing trick — more robust if manifest path layout changes.
- **W5:** Added explicit integration test that a pre-existing user-authored `.claude/hooks/<id>/` directory is preserved when a catalog hook with the same id is selected (no overwrite, no settings.json registration, no deletion on empty re-run).

### Proof of working behavior

**Unit tests (`packages/core/tests/manifest.test.ts`, 21 tests):** cover manifest path hashing, load/write/buildManifest/diffManifest, corrupt file recovery, schema-shape validation, `AIR_HOME` override, throw-on-no-home, and path-traversal ID rejection.

**Integration tests (`packages/extensions/adapter-claude/tests/claude-adapter.test.ts`, 6 new tests in the `manifest-based reconciliation` block):**

1. *Second run drops a skill* → `.claude/skills/<dropped-id>/` is removed on disk; surviving skill dirs untouched.
2. *Second run drops a hook* → `.claude/hooks/<dropped-id>/` removed AND the corresponding `_airHookId`-tagged entry is pruned from `.claude/settings.json.hooks.*`; user-authored entries without `_airHookId` remain.
3. *Second run drops an MCP server* → the stale key is deleted from `.mcp.json`'s `mcpServers`, user-added keys and top-level fields pass through.
4. *User-authored artifact preservation* → pre-existing `.claude/hooks/<id>/` dirs not in the prior manifest are left alone (local wins); catalog version is skipped for copy AND registration.
5. *Corrupt/missing manifest recovery* → treated as an empty prior selection; nothing is deleted; new manifest is written correctly.
6. *New: User-authored hook dir with id-collision with catalog hook* → the local directory is preserved verbatim, no HOOK.json is written, no settings.json registration occurs, and subsequent empty selection does not delete it.

**Test output (local, 2026-04-24):**

```
Test Files  37 passed (37)
     Tests  669 passed (669)
```

**Before/after state examples from the integration tests:**

*`.claude/skills/` after run 1 with skills `[a, b]`, then run 2 with `[a]`:*

```
run 1 → .claude/skills/a/, .claude/skills/b/
run 2 → .claude/skills/a/      (b/ removed)
manifest → { skills: ["a"], ... }
```

*`.claude/settings.json` hook entries after drop:*

```json
// run 1
{ "hooks": { "PreToolUse": [{ "hooks": [{ "command": "...", "_airHookId": "hook-a" }, { "command": "...", "_airHookId": "hook-b" }] }] } }
// run 2 (hook-b dropped)
{ "hooks": { "PreToolUse": [{ "hooks": [{ "command": "...", "_airHookId": "hook-a" }] }] } }
```

*`.mcp.json` after drop (user key preserved):*

```json
// run 1
{ "mcpServers": { "air-managed": { }, "user-added": { } } }
// run 2 (air-managed dropped)
{ "mcpServers": { "user-added": { } } }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)