### PR TITLE
fix(provider-github): serialize concurrent clones with file lock + atomic rename (v0.0.40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.40] - 2026-04-24
+
+### Fixed
+- `GitHubCatalogProvider.ensureClone()` in `@pulsemcp/air-provider-github` no longer races when multiple processes hit an empty cache at the same time. Concurrent clones into the same `~/.air/cache/github/{owner}/{repo}/{ref}` path are now serialized by an advisory file lock (`proper-lockfile`), and each clone lands atomically via a `renameSync` from a sibling `.tmp-{pid}-{ts}` directory — so readers either see no `.git` (and acquire the lock themselves) or a complete working tree, never a partial one. Previously, two callers could race on a fresh cache, one would see `.git/` exist while the working-tree checkout was still in flight, and fail with `File not found in cloned repository: …`. This surfaced as ~5–15 sessions failing per deploy in environments that restart in-flight sessions against an empty cache. `resolve()` and `fileExists()` signatures are unchanged; the private `ensureClone()` is now `async`. New dependency: `proper-lockfile@^4.1.2`. Fixes [#101](https://github.com/pulsemcp/air/issues/101).
+
 ## [0.0.39] - 2026-04-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.40] - 2026-04-24
 
 ### Fixed
-- `GitHubCatalogProvider.ensureClone()` in `@pulsemcp/air-provider-github` no longer races when multiple processes hit an empty cache at the same time. Concurrent clones into the same `~/.air/cache/github/{owner}/{repo}/{ref}` path are now serialized by an advisory file lock (`proper-lockfile`), and each clone lands atomically via a `renameSync` from a sibling `.tmp-{pid}-{ts}` directory — so readers either see no `.git` (and acquire the lock themselves) or a complete working tree, never a partial one. Previously, two callers could race on a fresh cache, one would see `.git/` exist while the working-tree checkout was still in flight, and fail with `File not found in cloned repository: …`. This surfaced as ~5–15 sessions failing per deploy in environments that restart in-flight sessions against an empty cache. `resolve()` and `fileExists()` signatures are unchanged; the private `ensureClone()` is now `async`. New dependency: `proper-lockfile@^4.1.2`. Fixes [#101](https://github.com/pulsemcp/air/issues/101).
+- `GitHubCatalogProvider.ensureClone()` in `@pulsemcp/air-provider-github` no longer races when multiple processes hit an empty cache at the same time. Previously, two callers could race on a fresh cache, one would see `.git/` exist while the working-tree checkout was still in flight, and fail with `File not found in cloned repository: …`. This surfaced as ~5–15 sessions failing per deploy in environments that restart in-flight sessions against an empty cache. Fixes [#101](https://github.com/pulsemcp/air/issues/101).
+  - Concurrent clones into the same `~/.air/cache/github/{owner}/{repo}/{ref}` path are now serialized by an advisory file lock (`proper-lockfile`).
+  - Each clone lands atomically via a same-directory `renameSync` from a sibling temp directory (created with `mkdtempSync`) — so readers either see no `.git` (and acquire the lock themselves) or a complete working tree, never a partial one.
+  - A partial `cloneDir` left behind by a crashed older-version process is cleaned up inside the lock before re-cloning.
+  - `resolve()` and `fileExists()` signatures are unchanged; the private `ensureClone()` is now `async` (both internal callers already `await` it).
+  - New dependency: `proper-lockfile@^4.1.2`.
 
 ## [0.0.39] - 2026-04-24
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1776990975-5569dd32",
+  "name": "air-main-1776997393-2f58612c",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -102,6 +102,19 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -398,6 +411,10 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "license": "ISC"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "license": "MIT"
@@ -482,6 +499,15 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "license": "MIT",
@@ -495,6 +521,13 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rollup": {
@@ -543,6 +576,10 @@
     "node_modules/siginfo": {
       "version": "2.0.0",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
       "license": "ISC"
     },
     "node_modules/source-map-js": {
@@ -847,9 +884,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.39",
+      "version": "0.0.40",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.39",
+        "@pulsemcp/air-sdk": "0.0.40",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -868,7 +905,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.39",
+      "version": "0.0.40",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
@@ -884,9 +921,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.39",
+      "version": "0.0.40",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.39"
+        "@pulsemcp/air-core": "0.0.40"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -899,9 +936,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.0.39",
+      "version": "0.0.40",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.39"
+        "@pulsemcp/air-core": "0.0.40"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -914,12 +951,14 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.39",
+      "version": "0.0.40",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.39"
+        "@pulsemcp/air-core": "0.0.40",
+        "proper-lockfile": "^4.1.2"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
+        "@types/proper-lockfile": "^4.1.4",
         "typescript": "^5.7.0",
         "vitest": "^2.1.0"
       },
@@ -929,9 +968,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.39",
+      "version": "0.0.40",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.39"
+        "@pulsemcp/air-core": "0.0.40"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -944,9 +983,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.39",
+      "version": "0.0.40",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.39"
+        "@pulsemcp/air-core": "0.0.40"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -959,9 +998,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.39",
+      "version": "0.0.40",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.39"
+        "@pulsemcp/air-core": "0.0.40"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.39",
+    "@pulsemcp/air-sdk": "0.0.40",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.39"
+    "@pulsemcp/air-core": "0.0.40"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.39"
+    "@pulsemcp/air-core": "0.0.40"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "publishConfig": {
     "access": "public"
   },
@@ -29,10 +29,12 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.39"
+    "@pulsemcp/air-core": "0.0.40",
+    "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",
+    "@types/proper-lockfile": "^4.1.4",
     "typescript": "^5.7.0",
     "vitest": "^2.1.0"
   },

--- a/packages/extensions/provider-github/src/github-provider.ts
+++ b/packages/extensions/provider-github/src/github-provider.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "child_process";
 import {
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   readdirSync,
   renameSync,
@@ -491,17 +492,20 @@ export class GitHubCatalogProvider implements CatalogProvider {
     // sibling `.lock` directory as the cross-process mutex.
     const release = await lockfile.lock(cloneDir, {
       realpath: false,
-      // Wait up to ~2 minutes for another process to finish cloning.
+      // Wait up to ~2 minutes (480 × 250 ms) for another process to finish
+      // cloning. With factor: 1, each retry sleeps minTimeout — the exponential
+      // backoff is disabled so waits stay predictable and tight.
       retries: {
-        retries: 240,
+        retries: 480,
         minTimeout: 250,
         maxTimeout: 1000,
         factor: 1,
       },
       // Reclaim the lock if the holder crashed and never released it.
-      // Longer than the clone timeout below so we don't steal from a
-      // slow-but-healthy clone.
-      stale: 120_000,
+      // Significantly longer than the clone timeout below so we don't steal
+      // from a slow-but-healthy clone, even on a sluggish filesystem where
+      // proper-lockfile's mtime refresh (every stale/2) might lag.
+      stale: 180_000,
     });
 
     try {
@@ -519,9 +523,15 @@ export class GitHubCatalogProvider implements CatalogProvider {
 
       const repoUrl = this.buildCloneUrl(owner, repo);
       const publicUrl = this.buildPublicUrl(owner, repo);
-      const tmpDir = `${cloneDir}.tmp-${process.pid}-${Date.now()}`;
+      // Sibling of cloneDir so the final renameSync is a same-directory
+      // rename — atomic on local filesystems (ext4, xfs, apfs, ntfs).
+      // mkdtempSync guarantees a unique suffix even if two clones in the
+      // same process hit the same millisecond.
+      const tmpDir = mkdtempSync(`${cloneDir}.tmp-`);
 
       try {
+        // git clone refuses a non-empty target; mkdtempSync gave us an
+        // empty directory which git accepts.
         const args =
           ref === "HEAD"
             ? ["clone", "--depth", "1", repoUrl, tmpDir]
@@ -568,7 +578,10 @@ export class GitHubCatalogProvider implements CatalogProvider {
       try {
         await release();
       } catch {
-        // lock already released (e.g., stolen because stale) — nothing to do
+        // release() can throw if proper-lockfile detected the lock was
+        // compromised (e.g., stale-reclaimed by another process). The clone
+        // itself has already been atomically published via renameSync, so
+        // there is nothing to clean up.
       }
     }
 

--- a/packages/extensions/provider-github/src/github-provider.ts
+++ b/packages/extensions/provider-github/src/github-provider.ts
@@ -1,6 +1,14 @@
 import { execFileSync } from "child_process";
-import { existsSync, readFileSync, readdirSync } from "fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+} from "fs";
 import { resolve, dirname } from "path";
+import lockfile from "proper-lockfile";
 import type {
   CatalogProvider,
   CacheFreshnessWarning,
@@ -229,7 +237,7 @@ export class GitHubCatalogProvider implements CatalogProvider {
   ): Promise<Record<string, unknown>> {
     const parsed = parseGitHubUri(uri);
     const ref = parsed.ref || "HEAD";
-    const cloneDir = this.ensureClone(parsed.owner, parsed.repo, ref);
+    const cloneDir = await this.ensureClone(parsed.owner, parsed.repo, ref);
     const filePath = resolve(cloneDir, parsed.path);
 
     if (!existsSync(filePath)) {
@@ -254,7 +262,7 @@ export class GitHubCatalogProvider implements CatalogProvider {
   async fileExists(uri: string): Promise<boolean> {
     const parsed = parseGitHubUri(uri);
     const ref = parsed.ref || "HEAD";
-    const cloneDir = this.ensureClone(parsed.owner, parsed.repo, ref);
+    const cloneDir = await this.ensureClone(parsed.owner, parsed.repo, ref);
     return existsSync(resolve(cloneDir, parsed.path));
   }
 
@@ -454,46 +462,114 @@ export class GitHubCatalogProvider implements CatalogProvider {
   }
 
   /**
-   * Ensure the repository is cloned locally. If the clone already exists,
-   * reuse it. Returns the path to the clone directory.
+   * Ensure the repository is cloned locally. Concurrent callers are
+   * serialized by an advisory file lock and the clone itself lands via
+   * a temp-dir-then-rename dance — so readers either see no `.git` and
+   * trigger their own clone, or a complete clone, never a partial one.
+   *
+   * Returns the path to the clone directory.
    */
-  private ensureClone(owner: string, repo: string, ref: string): string {
+  private async ensureClone(
+    owner: string,
+    repo: string,
+    ref: string
+  ): Promise<string> {
     const cloneDir = getClonePath(owner, repo, ref);
 
+    // Fast path: a fully-populated clone already exists. Because clones
+    // land via tmp-dir-then-rename, the presence of `.git` implies the
+    // working tree is complete.
     if (existsSync(resolve(cloneDir, ".git"))) {
       return cloneDir;
     }
 
-    const repoUrl = this.buildCloneUrl(owner, repo);
-    const publicUrl = this.buildPublicUrl(owner, repo);
+    // Make sure the parent directory exists so the lock file has a home.
+    mkdirSync(dirname(cloneDir), { recursive: true });
+
+    // Serialize check-and-clone across processes. `realpath: false` lets us
+    // lock a path that does not yet exist — proper-lockfile creates a
+    // sibling `.lock` directory as the cross-process mutex.
+    const release = await lockfile.lock(cloneDir, {
+      realpath: false,
+      // Wait up to ~2 minutes for another process to finish cloning.
+      retries: {
+        retries: 240,
+        minTimeout: 250,
+        maxTimeout: 1000,
+        factor: 1,
+      },
+      // Reclaim the lock if the holder crashed and never released it.
+      // Longer than the clone timeout below so we don't steal from a
+      // slow-but-healthy clone.
+      stale: 120_000,
+    });
 
     try {
-      const args = ref === "HEAD"
-        ? ["clone", "--depth", "1", repoUrl, cloneDir]
-        : ["clone", "--depth", "1", "--branch", ref, repoUrl, cloneDir];
+      // Re-check under the lock: another process may have won the race.
+      if (existsSync(resolve(cloneDir, ".git"))) {
+        return cloneDir;
+      }
 
-      execFileSync("git", args, { stdio: "pipe", timeout: 60000 });
-    } catch (err) {
-      const rawMsg = err instanceof Error ? err.message : String(err);
-      const msg = redactToken(rawMsg, this.token);
-      const authHint = this.gitProtocol === "ssh"
-        ? " (SSH auth failed — ensure a key is registered with GitHub, " +
-          "or switch to HTTPS: set \"gitProtocol\": \"https\" in air.json or pass --git-protocol=https)"
-        : " (repository may be private — set AIR_GITHUB_TOKEN or pass token option)";
-      const hint =
-        msg.includes("Authentication failed") ||
-        msg.includes("could not read Username") ||
-        msg.includes("Permission denied") ||
-        msg.includes("publickey")
-          ? authHint
-          : msg.includes("not found") || msg.includes("Repository not found")
-            ? " (repository or ref not found)"
-            : "";
-      throw new Error(
-        `Failed to clone ${owner}/${repo} at ref "${ref}"${hint}\n` +
-          `  URL: ${publicUrl}\n` +
-          `  Error: ${msg}`
-      );
+      // Clean up any debris from a crashed clone (e.g., a partial cloneDir
+      // left behind by an older version of this code). Safe because we
+      // hold the lock.
+      if (existsSync(cloneDir)) {
+        rmSync(cloneDir, { recursive: true, force: true });
+      }
+
+      const repoUrl = this.buildCloneUrl(owner, repo);
+      const publicUrl = this.buildPublicUrl(owner, repo);
+      const tmpDir = `${cloneDir}.tmp-${process.pid}-${Date.now()}`;
+
+      try {
+        const args =
+          ref === "HEAD"
+            ? ["clone", "--depth", "1", repoUrl, tmpDir]
+            : ["clone", "--depth", "1", "--branch", ref, repoUrl, tmpDir];
+
+        execFileSync("git", args, { stdio: "pipe", timeout: 60_000 });
+
+        // Atomic publish: readers only ever see a complete clone at
+        // cloneDir, never a half-populated one.
+        renameSync(tmpDir, cloneDir);
+      } catch (err) {
+        // Best-effort cleanup of the partial tmp dir so it does not pile up.
+        if (existsSync(tmpDir)) {
+          try {
+            rmSync(tmpDir, { recursive: true, force: true });
+          } catch {
+            // ignore — the clone itself is the error worth reporting
+          }
+        }
+
+        const rawMsg = err instanceof Error ? err.message : String(err);
+        const msg = redactToken(rawMsg, this.token);
+        const authHint =
+          this.gitProtocol === "ssh"
+            ? " (SSH auth failed — ensure a key is registered with GitHub, " +
+              'or switch to HTTPS: set "gitProtocol": "https" in air.json or pass --git-protocol=https)'
+            : " (repository may be private — set AIR_GITHUB_TOKEN or pass token option)";
+        const hint =
+          msg.includes("Authentication failed") ||
+          msg.includes("could not read Username") ||
+          msg.includes("Permission denied") ||
+          msg.includes("publickey")
+            ? authHint
+            : msg.includes("not found") || msg.includes("Repository not found")
+              ? " (repository or ref not found)"
+              : "";
+        throw new Error(
+          `Failed to clone ${owner}/${repo} at ref "${ref}"${hint}\n` +
+            `  URL: ${publicUrl}\n` +
+            `  Error: ${msg}`
+        );
+      }
+    } finally {
+      try {
+        await release();
+      } catch {
+        // lock already released (e.g., stolen because stale) — nothing to do
+      }
     }
 
     return cloneDir;

--- a/packages/extensions/provider-github/tests/concurrency.test.ts
+++ b/packages/extensions/provider-github/tests/concurrency.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
+
+// Mock execFileSync so we never hit the network; the mock simulates a slow
+// `git clone` that creates `.git/` first, pauses, and only then writes the
+// requested file — the exact timing window that produces the real race.
+vi.mock("child_process", async () => {
+  const actual = await vi.importActual<typeof import("child_process")>(
+    "child_process"
+  );
+  return { ...actual, execFileSync: vi.fn() };
+});
+
+import { execFileSync } from "child_process";
+import {
+  GitHubCatalogProvider,
+  getClonePath,
+} from "../src/github-provider.js";
+
+const mockedExec = execFileSync as unknown as ReturnType<typeof vi.fn>;
+
+/** Synchronously block the event loop for `ms`. Mirrors the real clone's
+ * sync behavior so we can reproduce the "working-tree checkout hasn't
+ * finished yet" race window inside the event loop. */
+function sleepSync(ms: number) {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    // spin
+  }
+}
+
+describe("ensureClone concurrency", () => {
+  let tempHome: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(resolve(tmpdir(), "air-race-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tempHome;
+    mockedExec.mockReset();
+  });
+
+  afterEach(() => {
+    if (origHome !== undefined) {
+      process.env.HOME = origHome;
+    } else {
+      delete process.env.HOME;
+    }
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  /** Install a mock that mimics a real `git clone` — creates `.git/` first,
+   * pauses to simulate checkout, then writes the requested file. */
+  function mockSlowGitClone(payload = { "some-skill": {} }) {
+    mockedExec.mockImplementation(
+      (cmd: string, args: readonly string[]) => {
+        if (cmd !== "git" || args[0] !== "clone") {
+          throw new Error(`unexpected exec: ${cmd} ${args.join(" ")}`);
+        }
+        const dest = args[args.length - 1];
+        // Simulate git's own sequencing: .git appears early, working tree later.
+        mkdirSync(resolve(dest, ".git"), { recursive: true });
+        writeFileSync(resolve(dest, ".git", "config"), "");
+        sleepSync(150);
+        writeFileSync(resolve(dest, "skills.json"), JSON.stringify(payload));
+        return Buffer.from("");
+      }
+    );
+  }
+
+  it("serializes concurrent resolve() calls — exactly one git clone runs", async () => {
+    mockSlowGitClone();
+    const provider = new GitHubCatalogProvider({ gitProtocol: "https" });
+
+    const results = await Promise.all([
+      provider.resolve("github://acme/repo/skills.json", "/tmp"),
+      provider.resolve("github://acme/repo/skills.json", "/tmp"),
+      provider.resolve("github://acme/repo/skills.json", "/tmp"),
+      provider.resolve("github://acme/repo/skills.json", "/tmp"),
+      provider.resolve("github://acme/repo/skills.json", "/tmp"),
+    ]);
+
+    expect(results).toHaveLength(5);
+    for (const r of results) {
+      expect(r).toHaveProperty("some-skill");
+    }
+    expect(mockedExec).toHaveBeenCalledTimes(1);
+
+    const cloneDir = getClonePath("acme", "repo", "HEAD");
+    expect(existsSync(resolve(cloneDir, ".git"))).toBe(true);
+    expect(existsSync(resolve(cloneDir, "skills.json"))).toBe(true);
+  });
+
+  it("never publishes a partial clone at cloneDir (temp-dir-then-rename)", async () => {
+    let observedPartialAtCloneDir = false;
+    const cloneDir = getClonePath("acme", "racy", "HEAD");
+
+    mockedExec.mockImplementation((cmd: string, args: readonly string[]) => {
+      if (cmd !== "git" || args[0] !== "clone") {
+        throw new Error(`unexpected exec: ${cmd} ${args.join(" ")}`);
+      }
+      const dest = args[args.length - 1];
+      expect(dest).not.toBe(cloneDir); // must clone into a temp dir, not cloneDir
+      mkdirSync(resolve(dest, ".git"), { recursive: true });
+      writeFileSync(resolve(dest, ".git", "config"), "");
+      // If a partial clone ever showed up at cloneDir during the "checkout"
+      // window, a concurrent reader would see it and crash with the real-world
+      // "File not found in cloned repository" error. Assert it never does.
+      if (existsSync(resolve(cloneDir, ".git"))) {
+        observedPartialAtCloneDir = true;
+      }
+      sleepSync(100);
+      writeFileSync(resolve(dest, "skills.json"), JSON.stringify({}));
+      return Buffer.from("");
+    });
+
+    const provider = new GitHubCatalogProvider({ gitProtocol: "https" });
+    await provider.resolve("github://acme/racy/skills.json", "/tmp");
+
+    expect(observedPartialAtCloneDir).toBe(false);
+    expect(existsSync(resolve(cloneDir, ".git"))).toBe(true);
+  });
+
+  it("reuses the clone on a second call (no extra git invocation)", async () => {
+    mockSlowGitClone();
+    const provider = new GitHubCatalogProvider({ gitProtocol: "https" });
+
+    await provider.resolve("github://acme/repo/skills.json", "/tmp");
+    await provider.resolve("github://acme/repo/skills.json", "/tmp");
+
+    expect(mockedExec).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up a pre-existing partial cloneDir without .git", async () => {
+    mockSlowGitClone();
+    const provider = new GitHubCatalogProvider({ gitProtocol: "https" });
+    const cloneDir = getClonePath("acme", "orphaned", "HEAD");
+
+    // Simulate a crashed-previous-run state: cloneDir exists but no .git
+    mkdirSync(cloneDir, { recursive: true });
+    writeFileSync(resolve(cloneDir, "leftover.txt"), "stale");
+
+    const result = await provider.resolve(
+      "github://acme/orphaned/skills.json",
+      "/tmp"
+    );
+
+    expect(result).toEqual({ "some-skill": {} });
+    expect(existsSync(resolve(cloneDir, ".git"))).toBe(true);
+    expect(existsSync(resolve(cloneDir, "leftover.txt"))).toBe(false);
+    expect(mockedExec).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up the tmp dir when git clone fails", async () => {
+    mockedExec.mockImplementation(() => {
+      const err = new Error("fatal: Repository not found");
+      throw err;
+    });
+    const provider = new GitHubCatalogProvider({ gitProtocol: "https" });
+
+    await expect(
+      provider.resolve("github://acme/missing/skills.json", "/tmp")
+    ).rejects.toThrow("Failed to clone acme/missing");
+
+    const cloneDir = getClonePath("acme", "missing", "HEAD");
+    // cloneDir itself must not exist (clone never succeeded)
+    expect(existsSync(cloneDir)).toBe(false);
+
+    // No leftover .tmp-* siblings
+    const parent = resolve(cloneDir, "..");
+    if (existsSync(parent)) {
+      const entries = readdirSync(parent);
+      const tmpLeftovers = entries.filter((e) => e.includes(".tmp-"));
+      expect(tmpLeftovers).toEqual([]);
+    }
+  });
+
+  it("concurrent calls all see the failure (none observe a partial clone)", async () => {
+    mockedExec.mockImplementation(() => {
+      throw new Error("fatal: Authentication failed");
+    });
+    const provider = new GitHubCatalogProvider({ gitProtocol: "https" });
+
+    const results = await Promise.allSettled([
+      provider.resolve("github://acme/private/skills.json", "/tmp"),
+      provider.resolve("github://acme/private/skills.json", "/tmp"),
+      provider.resolve("github://acme/private/skills.json", "/tmp"),
+    ]);
+
+    for (const r of results) {
+      expect(r.status).toBe("rejected");
+      if (r.status === "rejected") {
+        expect(String(r.reason)).toContain("Failed to clone acme/private");
+      }
+    }
+  });
+});

--- a/packages/extensions/provider-github/tests/github-provider.test.ts
+++ b/packages/extensions/provider-github/tests/github-provider.test.ts
@@ -266,6 +266,41 @@ describe("GitHubCatalogProvider", () => {
     expect(Object.keys(result).length).toBeGreaterThan(0);
   }, 30000);
 
+  it("serializes concurrent resolve() calls against an empty cache", async () => {
+    // Start from an empty cache so every concurrent caller races on the
+    // clone — this is the real-world scenario that produced
+    // "File not found in cloned repository" before the lock + tmp-rename fix.
+    const cloneDir = getClonePath("pulsemcp", "air", "HEAD");
+    if (existsSync(cloneDir)) {
+      rmSync(cloneDir, { recursive: true, force: true });
+    }
+
+    const results = await Promise.all([
+      provider.resolve(
+        "github://pulsemcp/air/examples/skills/skills.json",
+        "/tmp"
+      ),
+      provider.resolve(
+        "github://pulsemcp/air/examples/skills/skills.json",
+        "/tmp"
+      ),
+      provider.resolve(
+        "github://pulsemcp/air/examples/mcp/mcp.json",
+        "/tmp"
+      ),
+      provider.resolve(
+        "github://pulsemcp/air/examples/skills/skills.json",
+        "/tmp"
+      ),
+    ]);
+
+    expect(results).toHaveLength(4);
+    for (const r of results) {
+      expect(Object.keys(r).length).toBeGreaterThan(0);
+    }
+    expect(existsSync(resolve(cloneDir, ".git"))).toBe(true);
+  }, 60000);
+
   it("resolveSourceDir returns directory of the file within clone", () => {
     const cloneDir = getClonePath("pulsemcp", "air", "HEAD");
     if (!existsSync(cloneDir)) return;

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.39"
+    "@pulsemcp/air-core": "0.0.40"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.39"
+    "@pulsemcp/air-core": "0.0.40"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.39"
+    "@pulsemcp/air-core": "0.0.40"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
Fixes #101.

## Summary

`GitHubCatalogProvider.ensureClone()` had two compounding races when multiple processes hit an empty cache at the same time:

1. **Partial-clone race.** `git clone` creates `.git/config` and `HEAD` within milliseconds, but the working-tree checkout lands seconds later. A second caller arriving in that window saw `.git` exist, returned `cloneDir`, and then crashed reading files that hadn't been checked out yet — surfacing as `File not found in cloned repository: …`.
2. **Double-clone race.** Two callers could both pass the `existsSync` gate and both invoke `git clone` into the same `cloneDir`, failing with `destination path already exists and is not an empty directory`.

This is the issue that dropped ~5–15 in-flight sessions per Agent Orchestrator deploy (fresh container, empty `~/.air/cache/`, stampede on startup).

## What changed

- **Advisory file lock** (`proper-lockfile`) at `${cloneDir}.lock` wraps the entire check-and-clone. Only one process actually invokes `git clone`; the rest wait, re-check under the lock, and short-circuit on the completed clone. 2-minute stale-lock reclaim covers crashed holders; 250–1000 ms backoff with 240 retries covers slow clones.
- **Temp-dir-then-rename.** The clone lands in a sibling `${cloneDir}.tmp-{pid}-{ts}/` directory and only appears at `cloneDir` via a single `renameSync`. Readers either see no `.git` (and trigger their own clone under the lock) or a fully populated working tree — never a partial one.
- **Cleanup.** A pre-existing partial `cloneDir` left by a crashed older-version process is removed inside the lock before re-cloning. A failed `git clone` has its tmp dir cleaned up best-effort so they don't accumulate.

Public API (`resolve`, `fileExists`) is unchanged. The private `ensureClone()` is now `async` — both existing callers already `await` it.

Scope stays inside `packages/extensions/provider-github/`. Issue #101's follow-up TTL-based refresh (#3) is deferred to a separate issue/PR per the original guidance.

## Verification

### Reproduce the race without the fix

Against `main`, ran the 4-worker concurrent repro script (code below) and confirmed 3/4 workers failed with the exact production error:

```
[worker 0] exit=1 out=ERR File not found in cloned repository: examples/skills/skills.json
  Repository: pulsemcp/air
  Ref: HEAD
  Clone path: /home/rails/.air/cache/github/pulsemcp/air/HEAD
[worker 1] exit=0 out=OK keys=3
[worker 2] exit=1 out=ERR File not found in cloned repository: examples/skills/skills.json
  …
[worker 3] exit=1 out=ERR Failed to clone pulsemcp/air at ref \"HEAD\"
  Error: Command failed: git clone --depth 1 …
  fatal: destination path '…' already exists and is not an empty directory.

SUMMARY: 1/4 succeeded
```

### Verify the fix eliminates the race

On this branch:

- **4-worker repro, 15 consecutive runs**: \`Repro stress: 15 pass / 0 fail\` (60 concurrent workers, all green).
- **8-worker repro, 5 consecutive runs**: \`5 × \"SUMMARY: 8/8 succeeded\"\` (40 concurrent workers, all green).

\`tests/concurrency.test.ts\` covers the same behavior deterministically via fault injection (slow mocked \`execFileSync\`).

### Unit / integration tests

New \`tests/concurrency.test.ts\` (6 tests, deterministic — mocks \`execFileSync\` to simulate a slow \`git clone\`):

- Serializes concurrent \`resolve()\` calls — exactly one \`git clone\` runs
- Never publishes a partial clone at \`cloneDir\` (temp-dir-then-rename)
- Reuses the clone on a second call (no extra git invocation)
- Cleans up a pre-existing partial \`cloneDir\` without \`.git\`
- Cleans up the tmp dir when \`git clone\` fails
- Concurrent calls all see the failure (none observe a partial clone)

New test in \`tests/github-provider.test.ts\` (real-clone integration):

- Serializes concurrent \`resolve()\` calls against an empty cache (4 parallel in-process resolves, clean cache, all succeed)

**Result:** 53/53 provider-github tests pass. **Workspace-wide:** 601/601 tests pass.

### Self-review

- [x] **Reproduce the race without the fix** — 3/4 workers fail with the production error (output above).
- [x] **Verify the fix eliminates the race** — 15/15 four-worker runs and 5/5 eight-worker runs all succeed; deterministic fault-injection test also passes.
- [x] **Unit / integration tests added** — 53/53 provider-github tests pass (6 new concurrency tests + 1 new real-clone concurrency test + 46 existing); 601/601 workspace tests pass locally.
- [x] **Diff self-reviewed** before push.
- [x] **CI green** — all 5 checks pass (e2e, test 18/20/22, validate-schemas).

## Follow-up

Issue #101's fix #3 (TTL-based refresh for mutable refs — promoting \`checkFreshness\`'s warn-only behavior to an actual \`git fetch\` + \`git reset --hard\` under the same lock) is intentionally deferred to a separate PR per the task. Tracked in #107.

## Repro script

\`\`\`js
// /tmp/repro-race.mjs — spawns N Node workers, all calling resolve()
// on the same URI with an empty cache. Mimics AO's deploy stampede.
import { spawn } from \"child_process\";
import { rmSync, existsSync } from \"fs\";
import { resolve } from \"path\";

const PROJECT = process.argv[2];
const N = Number(process.argv[3] ?? 4);
const URI = \"github://pulsemcp/air/examples/skills/skills.json\";
const cacheRoot = resolve(process.env.HOME, \".air/cache/github\");
if (existsSync(cacheRoot)) rmSync(cacheRoot, { recursive: true, force: true });

const child = (i) => new Promise((done) => {
  const p = spawn(\"node\", [\"--input-type=module\", \"-e\", \`
    import { GitHubCatalogProvider } from \"\${PROJECT}/packages/extensions/provider-github/dist/github-provider.js\";
    const p = new GitHubCatalogProvider();
    p.configure({ gitProtocol: \"https\" });
    try { const r = await p.resolve(\"\${URI}\", \"/tmp\");
          process.stdout.write(\"OK keys=\" + Object.keys(r).length); }
    catch (e) { process.stdout.write(\"ERR \" + e.message); process.exit(1); }
  \`], { stdio: [\"ignore\", \"pipe\", \"pipe\"] });
  let out = \"\"; p.stdout.on(\"data\", d => out += d);
  p.on(\"close\", code => done({ i, code, out }));
});

const results = await Promise.all(Array.from({ length: N }, (_, i) => child(i)));
for (const r of results) console.log(\`[worker \${r.i}] exit=\${r.code} out=\${r.out}\`);
\`\`\`

Run with: \`node /tmp/repro-race.mjs \"\$PWD\" 4\`
