### PR TITLE
feat(core): loose catalog introspection (v0.0.42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Loosened catalog introspection.** `catalogs[]` entries in `air.json` now discover AIR artifact indexes anywhere within 3 directory levels of the catalog root, rather than requiring the rigid `<type>/<type>.json` layout. Files are identified by filename (`skills.json`, `roots.json`, `mcp.json`, `references.json`, `plugins.json`, `hooks.json`, or any filename containing those tokens) or by their `$schema`. `.gitignore` at the catalog root is honored; `node_modules`, `.git`, `dist`, `build`, `coverage`, `.next`, `.turbo`, `target`, `vendor`, and hidden directories are skipped. Within a single catalog, duplicate-type indexes merge in sorted relative-path order with later-wins by ID. This unblocks catalogs like `pulsemcp/pulsemcp` that organize indexes under `agents/agent-roots/roots.json` and `agents/mcp-servers/mcp.json`. Fixes [#108](https://github.com/pulsemcp/air/issues/108).
-- **`CatalogProvider` interface: `fileExists` replaced with `resolveCatalogDir`.** Remote catalog providers now return a local directory that AIR walks to discover indexes. `@pulsemcp/air-provider-github` implements this by cloning the repo and returning the resolved subdirectory path.
 - **`parseGitHubUri` accepts whole-repo URIs.** `github://owner/repo` and `github://owner/repo@ref` are now valid catalog URIs — not just paths with subdirectories — so you can point `catalogs[]` at the repo root.
+
+### Fixed
+- **`detectSchemaFromValue` no longer false-matches schema filenames that appear mid-URL.** Previously an unbounded substring check could classify a third-party JSON whose `$schema` URL happened to contain e.g. `"mcp.schema.json"` as an AIR MCP index. The function now matches the last path segment only (ignoring query strings and fragments).
+
+### Breaking
+- **`CatalogProvider.fileExists` removed; `resolveCatalogDir(uri) => Promise<string>` added in its place.** Remote catalog providers now return a local directory that AIR walks to discover indexes. Third-party providers must implement the new method. `@pulsemcp/air-provider-github` has been updated — it clones the repo and returns the resolved subdirectory path.
 
 ## [0.0.41] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.42] - 2026-04-24
+
+### Changed
+- **Loosened catalog introspection.** `catalogs[]` entries in `air.json` now discover AIR artifact indexes anywhere within 3 directory levels of the catalog root, rather than requiring the rigid `<type>/<type>.json` layout. Files are identified by filename (`skills.json`, `roots.json`, `mcp.json`, `references.json`, `plugins.json`, `hooks.json`, or any filename containing those tokens) or by their `$schema`. `.gitignore` at the catalog root is honored; `node_modules`, `.git`, `dist`, `build`, `coverage`, `.next`, `.turbo`, `target`, `vendor`, and hidden directories are skipped. Within a single catalog, duplicate-type indexes merge in sorted relative-path order with later-wins by ID. This unblocks catalogs like `pulsemcp/pulsemcp` that organize indexes under `agents/agent-roots/roots.json` and `agents/mcp-servers/mcp.json`. Fixes [#108](https://github.com/pulsemcp/air/issues/108).
+- **`CatalogProvider` interface: `fileExists` replaced with `resolveCatalogDir`.** Remote catalog providers now return a local directory that AIR walks to discover indexes. `@pulsemcp/air-provider-github` implements this by cloning the repo and returning the resolved subdirectory path.
+- **`parseGitHubUri` accepts whole-repo URIs.** `github://owner/repo` and `github://owner/repo@ref` are now valid catalog URIs — not just paths with subdirectories — so you can point `catalogs[]` at the repo root.
+
 ## [0.0.41] - 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Every AIR configuration starts with an `air.json` file. Each artifact property i
 }
 ```
 
-**Local catalog + shared remote catalog.** Your private team skills live in a directory you maintain (e.g., a sibling repo checked into `~/.air/` or an absolute path elsewhere on disk), layered with an org-wide catalog for shared defaults. When both sources follow the standard `<type>/<type>.json` layout, `catalogs` lets you reference each one with a single entry:
+**Local catalog + shared remote catalog.** Your private team skills live in a directory you maintain (e.g., a sibling repo checked into `~/.air/` or an absolute path elsewhere on disk), layered with an org-wide catalog for shared defaults. AIR walks each catalog up to 3 levels deep and discovers artifact indexes by filename or `$schema`, so `catalogs` lets you reference each source with a single entry regardless of its internal folder layout:
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,7 @@ There is no separate CLI config file. `air.json` is the single composition point
 
 ### Whole-catalog composition
 
-When you're layering full catalogs that follow the standard `<type>/<type>.json` layout, the `catalogs` field lets you reference each catalog once instead of listing every artifact type separately:
+The `catalogs` field lets you reference each catalog once instead of listing every artifact type separately:
 
 ```json
 {
@@ -47,7 +47,18 @@ When you're layering full catalogs that follow the standard `<type>/<type>.json`
 }
 ```
 
-Each entry expands into all six artifact arrays at resolution time; files that aren't present in a given catalog are silently skipped. `catalogs` and the per-type arrays compose — catalogs expand first, per-type arrays layer on top — so you can mix them to pull most artifacts from catalogs and add targeted overrides via the per-type arrays.
+Each entry is treated as a directory (local path or provider URI). AIR walks the catalog up to 3 directory levels deep and picks up any file whose filename or `$schema` identifies it as an AIR artifact index (`skills.json`, `roots.json`, `mcp.json`, `references.json`, `plugins.json`, `hooks.json`, or any filename that contains those keywords as delimited tokens). You are free to organize indexes under whatever folder names suit your repo — `agents/agent-roots/roots.json`, `config/mcp-servers/mcp.json`, and the conventional `<type>/<type>.json` layout all work.
+
+Traversal rules:
+
+- **Depth cap**: 3 levels below the catalog root. Indexes deeper than that must be referenced via explicit per-type arrays.
+- **Skipped directories**: `node_modules`, `.git`, `dist`, `build`, `coverage`, `.next`, `.turbo`, `target`, `vendor`, and any directory starting with `.`.
+- **`.gitignore` at the catalog root**: honored — ignored paths are not descended into.
+- **`$schema` check**: a JSON file whose `$schema` points to a non-AIR schema is skipped even if its filename matches. Files without `$schema` are identified by filename alone.
+
+Within a single catalog, if two indexes of the same type are found, they are merged in sorted relative-path order with later-wins by ID. Across multiple entries in `catalogs[]`, catalogs earlier in the array are merged first; later catalogs override. The per-type arrays (`skills`, `mcp`, …) layer on top of catalog-discovered indexes — catalogs expand first, explicit arrays last.
+
+Remote catalog URIs (e.g. `github://owner/repo@ref/path`) are supported when the matching provider can clone or mount the source locally. You can point at the whole repo (`github://owner/repo`), a ref (`github://owner/repo@main`), or a subdirectory (`github://owner/repo@main/agents`).
 
 ## Merging Strategy
 

--- a/docs/guides/composition-and-overrides.md
+++ b/docs/guides/composition-and-overrides.md
@@ -64,19 +64,27 @@ Full replacement is predictable. You never have to wonder which fields came from
 
 When you want to layer two or more full catalogs — say, a shared team catalog and your own local catalog — you don't need to list every artifact type separately. The `catalogs` field in `air.json` accepts an ordered array of catalog roots, and AIR expands each one into all six artifact arrays automatically.
 
-A **catalog** is a directory (local or remote) that follows AIR's standard layout:
+A **catalog** is a directory (local or remote) containing AIR artifact index files. AIR walks the catalog root up to 3 directory levels deep and discovers any file that looks like an AIR artifact index — either by filename (`skills.json`, `roots.json`, `mcp.json`, `references.json`, `plugins.json`, `hooks.json`, or any filename with those keywords as delimited tokens) or by `$schema`. Your folder layout is up to you:
 
 ```
 <catalog>/
-├── skills/skills.json
-├── references/references.json
+├── skills/skills.json                 # conventional layout
 ├── mcp/mcp.json
-├── plugins/plugins.json
-├── roots/roots.json
-└── hooks/hooks.json
+├── agents/agent-roots/roots.json      # custom subdirectories work too
+├── config/mcp-servers/mcp.json
+└── hooks.json                         # files at the root work as well
 ```
 
-This is the same layout `air init` creates, and it's what each official example in this repo uses. You don't need all six files — any that are missing are silently skipped, so a catalog that only ships skills and MCP servers works fine.
+This is the same layout `air init` creates by default, and it's what each official example in this repo uses — but any layout up to 3 levels deep is accepted. You don't need all six artifact types — a catalog that only ships skills and MCP servers works fine.
+
+**Traversal rules:**
+
+- **Depth cap**: 3 levels below the catalog root. Indexes deeper than that must be referenced via the explicit per-type arrays.
+- **Skipped directories**: `node_modules`, `.git`, `dist`, `build`, `coverage`, `.next`, `.turbo`, `target`, `vendor`, and any directory starting with `.`.
+- **`.gitignore`** at the catalog root is honored — ignored paths are not descended into.
+- **`$schema` check**: a JSON file whose `$schema` points to a non-AIR schema is skipped even if its filename matches. Files without `$schema` are identified by filename alone.
+
+Within a single catalog, if two indexes of the same type are discovered, they merge in sorted relative-path order with later-wins by ID. Across multiple catalogs, earlier entries are merged first; later catalogs override.
 
 ### Two-catalog composition (the common case)
 
@@ -114,9 +122,9 @@ Effective load order for MCP servers: `github://acme/air-org/mcp/mcp.json` → `
 ### When to prefer `catalogs` over per-type arrays
 
 - You're layering full catalogs (org + team + local). `catalogs: [A, B, C]` beats writing each of the six artifact arrays for every catalog.
-- The catalog's layout matches the standard `<type>/<type>.json` convention (which is what `air init` produces).
+- The catalog's index files live within 3 directory levels of the catalog root.
 
-Use the per-type arrays when you want to pull just one artifact type from a source, or when the index file doesn't live at the standard path.
+Use the per-type arrays when you want to pull just one artifact type from a source, or when an index file lives deeper than the discovery depth cap.
 
 ## Layering patterns
 
@@ -151,7 +159,7 @@ A common team shape is a private catalog kept as a sibling directory under `~/.a
 
 The org catalog provides the baseline and the team's local catalog adds team-specific artifacts (and overrides any org defaults it wants to replace).
 
-If your catalogs don't follow the standard layout — or you only need some artifact types from a source — use the per-type arrays instead:
+If you only need some artifact types from a source, or the indexes live deeper than the 3-level discovery cap, use the per-type arrays instead:
 
 ```json
 {
@@ -330,6 +338,8 @@ To effectively "remove" an artifact from an earlier layer, you'd need to overrid
 | Remote + local files | Both loaded, same override rules apply |
 | `catalogs` + per-type arrays | Catalogs expand first, per-type arrays layer on top |
 | Catalog missing an artifact file | Silently skipped — the catalog contributes nothing for that type |
+| Two indexes of the same type in one catalog | Merged in sorted relative-path order, later-wins by ID |
+| Index deeper than 3 levels in a catalog | Not discovered — reference it via the explicit per-type array instead |
 
 ## Next steps
 

--- a/docs/guides/understanding-air-json.md
+++ b/docs/guides/understanding-air-json.md
@@ -57,7 +57,7 @@ You don't need both `catalogs` and the per-type arrays. Use `catalogs` when you'
 | `$schema` | string | JSON Schema URI for editor validation and autocomplete. |
 | `description` | string | Human-readable description of this configuration scope. Max 500 characters. |
 | `extensions` | string[] | Extension packages or local paths to load (adapters, providers, transforms). |
-| `catalogs` | string[] | Paths or URIs to artifact catalogs — directories that follow the standard `<type>/<type>.json` layout. Each catalog expands into all six artifact arrays; missing files are silently skipped. |
+| `catalogs` | string[] | Paths or URIs to artifact catalogs — directories that AIR walks (up to 3 levels deep) to discover artifact index files by filename or `$schema`. `.gitignore` at the catalog root is honored; `node_modules`, `.git`, and common build output directories are skipped. |
 | `skills` | string[] | Paths to skills index files. |
 | `references` | string[] | Paths to references index files. |
 | `mcp` | string[] | Paths to MCP server configuration files. |
@@ -124,9 +124,9 @@ For the common case of layering two or more full catalogs, the `catalogs` field 
 }
 ```
 
-Each entry is a directory that follows the standard AIR layout — `<type>/<type>.json` for each of the six artifact types. AIR expands every catalog into all six artifact arrays at resolution time. Files that aren't present in a catalog are silently skipped, so a catalog can ship only the artifact types it needs.
+Each entry is a directory (local path or provider URI). AIR walks the catalog up to 3 directory levels deep and picks up any file whose filename or `$schema` identifies it as an AIR artifact index (`skills.json`, `roots.json`, `mcp.json`, `references.json`, `plugins.json`, `hooks.json`, or any filename containing those keywords as delimited tokens). Folder names are free — `agents/agent-roots/roots.json`, `config/mcp-servers/mcp.json`, and the conventional `<type>/<type>.json` layout all work.
 
-`catalogs` and the per-type arrays compose: catalogs expand first, then the per-type arrays layer on top. See [Composition and Overrides](composition-and-overrides.md) for details.
+Within a single catalog, if two indexes of the same type are found, they merge in sorted relative-path order with later-wins by ID. Across multiple catalogs, earlier entries are merged first; later catalogs override. Per-type arrays (`skills`, `mcp`, …) layer on top last. See [Composition and Overrides](composition-and-overrides.md) for details.
 
 ### Example
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1776991012-a6f04c43",
+  "name": "air-main-1777056537-b6aae47b",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -14,8 +14,282 @@
         "vitest": "^2.1.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
       "cpu": [
         "x64"
       ],
@@ -29,8 +303,163 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -66,8 +495,248 @@
       "resolved": "packages/extensions/secrets-file",
       "link": true
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
       "cpu": [
         "x64"
       ],
@@ -79,7 +748,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
       ],
@@ -90,13 +761,101 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -105,6 +864,8 @@
     },
     "node_modules/@types/proper-lockfile": {
       "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -113,11 +874,15 @@
     },
     "node_modules/@types/retry": {
       "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -132,6 +897,8 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -157,6 +924,8 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -168,6 +937,8 @@
     },
     "node_modules/@vitest/runner": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -180,6 +951,8 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -193,6 +966,8 @@
     },
     "node_modules/@vitest/spy": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -204,6 +979,8 @@
     },
     "node_modules/@vitest/utils": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -216,7 +993,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -231,6 +1010,8 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -246,6 +1027,8 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -254,6 +1037,8 @@
     },
     "node_modules/cac": {
       "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -262,6 +1047,8 @@
     },
     "node_modules/chai": {
       "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -277,6 +1064,8 @@
     },
     "node_modules/chalk": {
       "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -287,6 +1076,8 @@
     },
     "node_modules/check-error": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -295,6 +1086,8 @@
     },
     "node_modules/commander": {
       "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -302,6 +1095,8 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -318,6 +1113,8 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -326,11 +1123,15 @@
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -368,6 +1169,8 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -376,6 +1179,8 @@
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -384,10 +1189,14 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "funding": [
         {
           "type": "github",
@@ -400,8 +1209,25 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/get-tsconfig": {
-      "version": "4.13.7",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -413,19 +1239,36 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -434,11 +1277,15 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -456,11 +1303,15 @@
     },
     "node_modules/pathe": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -469,11 +1320,15 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -501,6 +1356,8 @@
     },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -510,6 +1367,8 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -517,6 +1376,8 @@
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -525,13 +1386,17 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.1",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -545,45 +1410,51 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -592,26 +1463,36 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinypool": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -620,6 +1501,8 @@
     },
     "node_modules/tinyrainbow": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -628,6 +1511,8 @@
     },
     "node_modules/tinyspy": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -636,6 +1521,8 @@
     },
     "node_modules/tsx": {
       "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -652,8 +1539,282 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tsx/node_modules/@esbuild/linux-x64": {
       "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -667,8 +1828,112 @@
         "node": ">=18"
       }
     },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tsx/node_modules/esbuild": {
       "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -709,6 +1974,8 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -721,11 +1988,15 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -784,6 +2055,8 @@
     },
     "node_modules/vite-node": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -805,6 +2078,8 @@
     },
     "node_modules/vitest": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -869,6 +2144,8 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -884,9 +2161,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.0.41",
+      "version": "0.0.42",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.0.41",
+        "@pulsemcp/air-sdk": "0.0.42",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -905,10 +2182,11 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.0.41",
+      "version": "0.0.42",
       "dependencies": {
         "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1"
+        "ajv-formats": "^3.0.1",
+        "ignore": "^7.0.5"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -921,9 +2199,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.0.41",
+      "version": "0.0.42",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.41"
+        "@pulsemcp/air-core": "0.0.42"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -936,9 +2214,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.0.41",
+      "version": "0.0.42",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.41"
+        "@pulsemcp/air-core": "0.0.42"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -951,9 +2229,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.0.41",
+      "version": "0.0.42",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.41",
+        "@pulsemcp/air-core": "0.0.42",
         "proper-lockfile": "^4.1.2"
       },
       "devDependencies": {
@@ -968,9 +2246,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.0.41",
+      "version": "0.0.42",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.41"
+        "@pulsemcp/air-core": "0.0.42"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -983,9 +2261,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.0.41",
+      "version": "0.0.42",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.41"
+        "@pulsemcp/air-core": "0.0.42"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -998,9 +2276,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.0.41",
+      "version": "0.0.42",
       "dependencies": {
-        "@pulsemcp/air-core": "0.0.41"
+        "@pulsemcp/air-core": "0.0.42"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.0.41",
+    "@pulsemcp/air-sdk": "0.0.42",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/tests/resolve-command.test.ts
+++ b/packages/cli/tests/resolve-command.test.ts
@@ -230,9 +230,6 @@ export default {
   name: "stub-provider-ext",
   provider: {
     scheme: "stub",
-    async fileExists() {
-      return true;
-    },
     async resolve(uri) {
       // Return synthetic MCP server content so we can assert the provider
       // was actually invoked (not just loaded).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "publishConfig": {
     "access": "public"
   },
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "ajv": "^8.17.1",
-    "ajv-formats": "^3.0.1"
+    "ajv-formats": "^3.0.1",
+    "ignore": "^7.0.5"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,5 +1,6 @@
-import { readFileSync, existsSync } from "fs";
+import { readFileSync, readdirSync, existsSync, type Dirent } from "fs";
 import { resolve, dirname } from "path";
+import ignore, { type Ignore } from "ignore";
 import type {
   AirConfig,
   ResolvedArtifacts,
@@ -11,6 +12,11 @@ import type {
   HookEntry,
   CatalogProvider,
 } from "./types.js";
+import {
+  detectSchemaType,
+  detectSchemaFromValue,
+  type SchemaType,
+} from "./schemas.js";
 
 function loadJsonFile(filePath: string): Record<string, unknown> {
   if (!existsSync(filePath)) {
@@ -184,9 +190,7 @@ export function configureProviders(
 }
 
 /**
- * Artifact types recognized by the standard catalog layout.
- * A catalog is a directory where each of these types lives at
- * `<type>/<type>.json` relative to the catalog root.
+ * Artifact types recognized as catalog-expandable primitives.
  */
 type ArtifactType =
   | "skills"
@@ -196,83 +200,236 @@ type ArtifactType =
   | "roots"
   | "hooks";
 
-const CATALOG_LAYOUT: Record<ArtifactType, string> = {
-  skills: "skills/skills.json",
-  references: "references/references.json",
-  mcp: "mcp/mcp.json",
-  plugins: "plugins/plugins.json",
-  roots: "roots/roots.json",
-  hooks: "hooks/hooks.json",
-};
+const ARTIFACT_TYPES: ArtifactType[] = [
+  "skills",
+  "references",
+  "mcp",
+  "plugins",
+  "roots",
+  "hooks",
+];
 
-/** Build the conventional path for a catalog entry + artifact type. */
-function buildCatalogPath(catalog: string, type: ArtifactType): string {
-  return catalog.replace(/\/+$/, "") + "/" + CATALOG_LAYOUT[type];
+/**
+ * Directories never descended into when discovering artifact indexes in a
+ * catalog. Covers common build/vendor dirs and VCS internals.
+ */
+const CATALOG_SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  "coverage",
+  ".next",
+  ".turbo",
+  "target",
+  "vendor",
+]);
+
+/** Maximum directory depth walked under a catalog root (root itself is depth 0). */
+const CATALOG_MAX_DEPTH = 3;
+
+interface DiscoveredIndex {
+  /** Absolute path to the index file. */
+  absPath: string;
+  /** Path relative to the catalog root, forward-slash separated. For deterministic ordering. */
+  relPath: string;
+  /** Artifact type the index provides. */
+  type: ArtifactType;
 }
 
 /**
- * Expand catalog entries into concrete index paths for a given artifact type,
- * filtering to only those that actually exist. Missing files (local or remote)
- * are silently skipped so that a catalog may omit artifact types it doesn't
- * provide.
+ * Read a JSON index file and confirm it is a plausible AIR artifact index of
+ * the given expected type. Returns the detected type or null to signal skip.
+ *
+ * A declared `$schema` always takes precedence over filename detection — a
+ * file named `roots.json` whose `$schema` points at a non-AIR schema is
+ * skipped entirely. Unparseable JSON, arrays, and primitives are skipped.
  */
-async function expandCatalogPaths(
-  catalogs: string[],
-  type: ArtifactType,
+function detectIndexType(
+  absPath: string,
+  filename: string
+): ArtifactType | null {
+  let content: string;
+  try {
+    content = readFileSync(absPath, "utf-8");
+  } catch {
+    return null;
+  }
+  let data: unknown;
+  try {
+    data = JSON.parse(content);
+  } catch {
+    return null;
+  }
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    return null;
+  }
+  const obj = data as Record<string, unknown>;
+
+  let detected: SchemaType | null = null;
+
+  if (typeof obj.$schema === "string") {
+    const bySchema = detectSchemaFromValue(obj.$schema);
+    if (bySchema === null) return null;
+    detected = bySchema;
+  } else {
+    detected = detectSchemaType(filename);
+  }
+
+  if (detected === null) return null;
+  if (detected === "air") return null;
+  if (!ARTIFACT_TYPES.includes(detected as ArtifactType)) return null;
+  return detected as ArtifactType;
+}
+
+/**
+ * Walk a catalog root directory and return all artifact index files found
+ * within `CATALOG_MAX_DEPTH` levels, skipping `CATALOG_SKIP_DIRS`, hidden
+ * entries, and anything matched by a root-level `.gitignore` if present.
+ *
+ * Files are returned sorted by relative path (alphabetic, depth-naive) so
+ * that "later wins" collision semantics within a single catalog are stable
+ * across machines and filesystems.
+ */
+function discoverCatalogIndexes(catalogDir: string): DiscoveredIndex[] {
+  if (!existsSync(catalogDir)) return [];
+
+  const ig: Ignore = ignore();
+  const rootGitignore = resolve(catalogDir, ".gitignore");
+  if (existsSync(rootGitignore)) {
+    try {
+      ig.add(readFileSync(rootGitignore, "utf-8"));
+    } catch {
+      // best effort — a broken .gitignore doesn't block discovery
+    }
+  }
+
+  const discovered: DiscoveredIndex[] = [];
+
+  function recurse(currentDir: string, depth: number, relDir: string): void {
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(currentDir, { withFileTypes: true }) as Dirent[];
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const name = entry.name;
+      if (name.startsWith(".")) continue;
+
+      const rel = relDir === "" ? name : `${relDir}/${name}`;
+      const absPath = resolve(currentDir, name);
+
+      if (entry.isDirectory()) {
+        if (CATALOG_SKIP_DIRS.has(name)) continue;
+        // The `ignore` library expects paths without a leading slash; directory
+        // matching conventionally uses a trailing slash.
+        if (ig.ignores(`${rel}/`)) continue;
+        if (depth + 1 > CATALOG_MAX_DEPTH) continue;
+        recurse(absPath, depth + 1, rel);
+      } else if (entry.isFile()) {
+        if (!name.endsWith(".json")) continue;
+        if (ig.ignores(rel)) continue;
+        const type = detectIndexType(absPath, name);
+        if (!type) continue;
+        discovered.push({ absPath, relPath: rel, type });
+      }
+    }
+  }
+
+  recurse(catalogDir, 0, "");
+
+  discovered.sort((a, b) => a.relPath.localeCompare(b.relPath));
+  return discovered;
+}
+
+/**
+ * Resolve a single catalog entry (local path or provider URI) to a local
+ * directory ready to be walked for index discovery. Throws for URIs whose
+ * scheme has no registered provider, or whose provider does not support
+ * catalog discovery (missing `resolveCatalogDir`).
+ */
+async function resolveCatalogRoot(
+  catalog: string,
   baseDir: string,
   providers: CatalogProvider[]
-): Promise<string[]> {
-  const result: string[] = [];
+): Promise<string> {
+  const scheme = getScheme(catalog);
+  if (!scheme) {
+    return resolve(baseDir, catalog);
+  }
+
+  const provider = providers.find((prov) => prov.scheme === scheme);
+  if (!provider) {
+    throw new Error(
+      `No catalog provider registered for scheme "${scheme}://" (catalog: ${catalog}). ` +
+        `Install an extension that handles this scheme.`
+    );
+  }
+  if (!provider.resolveCatalogDir) {
+    throw new Error(
+      `Provider for "${scheme}://" does not support catalog discovery — ` +
+        `it lacks resolveCatalogDir(). Upgrade the provider extension or ` +
+        `reference its artifact indexes via explicit per-type arrays.`
+    );
+  }
+
+  return await provider.resolveCatalogDir(catalog);
+}
+
+/**
+ * Expand every entry in `catalogs[]` into a per-type map of absolute index
+ * file paths. Each catalog is resolved to a local directory and walked for
+ * artifact index files (depth-capped, gitignore-aware, skip-listed).
+ *
+ * Within a single catalog, files of the same type discovered at multiple
+ * locations are merged in sorted relPath order with later-wins semantics —
+ * the downstream `loadAndMerge` consumes the returned arrays in order and
+ * applies the same "later wins by ID" rule as everywhere else in AIR.
+ *
+ * Across catalogs, catalogs earlier in `catalogs[]` are processed first so
+ * that later catalogs override earlier ones, matching the existing contract.
+ */
+async function expandAllCatalogs(
+  catalogs: string[],
+  baseDir: string,
+  providers: CatalogProvider[]
+): Promise<Record<ArtifactType, string[]>> {
+  const result: Record<ArtifactType, string[]> = {
+    skills: [],
+    references: [],
+    mcp: [],
+    plugins: [],
+    roots: [],
+    hooks: [],
+  };
 
   for (const catalog of catalogs) {
-    const candidate = buildCatalogPath(catalog, type);
-    const scheme = getScheme(candidate);
-
-    if (scheme) {
-      const provider = providers.find((prov) => prov.scheme === scheme);
-      if (!provider) {
-        throw new Error(
-          `No catalog provider registered for scheme "${scheme}://" (catalog: ${catalog}). ` +
-            `Install an extension that handles this scheme.`
-        );
-      }
-
-      if (provider.fileExists) {
-        if (await provider.fileExists(candidate)) {
-          result.push(candidate);
-        }
-        continue;
-      }
-
-      // Note: this also swallows real failures (network, auth) for providers
-      // that don't implement fileExists. Providers used for catalogs should
-      // implement fileExists to surface such errors clearly.
-      try {
-        await provider.resolve(candidate, baseDir);
-        result.push(candidate);
-      } catch {
-        // intentionally empty
-      }
-    } else {
-      const resolvedPath = resolve(baseDir, candidate);
-      if (existsSync(resolvedPath)) {
-        result.push(candidate);
-      }
+    const catalogDir = await resolveCatalogRoot(catalog, baseDir, providers);
+    const discovered = discoverCatalogIndexes(catalogDir);
+    for (const entry of discovered) {
+      result[entry.type].push(entry.absPath);
     }
   }
 
   return result;
 }
 
+
 /**
  * Resolve all artifacts from an air.json file.
  * Each artifact property is an array of paths; files merge in order.
  * Remote URIs are delegated to the matching CatalogProvider.
  *
- * `catalogs` entries are expanded first into per-type paths following the
- * standard layout (`<catalog>/<type>/<type>.json`), then the explicit
- * per-type arrays layer on top. Missing files within a catalog are
- * silently skipped.
+ * `catalogs` entries are expanded first via directory-walking discovery —
+ * each catalog is resolved to a local directory (cloned by the relevant
+ * provider for remote URIs) and walked up to `CATALOG_MAX_DEPTH` levels
+ * for artifact index files. Files are identified by `$schema` (preferred)
+ * or filename, and grouped by artifact type. Skip-listed directories
+ * (node_modules, .git, dist, build, etc.) and entries matched by a
+ * root-level `.gitignore` are not descended into. Explicit per-type
+ * arrays layer on top of catalog-discovered indexes.
  *
  * All `path` fields in resolved entries are absolute paths,
  * making artifacts self-contained regardless of source location.
@@ -290,44 +447,40 @@ export async function resolveArtifacts(
   // explicit providerOptions override them. Providers ignore unknown keys.
   configureProviders(providers, airConfig, options?.providerOptions);
 
-  async function paths(type: ArtifactType, explicit: string[]): Promise<string[]> {
-    const fromCatalogs = await expandCatalogPaths(
-      catalogs,
-      type,
-      baseDir,
-      providers
-    );
-    return [...fromCatalogs, ...explicit];
+  const fromCatalogs = await expandAllCatalogs(catalogs, baseDir, providers);
+
+  function paths(type: ArtifactType, explicit: string[]): string[] {
+    return [...fromCatalogs[type], ...explicit];
   }
 
   const resolved: ResolvedArtifacts = {
     skills: await loadAndMerge<SkillEntry>(
-      await paths("skills", airConfig.skills || []),
+      paths("skills", airConfig.skills || []),
       baseDir,
       providers
     ),
     references: await loadAndMerge<ReferenceEntry>(
-      await paths("references", airConfig.references || []),
+      paths("references", airConfig.references || []),
       baseDir,
       providers
     ),
     mcp: await loadAndMerge<McpServerEntry>(
-      await paths("mcp", airConfig.mcp || []),
+      paths("mcp", airConfig.mcp || []),
       baseDir,
       providers
     ),
     plugins: await loadAndMerge<PluginEntry>(
-      await paths("plugins", airConfig.plugins || []),
+      paths("plugins", airConfig.plugins || []),
       baseDir,
       providers
     ),
     roots: await loadAndMerge<RootEntry>(
-      await paths("roots", airConfig.roots || []),
+      paths("roots", airConfig.roots || []),
       baseDir,
       providers
     ),
     hooks: await loadAndMerge<HookEntry>(
-      await paths("hooks", airConfig.hooks || []),
+      paths("hooks", airConfig.hooks || []),
       baseDir,
       providers
     ),

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -90,11 +90,17 @@ export function detectSchemaType(filename: string): SchemaType | null {
 
 /**
  * Detect schema type from a $schema value in JSON content.
+ *
+ * Matches the last path segment only (before any ?query or #fragment), so
+ * arbitrary URLs that happen to contain a schema filename earlier in their
+ * path — e.g. a third-party `https://example.com/mcp.schema.json/something` —
+ * are NOT misclassified as AIR indexes.
  */
 export function detectSchemaFromValue(schemaValue: string): SchemaType | null {
-  const lower = schemaValue.toLowerCase();
+  const withoutQuery = schemaValue.split(/[?#]/, 1)[0];
+  const basename = (withoutQuery.split(/[\\/]/).pop() || "").toLowerCase();
   for (const type of getAllSchemaTypes()) {
-    if (lower.includes(SCHEMA_FILES[type])) {
+    if (basename === SCHEMA_FILES[type]) {
       return type;
     }
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,10 +7,15 @@ export interface AirConfig {
   description?: string;
   extensions?: string[];
   /**
-   * Catalog references — each entry is a directory (local path or provider URI)
-   * that follows the standard AIR layout: `<type>/<type>.json` for each of the
-   * six artifact types. Catalogs expand into all six artifact arrays in order;
-   * missing files within a catalog are silently skipped. The per-type arrays
+   * Catalog references — each entry is a directory (local path or provider URI).
+   * AIR walks the catalog up to 3 directory levels deep and discovers any file
+   * identified as an AIR artifact index by filename (`skills.json`, `roots.json`,
+   * `mcp.json`, `references.json`, `plugins.json`, `hooks.json`, or any filename
+   * containing those keywords as delimited tokens) or by `$schema`. `.gitignore`
+   * at the catalog root is honored; `node_modules`, `.git`, and common build
+   * output directories are skipped. Within a single catalog, duplicate-type
+   * indexes merge in sorted relative-path order; across catalogs, earlier
+   * entries merge first and later catalogs override. The per-type arrays
    * below layer on top of (and can override) catalog-expanded entries.
    */
   catalogs?: string[];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -279,16 +279,16 @@ export interface CatalogProvider {
    */
   refreshCache?(): Promise<CacheRefreshResult[]>;
   /**
-   * Check whether the URI resolves to an existing file.
-   * Used during catalog expansion to skip conventional paths that aren't
-   * present in a given catalog. Implementations should throw for real
-   * failures (network, auth, missing repo) and only return false for
-   * "file does not exist in an otherwise-reachable source".
+   * Resolve a catalog URI to a local directory that AIR can walk to
+   * discover artifact index files. Providers should ensure the source
+   * is available locally (e.g. by cloning a repo) and return an absolute
+   * path to the catalog's root directory on disk.
    *
-   * If omitted, catalog expansion falls back to trying resolve() and
-   * treating any thrown error as "does not exist".
+   * Required for catalog discovery. Providers that cannot expose a local
+   * directory for a catalog URI will cause catalog expansion to fail with
+   * a clear error — `catalogs[]` entries must be traversable.
    */
-  fileExists?(uri: string): Promise<boolean>;
+  resolveCatalogDir?(uri: string): Promise<string>;
 }
 
 /**

--- a/packages/core/tests/catalogs.test.ts
+++ b/packages/core/tests/catalogs.test.ts
@@ -365,9 +365,17 @@ describe("catalogs", () => {
         name: "test",
         catalogs: ["./cat"],
       },
+      // Depth 0 — file at the catalog root.
+      "cat/roots.json": {
+        "root-level-root": exampleRoot("root-level-root"),
+      },
       // Depth 2 from the catalog root — discovered.
-      "cat/agents/roots.json": {
+      "cat/agents/agent-roots/roots.json": {
         "shallow-root": exampleRoot("shallow-root"),
+      },
+      // Depth 3 — at the cap, still discovered.
+      "cat/a/b/c/roots.json": {
+        "boundary-root": exampleRoot("boundary-root"),
       },
       // Depth 4 — beyond the cap.
       "cat/a/b/c/d/roots.json": {
@@ -377,7 +385,9 @@ describe("catalogs", () => {
     cleanup = c;
 
     const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.roots["root-level-root"]).toBeDefined();
     expect(artifacts.roots["shallow-root"]).toBeDefined();
+    expect(artifacts.roots["boundary-root"]).toBeDefined();
     expect(artifacts.roots["too-deep-root"]).toBeUndefined();
   });
 

--- a/packages/core/tests/catalogs.test.ts
+++ b/packages/core/tests/catalogs.test.ts
@@ -181,45 +181,7 @@ describe("catalogs", () => {
     );
   });
 
-  it("uses a provider's fileExists to skip missing catalog files", async () => {
-    const { dir, cleanup: c } = createTempAirDir({
-      "air.json": {
-        name: "test",
-        catalogs: ["mock://catalog-a"],
-      },
-    });
-    cleanup = c;
-
-    const calls: string[] = [];
-    const provider: CatalogProvider = {
-      scheme: "mock",
-      async fileExists(uri: string): Promise<boolean> {
-        calls.push(`exists:${uri}`);
-        return uri.endsWith("skills/skills.json");
-      },
-      async resolve(uri: string): Promise<Record<string, unknown>> {
-        calls.push(`resolve:${uri}`);
-        if (uri.endsWith("skills/skills.json")) {
-          return { deploy: exampleSkill("deploy") };
-        }
-        throw new Error(`Mock provider asked to resolve unexpected URI: ${uri}`);
-      },
-    };
-
-    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
-      providers: [provider],
-    });
-
-    expect(artifacts.skills["deploy"]).toBeDefined();
-    expect(artifacts.mcp).toEqual({});
-    // fileExists was called for every artifact type, resolve only for the existing one
-    const existsCalls = calls.filter((c) => c.startsWith("exists:"));
-    const resolveCalls = calls.filter((c) => c.startsWith("resolve:"));
-    expect(existsCalls).toHaveLength(6);
-    expect(resolveCalls).toEqual(["resolve:mock://catalog-a/skills/skills.json"]);
-  });
-
-  it("falls back to resolve() when a provider does not implement fileExists", async () => {
+  it("throws a clear error when a provider lacks resolveCatalogDir", async () => {
     const { dir, cleanup: c } = createTempAirDir({
       "air.json": {
         name: "test",
@@ -230,11 +192,41 @@ describe("catalogs", () => {
 
     const provider: CatalogProvider = {
       scheme: "mock2",
-      async resolve(uri: string): Promise<Record<string, unknown>> {
-        if (uri.endsWith("mcp/mcp.json")) {
-          return { server: exampleMcpStdio({ title: "Mock Server" }) };
-        }
-        throw new Error("not found");
+      async resolve(): Promise<Record<string, unknown>> {
+        return {};
+      },
+    };
+
+    await expect(
+      resolveArtifacts(join(dir, "air.json"), { providers: [provider] })
+    ).rejects.toThrow(/does not support catalog discovery/);
+  });
+
+  it("delegates to provider.resolveCatalogDir for remote catalog URIs", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["mock://cat-a"],
+      },
+      // Provider clones "mock://cat-a" into this local directory.
+      "remote-clone/agent-roots/roots.json": {
+        "web-app": exampleRoot("web-app"),
+      },
+      "remote-clone/mcp-servers/mcp.json": {
+        github: exampleMcpStdio({ title: "Remote GitHub" }),
+      },
+    });
+    cleanup = c;
+
+    const calls: string[] = [];
+    const provider: CatalogProvider = {
+      scheme: "mock",
+      async resolveCatalogDir(uri: string): Promise<string> {
+        calls.push(`resolveCatalogDir:${uri}`);
+        return join(dir, "remote-clone");
+      },
+      async resolve(): Promise<Record<string, unknown>> {
+        throw new Error("resolve() should not be called for catalog discovery");
       },
     };
 
@@ -242,8 +234,9 @@ describe("catalogs", () => {
       providers: [provider],
     });
 
-    expect(artifacts.mcp["server"]?.title).toBe("Mock Server");
-    expect(artifacts.skills).toEqual({});
+    expect(artifacts.roots["web-app"]).toBeDefined();
+    expect(artifacts.mcp["github"].title).toBe("Remote GitHub");
+    expect(calls).toEqual(["resolveCatalogDir:mock://cat-a"]);
   });
 
   it("allows per-catalog scoping — explicit arrays are unaffected when no catalogs are listed", async () => {
@@ -274,6 +267,255 @@ describe("catalogs", () => {
     const artifacts = await resolveArtifacts(join(dir, "air.json"));
     expect(artifacts.skills["deploy"]).toBeDefined();
     expect(artifacts.mcp).toEqual({});
+  });
+
+  // ---------------------------------------------------------------------
+  // Loose catalog introspection — catalogs may place indexes anywhere in
+  // the tree (not only under the conventional <type>/<type>.json layout).
+  // ---------------------------------------------------------------------
+
+  it("discovers roots.json under a non-conventional subdirectory name", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./pulsemcp-agents"],
+      },
+      // Mimics pulsemcp/pulsemcp's actual layout from issue #108.
+      "pulsemcp-agents/agent-roots/roots.json": {
+        "air-root": exampleRoot("air-root"),
+      },
+      "pulsemcp-agents/mcp-servers/mcp.json": {
+        github: exampleMcpStdio({ title: "Agent GitHub" }),
+      },
+      // Conventional paths still work alongside.
+      "pulsemcp-agents/skills/skills.json": {
+        deploy: exampleSkill("deploy"),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.roots["air-root"]).toBeDefined();
+    expect(artifacts.mcp["github"].title).toBe("Agent GitHub");
+    expect(artifacts.skills["deploy"]).toBeDefined();
+  });
+
+  it("discovers an index by $schema when filename does not match the type keyword", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./cat"],
+      },
+      // Filename has no catalog-type keyword — only $schema identifies it.
+      "cat/extras/my-config.json": {
+        $schema: "https://pulsemcp.com/air/roots.schema.json",
+        "web-app": exampleRoot("web-app"),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.roots["web-app"]).toBeDefined();
+  });
+
+  it("skips JSON files whose $schema points to a non-AIR schema", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./cat"],
+      },
+      // Filename says "roots" but $schema is explicitly non-AIR — must be skipped.
+      "cat/agent-roots/roots.json": {
+        $schema: "https://example.com/unrelated.schema.json",
+        "web-app": exampleRoot("web-app"),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.roots).toEqual({});
+  });
+
+  it("resolves collisions within a single catalog via last-wins by sorted relPath", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./cat"],
+      },
+      // Sorted alphabetically by relPath: "agent-roots/roots.json" < "experiments/roots/roots.json"
+      // so "experiments" wins when both define the same ID.
+      "cat/agent-roots/roots.json": {
+        "web-app": exampleRoot("web-app", { description: "Agent roots" }),
+      },
+      "cat/experiments/roots/roots.json": {
+        "web-app": exampleRoot("web-app", { description: "Experiments roots" }),
+        "experimental-app": exampleRoot("experimental-app"),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.roots["web-app"].description).toBe("Experiments roots");
+    expect(artifacts.roots["experimental-app"]).toBeDefined();
+  });
+
+  it("caps directory walk at depth 3 from the catalog root", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./cat"],
+      },
+      // Depth 2 from the catalog root — discovered.
+      "cat/agents/roots.json": {
+        "shallow-root": exampleRoot("shallow-root"),
+      },
+      // Depth 4 — beyond the cap.
+      "cat/a/b/c/d/roots.json": {
+        "too-deep-root": exampleRoot("too-deep-root"),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.roots["shallow-root"]).toBeDefined();
+    expect(artifacts.roots["too-deep-root"]).toBeUndefined();
+  });
+
+  it("respects .gitignore at the catalog root", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./cat"],
+      },
+      "cat/.gitignore": "scratch/\ntmp-roots.json\n",
+      "cat/kept/roots.json": {
+        "kept-root": exampleRoot("kept-root"),
+      },
+      // Directory ignored by .gitignore — must not be descended into.
+      "cat/scratch/roots.json": {
+        "ignored-root": exampleRoot("ignored-root"),
+      },
+      // File ignored by .gitignore — must be skipped.
+      "cat/tmp-roots.json": {
+        "tmp-root": exampleRoot("tmp-root"),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.roots["kept-root"]).toBeDefined();
+    expect(artifacts.roots["ignored-root"]).toBeUndefined();
+    expect(artifacts.roots["tmp-root"]).toBeUndefined();
+  });
+
+  it("never descends into hardcoded skip directories (node_modules, .git, dist, …)", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./cat"],
+      },
+      "cat/skills/skills.json": {
+        deploy: exampleSkill("deploy"),
+      },
+      "cat/node_modules/foo/roots.json": {
+        "noise-root": exampleRoot("noise-root"),
+      },
+      "cat/dist/roots.json": {
+        "build-root": exampleRoot("build-root"),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.skills["deploy"]).toBeDefined();
+    expect(artifacts.roots["noise-root"]).toBeUndefined();
+    expect(artifacts.roots["build-root"]).toBeUndefined();
+  });
+
+  it("skips hidden directories and files during discovery", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./cat"],
+      },
+      "cat/skills/skills.json": {
+        deploy: exampleSkill("deploy"),
+      },
+      "cat/.private/roots.json": {
+        "hidden-root": exampleRoot("hidden-root"),
+      },
+      "cat/.stashed-roots.json": {
+        "dotfile-root": exampleRoot("dotfile-root"),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.skills["deploy"]).toBeDefined();
+    expect(artifacts.roots["hidden-root"]).toBeUndefined();
+    expect(artifacts.roots["dotfile-root"]).toBeUndefined();
+  });
+
+  it("ignores JSON files whose filename has no AIR type keyword and no $schema", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./cat"],
+      },
+      "cat/package.json": { name: "not-air", version: "1.0.0" },
+      "cat/tsconfig.json": { compilerOptions: { target: "ES2020" } },
+      "cat/skills/skills.json": {
+        deploy: exampleSkill("deploy"),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.skills["deploy"]).toBeDefined();
+  });
+
+  it("skips unparseable JSON files silently", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./cat"],
+      },
+      "cat/skills/skills.json": {
+        deploy: exampleSkill("deploy"),
+      },
+      // Matches the filename pattern for "roots" but is not valid JSON.
+      "cat/extras/roots.json": "not valid json {{",
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.skills["deploy"]).toBeDefined();
+    expect(artifacts.roots).toEqual({});
+  });
+
+  it("resolves relative path fields against the discovered index's directory", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["./cat"],
+      },
+      "cat/agent-roots/roots.json": {
+        "web-app": {
+          description: "Web app root",
+          default_mcp_servers: [],
+          default_skills: [],
+        },
+      },
+      "cat/custom/skills.json": {
+        "custom-skill": { description: "Custom skill", path: "./actual-dir" },
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+    expect(artifacts.skills["custom-skill"].path).toBe(
+      join(dir, "cat/custom/actual-dir")
+    );
   });
 
   it("expands plugins declared across separate catalogs", async () => {

--- a/packages/core/tests/schemas.test.ts
+++ b/packages/core/tests/schemas.test.ts
@@ -98,6 +98,24 @@ describe("detectSchemaFromValue", () => {
   it("returns null for unknown schemas", () => {
     expect(detectSchemaFromValue("https://example.com/unknown.json")).toBeNull();
   });
+
+  it("does not match a schema filename that appears earlier in the path", () => {
+    expect(
+      detectSchemaFromValue("https://example.com/mcp.schema.json/something.json")
+    ).toBeNull();
+    expect(
+      detectSchemaFromValue("https://example.com/skills.schema.json/else")
+    ).toBeNull();
+  });
+
+  it("ignores query strings and fragments", () => {
+    expect(
+      detectSchemaFromValue("https://example.com/mcp.schema.json?v=1")
+    ).toBe("mcp");
+    expect(
+      detectSchemaFromValue("https://example.com/mcp.schema.json#frag")
+    ).toBe("mcp");
+  });
 });
 
 describe("isValidSchemaType", () => {

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.41"
+    "@pulsemcp/air-core": "0.0.42"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.41"
+    "@pulsemcp/air-core": "0.0.42"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.41",
+    "@pulsemcp/air-core": "0.0.42",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/extensions/provider-github/src/github-provider.ts
+++ b/packages/extensions/provider-github/src/github-provider.ts
@@ -82,14 +82,22 @@ function validateUriComponent(value: string, label: string): void {
  * Parse a github:// URI into its components.
  *
  * Supported formats:
- *   github://owner/repo/path/to/file.json              — default branch
- *   github://owner/repo@ref/path/to/file.json          — ref on repo (preferred)
- *   github://owner/repo/path/to/file.json@ref          — ref on path (legacy)
+ *   github://owner/repo                                  — whole repo (catalogs)
+ *   github://owner/repo@ref                              — whole repo at ref (catalogs)
+ *   github://owner/repo/path/to/file.json                — file at default branch
+ *   github://owner/repo@ref/path/to/file.json            — file at ref (preferred)
+ *   github://owner/repo/path/to/file.json@ref            — legacy ref-on-path syntax
+ *   github://owner/repo/path                             — subdirectory (catalogs)
+ *   github://owner/repo@ref/path                         — subdirectory at ref (catalogs)
  *
  * The repo-level syntax (owner/repo@ref) is preferred because it clearly
  * separates the repository reference from the file path and avoids ambiguity
  * when file paths contain "@" characters. The path-level syntax is supported
  * for backward compatibility.
+ *
+ * When used as a catalog root, the path may be empty (whole-repo) or point
+ * to any directory. `resolve()` separately validates that the path is
+ * non-empty before reading the file.
  *
  * Note: refs containing slashes (e.g., feature/branch) cannot be expressed
  * with the repo-level syntax because the URI is split on "/". Use the legacy
@@ -99,16 +107,9 @@ export function parseGitHubUri(uri: string): GitHubUri {
   const withoutScheme = uri.replace(/^github:\/\//, "");
   const parts = withoutScheme.split("/");
 
-  if (parts.length < 3) {
-    // Detect repo@ref with no path for a more helpful error
-    if (parts.length === 2 && parts[1]?.includes("@")) {
-      throw new Error(
-        `Missing file path in github:// URI: "${uri}". ` +
-          `URI must include a path after the ref: github://owner/repo@ref/path/to/file.json`
-      );
-    }
+  if (parts.length < 2 || !parts[0] || !parts[1]) {
     throw new Error(
-      `Invalid github:// URI: "${uri}". Expected format: github://owner/repo[@ref]/path/to/file.json`
+      `Invalid github:// URI: "${uri}". Expected format: github://owner/repo[@ref][/path]`
     );
   }
 
@@ -124,7 +125,7 @@ export function parseGitHubUri(uri: string): GitHubUri {
     if (ref.length === 0) {
       throw new Error(
         `Empty ref after "@" in github:// URI: "${uri}". ` +
-          `Either remove the "@" or specify a ref: github://owner/repo@ref/path`
+          `Either remove the "@" or specify a ref: github://owner/repo@ref[/path]`
       );
     }
   }
@@ -133,13 +134,13 @@ export function parseGitHubUri(uri: string): GitHubUri {
   let filePath = parts.slice(2).join("/");
 
   // If no ref on repo, check for legacy @ref at the end of the path
-  if (!ref) {
+  if (!ref && filePath) {
     const pathAtIndex = filePath.lastIndexOf("@");
     if (pathAtIndex > 0) {
       ref = filePath.slice(pathAtIndex + 1);
       filePath = filePath.slice(0, pathAtIndex);
     }
-  } else {
+  } else if (ref && filePath) {
     // Repo-level ref already found — reject if path also has @ref (ambiguous)
     const pathAtIndex = filePath.lastIndexOf("@");
     if (pathAtIndex > 0) {
@@ -154,7 +155,7 @@ export function parseGitHubUri(uri: string): GitHubUri {
   validateUriComponent(owner, "owner");
   validateUriComponent(repo, "repo");
   if (ref) validateUriComponent(ref, "ref");
-  validateUriComponent(filePath, "path");
+  if (filePath) validateUriComponent(filePath, "path");
 
   return { owner, repo, path: filePath, ref };
 }
@@ -237,6 +238,12 @@ export class GitHubCatalogProvider implements CatalogProvider {
     _baseDir: string
   ): Promise<Record<string, unknown>> {
     const parsed = parseGitHubUri(uri);
+    if (!parsed.path) {
+      throw new Error(
+        `github:// URI must include a file path: "${uri}". ` +
+          `Expected format: github://owner/repo[@ref]/path/to/file.json`
+      );
+    }
     const ref = parsed.ref || "HEAD";
     const cloneDir = await this.ensureClone(parsed.owner, parsed.repo, ref);
     const filePath = resolve(cloneDir, parsed.path);
@@ -255,16 +262,28 @@ export class GitHubCatalogProvider implements CatalogProvider {
   }
 
   /**
-   * Check whether the file referenced by a github:// URI exists in the clone.
-   * Ensures the repository is cloned (throwing on real clone failures) and
-   * then checks the file on disk. Used by catalog expansion to skip
-   * conventional artifact paths that a given catalog doesn't provide.
+   * Resolve a catalog URI to the local clone directory rooted at the URI's
+   * path within the clone. Ensures the repository is cloned (performing a
+   * shallow clone on first access) before returning. Core then walks the
+   * returned directory to discover artifact index files.
+   *
+   * For a URI like `github://owner/repo@ref/agents`, this returns the
+   * absolute path to `<cloneDir>/agents`.
    */
-  async fileExists(uri: string): Promise<boolean> {
+  async resolveCatalogDir(uri: string): Promise<string> {
     const parsed = parseGitHubUri(uri);
     const ref = parsed.ref || "HEAD";
     const cloneDir = await this.ensureClone(parsed.owner, parsed.repo, ref);
-    return existsSync(resolve(cloneDir, parsed.path));
+    const catalogDir = resolve(cloneDir, parsed.path);
+    if (!existsSync(catalogDir)) {
+      throw new Error(
+        `Catalog path not found in cloned repository: ${parsed.path}\n` +
+          `  Repository: ${parsed.owner}/${parsed.repo}\n` +
+          `  Ref: ${ref}\n` +
+          `  Clone path: ${cloneDir}`
+      );
+    }
+    return catalogDir;
   }
 
   /**

--- a/packages/extensions/provider-github/tests/github-provider.test.ts
+++ b/packages/extensions/provider-github/tests/github-provider.test.ts
@@ -109,10 +109,33 @@ describe("parseGitHubUri", () => {
 
   // --- error cases ---
 
-  it("throws on URI with too few segments", () => {
-    expect(() => parseGitHubUri("github://acme/repo")).toThrow(
-      "Invalid github:// URI"
-    );
+  it("accepts a whole-repo URI without a path (used as catalog root)", () => {
+    const result = parseGitHubUri("github://acme/repo");
+    expect(result).toEqual({
+      owner: "acme",
+      repo: "repo",
+      path: "",
+    });
+  });
+
+  it("accepts a whole-repo URI with @ref but no path (used as catalog root)", () => {
+    const result = parseGitHubUri("github://acme/repo@main");
+    expect(result).toEqual({
+      owner: "acme",
+      repo: "repo",
+      path: "",
+      ref: "main",
+    });
+  });
+
+  it("accepts a subdirectory URI (used as catalog root)", () => {
+    const result = parseGitHubUri("github://acme/repo@main/agents");
+    expect(result).toEqual({
+      owner: "acme",
+      repo: "repo",
+      path: "agents",
+      ref: "main",
+    });
   });
 
   it("throws on URI with only owner", () => {
@@ -155,12 +178,6 @@ describe("parseGitHubUri", () => {
     expect(() =>
       parseGitHubUri("github://acme/repo@main;rm -rf //file.json")
     ).toThrow("Invalid ref");
-  });
-
-  it("gives helpful error for repo@ref with no path", () => {
-    expect(() =>
-      parseGitHubUri("github://acme/repo@main")
-    ).toThrow("Missing file path");
   });
 
   it("rejects empty ref after @ on repo segment", () => {
@@ -311,6 +328,58 @@ describe("GitHubCatalogProvider", () => {
     expect(sourceDir).toBeDefined();
     expect(sourceDir).toContain("examples/skills");
   });
+
+  it("resolve() throws when given a URI with no file path", async () => {
+    await expect(
+      provider.resolve("github://pulsemcp/air", "/tmp")
+    ).rejects.toThrow(/must include a file path/);
+  });
+
+  it("resolveCatalogDir returns the catalog directory within a clone", async () => {
+    // Reuse the clone from earlier tests in this block.
+    const cloneDir = getClonePath("pulsemcp", "air", "HEAD");
+    if (!existsSync(resolve(cloneDir, ".git"))) {
+      await provider.resolve(
+        "github://pulsemcp/air/examples/skills/skills.json",
+        "/tmp"
+      );
+    }
+
+    const catalogDir = await provider.resolveCatalogDir(
+      "github://pulsemcp/air/examples"
+    );
+    expect(catalogDir).toBe(resolve(cloneDir, "examples"));
+    expect(existsSync(catalogDir)).toBe(true);
+  }, 30000);
+
+  it("resolveCatalogDir returns the clone root for a whole-repo catalog URI", async () => {
+    const cloneDir = getClonePath("pulsemcp", "air", "HEAD");
+    if (!existsSync(resolve(cloneDir, ".git"))) {
+      await provider.resolve(
+        "github://pulsemcp/air/examples/skills/skills.json",
+        "/tmp"
+      );
+    }
+
+    const catalogDir = await provider.resolveCatalogDir("github://pulsemcp/air");
+    expect(catalogDir).toBe(cloneDir);
+  }, 30000);
+
+  it("resolveCatalogDir throws when the catalog path is missing from the clone", async () => {
+    const cloneDir = getClonePath("pulsemcp", "air", "HEAD");
+    if (!existsSync(resolve(cloneDir, ".git"))) {
+      await provider.resolve(
+        "github://pulsemcp/air/examples/skills/skills.json",
+        "/tmp"
+      );
+    }
+
+    await expect(
+      provider.resolveCatalogDir(
+        "github://pulsemcp/air/no-such-subdirectory-xyz"
+      )
+    ).rejects.toThrow(/Catalog path not found/);
+  }, 30000);
 
   it("throws when file not found in clone", async () => {
     const cloneDir = getClonePath("pulsemcp", "air", "HEAD");

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.41"
+    "@pulsemcp/air-core": "0.0.42"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.41"
+    "@pulsemcp/air-core": "0.0.42"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.0.41"
+    "@pulsemcp/air-core": "0.0.42"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/init.ts
+++ b/packages/sdk/src/init.ts
@@ -125,8 +125,8 @@ Skills live as directories containing a \`SKILL.md\`. Point at one from
 
 The simplest way to layer a shared team or org catalog on top of your local
 workspace is the \`catalogs\` field. Each entry is a directory (local path or
-\`github://\` URI) that follows the standard \`<type>/<type>.json\` layout, and
-AIR expands it into all six artifact arrays automatically:
+\`github://\` URI). AIR walks the catalog up to 3 levels deep and discovers
+any file identified as an AIR artifact index by filename or \`$schema\`:
 
 \`\`\`json
 {


### PR DESCRIPTION
## Summary

Fixes [#108](https://github.com/pulsemcp/air/issues/108).

`catalogs[]` entries in `air.json` no longer require the rigid `<type>/<type>.json` layout. AIR now walks each catalog root up to 3 directory levels deep and picks up any file identified as an AIR artifact index either by filename (`skills.json`, `roots.json`, `mcp.json`, `references.json`, `plugins.json`, `hooks.json`, or any filename containing those tokens as delimited segments) or by `$schema`.

- **Traversal rules**: depth cap 3, `.gitignore` at catalog root honored, `node_modules` / `.git` / `dist` / `build` / `coverage` / `.next` / `.turbo` / `target` / `vendor` / hidden dirs skipped. JSON files whose `$schema` points at a non-AIR schema are skipped even if the filename matches.
- **Collision handling**: within a single catalog, indexes of the same type merge in sorted relative-path order with later-wins by ID. Across catalogs, earlier entries merge first; later catalogs override.
- **Design decisions per issue**: last-wins within a single catalog, depth cap at 3 + respect `.gitignore`, discovery is the default (no backwards-compat shim).

### Motivating concrete problem

`pulsemcp/pulsemcp` uses `agents/agent-roots/roots.json` and `agents/mcp-servers/mcp.json` — previously silently skipped, hiding ~60 agent roots and ~88 MCP servers from `air resolve`. They are now discovered automatically.

## Breaking changes

- **`CatalogProvider.fileExists` removed**, replaced with `resolveCatalogDir(uri) => Promise<string>`. Providers now return a local directory path that AIR walks. `@pulsemcp/air-provider-github` implements this by cloning the repo and returning the resolved subdirectory.
- **`parseGitHubUri` accepts whole-repo URIs** — `github://owner/repo` and `github://owner/repo@ref` are now valid catalog URIs (`catalogs[]`). Using one as a direct artifact path still fails because `resolve()` rejects an empty path.

Per the issue, no backwards-compat shim.

## Version

Bumps all packages from 0.0.41 -> 0.0.42 and adds a changelog entry.

## Verification

- [x] **CI green.** All 5 checks (`test (18)`, `test (20)`, `test (22)`, `e2e`, `validate-schemas`) pass on the latest commit via the `wait-for-ci` skill.
- [x] **Tests added and passing.** `packages/core/tests/catalogs.test.ts` gains 12+ new tests covering discovery-based catalog resolution (custom subdirectory layouts, `$schema`-based detection, non-AIR `$schema` rejection, last-wins collision handling, depth cap with explicit depth-0 and depth-3 boundary coverage, `.gitignore`, skip-list, hidden dirs, unparseable JSON, relative-path resolution against the discovered index's directory, remote URI delegation to `resolveCatalogDir`, clear error when provider lacks it). `packages/core/tests/schemas.test.ts` gains tests for the `$schema` URL substring false-positive and query/fragment handling. `packages/extensions/provider-github/tests/github-provider.test.ts` gains tests for whole-repo URI acceptance and `resolveCatalogDir` behavior. Core tests: 152/152.
- [x] **Self-review completed (subagent fresh-eyes pass).** A second-pass review flagged a correctness bug in `detectSchemaFromValue` (unbounded substring match over the full `$schema` URL) — a malicious or accidental third-party `$schema` containing e.g. `"mcp.schema.json"` mid-URL could be misclassified as an AIR MCP index. Fixed in the second commit (`eedab6e`) by matching the URL's basename only. The same pass caught three stale doc strings / scaffolding comments still describing the old rigid layout (`AirConfig.catalogs` TS hover, `air init` README scaffold, root `README.md`) — all refreshed. Pre-existing `/private/var` vs `/var` symlink failures in `packages/sdk/tests/discover-indexes.test.ts` and `auto-discovery.test.ts` are unrelated to this change and pass on Linux CI.
- [x] **Proof the change works.** Integration test `catalogs.test.ts > discovers roots.json under non-conventional subdirectory` constructs a catalog with the exact `pulsemcp/pulsemcp` layout (`pulsemcp-agents/agent-roots/roots.json`) and asserts that `resolveArtifacts` merges those roots. This is the concrete shape described in the issue.

## Test plan

- [x] `npm run build` passes for all packages
- [x] `npx vitest run` — 735/740 (5 failures are pre-existing macOS symlink issues, unrelated)
- [x] Core tests pass (152/152)
- [x] Provider-github tests pass
- [x] Docs updated: `docs/configuration.md`, `docs/guides/understanding-air-json.md`, `docs/guides/composition-and-overrides.md`, root `README.md`, `air init` scaffold README, `AirConfig.catalogs` TS docstring

Generated with [Claude Code](https://claude.com/claude-code)