### PR TITLE
feat(cli): add air resolve --no-scope flag (v0.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-04-25
+
+### Added
+- **`air resolve --no-scope` flag** for emitting shortname-keyed output. Pass `--no-scope` to rewrite both top-level keys (`@local/github` → `github`) and reference fields inside entries (`default_skills`, `default_mcp_servers`, `skills.references`, `plugins.{skills,mcp_servers,hooks,plugins}`, `hooks.references`) to bare shortnames. The flag is opt-in and **hard-fails** when a shortname is contributed by more than one scope within the same artifact category — the error lists every colliding qualified ID so you can pick which one to drop via `air.json#exclude`. Useful for single-scope universes (local-only, internal-only, or single private catalog) and for downstream consumers that were built around bare shortnames before 0.1.0. The default qualified output is unchanged. New exports: `stripScopes` and `ShortnameCollisionError` from both `@pulsemcp/air-core` and `@pulsemcp/air-sdk`. Resolves [#116](https://github.com/pulsemcp/air/issues/116).
+
 ## [0.1.0] - 2026-04-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-04-25
+## [0.1.1] - 2026-04-25
 
 ### Added
 - **`air resolve --no-scope` flag** for emitting shortname-keyed output. Pass `--no-scope` to rewrite both top-level keys (`@local/github` → `github`) and reference fields inside entries (`default_skills`, `default_mcp_servers`, `skills.references`, `plugins.{skills,mcp_servers,hooks,plugins}`, `hooks.references`) to bare shortnames. The flag is opt-in and **hard-fails** when a shortname is contributed by more than one scope within the same artifact category — the error lists every colliding qualified ID so you can pick which one to drop via `air.json#exclude`. Useful for single-scope universes (local-only, internal-only, or single private catalog) and for downstream consumers that were built around bare shortnames before 0.1.0. The default qualified output is unchanged. New exports: `stripScopes` and `ShortnameCollisionError` from both `@pulsemcp/air-core` and `@pulsemcp/air-sdk`. Resolves [#116](https://github.com/pulsemcp/air/issues/116).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -145,28 +145,69 @@ Loads `air.json`, runs catalog providers (e.g., `github://`) declared under `ext
 
 ```json
 {
-  "skills":     { "<id>": { "description": "...", "path": "/abs/path" } },
-  "references": { "<id>": { "description": "...", "path": "/abs/path" } },
-  "mcp":        { "<id>": { "type": "stdio", "command": "...", "args": [] } },
-  "plugins":    { "<id>": { "description": "...", "skills": [], "mcp_servers": [] } },
-  "roots":      { "<id>": { "description": "...", "default_skills": [] } },
-  "hooks":      { "<id>": { "description": "...", "path": "/abs/path" } }
+  "skills":     { "@scope/<id>": { "description": "...", "path": "/abs/path" } },
+  "references": { "@scope/<id>": { "description": "...", "path": "/abs/path" } },
+  "mcp":        { "@scope/<id>": { "type": "stdio", "command": "...", "args": [] } },
+  "plugins":    { "@scope/<id>": { "description": "...", "skills": [], "mcp_servers": [] } },
+  "roots":      { "@scope/<id>": { "description": "...", "default_skills": [] } },
+  "hooks":      { "@scope/<id>": { "description": "...", "path": "/abs/path" } }
 }
 ```
 
-All `path` fields are absolute, making the output self-contained regardless of where the `air.json` lives.
+Keys are qualified IDs (`@scope/id`); reference fields inside entries (e.g. `default_skills`, `mcp_servers`) are likewise qualified. All `path` fields are absolute, making the output self-contained regardless of where the `air.json` lives.
 
 **Options:**
 
 | Flag | Description |
 |------|-------------|
 | `--json` | Emit JSON output (default and currently the only supported format; accepted for forward-compat). |
+| `--no-scope` | Emit shortname-keyed output instead of the default qualified-ID keys. Hard-fails if any shortname is contributed by more than one scope. See [Shortname-keyed output](#shortname-keyed-output---no-scope) below. |
 | `--config <path>` | Path to `air.json`. Defaults to `AIR_CONFIG` env or `~/.air/air.json`. |
 | `--git-protocol <ssh\|https>` | Protocol used by git-based catalog providers when cloning. Defaults to `ssh`. Overrides the `gitProtocol` field in `air.json` and the `AIR_GIT_PROTOCOL` env var for this invocation. |
 
 **Exit codes:**
 - `0` — resolved successfully; JSON written to stdout
-- `1` — resolution failed (e.g., missing `air.json`, unreachable provider); error on stderr
+- `1` — resolution failed (e.g., missing `air.json`, unreachable provider, or `--no-scope` with cross-scope shortname collisions); error on stderr
+
+#### Shortname-keyed output (`--no-scope`)
+
+Pass `--no-scope` to emit the same artifact tree but keyed by bare shortnames (`github`) instead of qualified IDs (`@local/github`). Reference fields inside entries — `default_skills`, `mcp_servers`, `skills.references`, etc. — are likewise rewritten to bare form.
+
+```bash
+air resolve --no-scope
+```
+
+```json
+{
+  "mcp":   { "github": { "type": "stdio", "command": "..." } },
+  "roots": { "default": { "default_mcp_servers": ["github"] } }
+}
+```
+
+`--no-scope` is **opt-in** and **hard-fails** when a shortname is contributed by more than one scope within the same artifact category. The error lists every colliding qualified ID so you can pick which one to drop:
+
+```
+Error: --no-scope requires unique shortnames across all scopes, but
+  shortname "github" maps to multiple qualified IDs:
+    - @local/github
+    - @reframe-systems/agentic-engineering/github
+  Either use the default qualified output, or exclude one of them
+  via air.json#exclude.
+```
+
+There is no silent later-wins. Either drop the colliding entry via `air.json#exclude`, or stay on the default qualified output.
+
+**When to use `--no-scope`:**
+
+- You are committed to a single-scope universe — local-only, internal-only, or a single private catalog.
+- You are an early adopter whose downstream consumer (database schema, UI, scripts) was built around bare shortnames and would otherwise need to maintain a regex-stripping shim.
+- The output is consumed by humans, scripts, or UIs where qualified IDs add noise (`jq`, tables, dashboards, demos).
+
+**When NOT to use `--no-scope`:**
+
+- You compose multiple catalogs intentionally and want both `@acme/review` and `@local/review` to coexist — that is exactly what the default qualified output is for.
+
+**Trade-off.** Using `--no-scope` is a commitment. Add a second catalog later that contributes a colliding shortname, and your build breaks until you either exclude the colliding artifact via `air.json#exclude` or switch back to the default qualified output (and update consumers). That's the right trade-off for this flag — brevity now in exchange for an enforced invariant. Users who want compositional flexibility should stick with the default.
 
 ## Environment Variables
 

--- a/docs/guides/composition-and-overrides.md
+++ b/docs/guides/composition-and-overrides.md
@@ -123,6 +123,10 @@ Error: Reference "review" is ambiguous — candidates: @acme/air-org/review,
 
 After resolution, root and plugin reference fields are stored in **canonical (qualified) form** so adapters and consumers do not need to re-resolve them.
 
+### Single-scope universes: `air resolve --no-scope`
+
+If you are committed to a single-scope setup — local-only, internal-only, or one private catalog — and the qualified form is more friction than it is worth, `air resolve --no-scope` emits the same artifact tree keyed by bare shortnames instead of qualified IDs. The flag hard-fails if any shortname is contributed by more than one scope, so you cannot lose an artifact silently. This is opt-in and narrowly scoped: every consumer that adopts it commits to the single-scope invariant. See [`air resolve` in the CLI reference](../cli.md#shortname-keyed-output---no-scope) for the full trade-off and example error output.
+
 ## Whole-catalog composition
 
 When you want to layer two or more full catalogs you don't need to list every artifact type separately. The `catalogs` field in `air.json` accepts an ordered array of catalog roots, and AIR expands each one into all six artifact arrays automatically.

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -277,24 +277,65 @@ air resolve --json
 
 ```json
 {
-  "skills":     { "<id>": { "description": "...", "path": "/abs/path" } },
-  "references": { "<id>": { "description": "...", "path": "/abs/path" } },
-  "mcp":        { "<id>": { "type": "stdio", "command": "...", "args": [] } },
-  "plugins":    { "<id>": { "description": "...", "skills": [], "mcp_servers": [] } },
-  "roots":      { "<id>": { "description": "...", "default_skills": [] } },
-  "hooks":      { "<id>": { "description": "...", "path": "/abs/path" } }
+  "skills":     { "@scope/<id>": { "description": "...", "path": "/abs/path" } },
+  "references": { "@scope/<id>": { "description": "...", "path": "/abs/path" } },
+  "mcp":        { "@scope/<id>": { "type": "stdio", "command": "...", "args": [] } },
+  "plugins":    { "@scope/<id>": { "description": "...", "skills": [], "mcp_servers": [] } },
+  "roots":      { "@scope/<id>": { "description": "...", "default_skills": [] } },
+  "hooks":      { "@scope/<id>": { "description": "...", "path": "/abs/path" } }
 }
 ```
 
-All `path` fields are absolute, matching what `resolveArtifacts()` returns from `@pulsemcp/air-core`. Unused artifact types are emitted as empty objects.
+Keys are qualified IDs (`@scope/id`); reference fields inside entries are likewise qualified. All `path` fields are absolute, matching what `resolveArtifacts()` returns from `@pulsemcp/air-core`. Unused artifact types are emitted as empty objects.
 
 ### Options
 
 | Flag | Description |
 |------|-------------|
 | `--json` | Emit JSON output (currently the only supported format) |
+| `--no-scope` | Emit shortname-keyed output instead of qualified-ID keys; hard-fails on cross-scope shortname collisions (see below) |
 | `--config <path>` | Path to air.json (default: `AIR_CONFIG` env or `~/.air/air.json`) |
 | `--git-protocol <ssh\|https>` | Protocol used by git-based catalog providers when cloning |
+
+### Shortname-keyed output (`--no-scope`)
+
+```bash
+air resolve --no-scope
+```
+
+Same artifact tree, but every key — and every reference inside an entry — is a bare shortname:
+
+```json
+{
+  "mcp":   { "github": { "type": "stdio", "command": "..." } },
+  "roots": { "default": { "default_mcp_servers": ["github"] } }
+}
+```
+
+`--no-scope` is opt-in and hard-fails when a shortname is contributed by more than one scope within the same artifact category:
+
+```
+Error: --no-scope requires unique shortnames across all scopes, but
+  shortname "github" maps to multiple qualified IDs:
+    - @local/github
+    - @reframe-systems/agentic-engineering/github
+  Either use the default qualified output, or exclude one of them
+  via air.json#exclude.
+```
+
+There is no silent later-wins. Either drop the colliding entry via `air.json#exclude`, or stay on the default qualified output.
+
+**Use `--no-scope` when:**
+
+- You are committed to a single-scope universe — local-only, internal-only, or a single private catalog.
+- You are an early adopter whose downstream consumer (database schema, UI, scripts) was built around bare shortnames and would otherwise need to maintain a regex-stripping shim.
+- The output is consumed by humans, scripts, or UIs where qualified IDs add noise (`jq`, tables, dashboards, demos).
+
+**Do not use `--no-scope` when:**
+
+- You compose multiple catalogs intentionally and want both `@acme/review` and `@local/review` to coexist — that is exactly what the default qualified output is for.
+
+**Trade-off.** Using `--no-scope` is a commitment. Add a second catalog later that contributes a colliding shortname, and your build breaks until you either exclude one of them via `air.json#exclude` or switch back to the default qualified output and update consumers. Brevity now in exchange for an enforced invariant; users who want compositional flexibility should stick with the default.
 
 ### When to use it
 
@@ -302,7 +343,7 @@ All `path` fields are absolute, matching what `resolveArtifacts()` returns from 
 - **Orchestrators** that show users "what skills/roots are available" before they pick a root for `air prepare`
 - **Debugging** — confirm that `github://` URIs and `catalogs` entries resolve to the expected merged view
 
-For programmatic TypeScript/JavaScript consumers, use `resolveFullArtifacts()` from `@pulsemcp/air-sdk` instead — it returns the same object without spawning a subprocess.
+For programmatic TypeScript/JavaScript consumers, use `resolveFullArtifacts()` from `@pulsemcp/air-sdk` instead — it returns the same object without spawning a subprocess. The same `stripScopes(artifacts)` helper used internally by `--no-scope` is also exported from `@pulsemcp/air-sdk` for callers that want shortname-keyed output programmatically.
 
 ## air export — building plugin marketplaces
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1777143371-577145c2",
+  "name": "air-main-1777160302-cfd02f86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -14,417 +14,16 @@
         "vitest": "^2.1.0"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -432,9 +31,8 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pulsemcp/air-adapter-claude": {
       "resolved": "packages/extensions/adapter-claude",
@@ -468,235 +66,13 @@
       "resolved": "packages/extensions/secrets-file",
       "link": true
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -704,130 +80,46 @@
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/proper-lockfile": {
       "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
-      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/retry": "*"
       }
     },
     "node_modules/@types/retry": {
       "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
-      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
-      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/spy": "2.1.9",
         "@vitest/utils": "2.1.9",
@@ -840,9 +132,8 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
-      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/spy": "2.1.9",
         "estree-walker": "^3.0.3",
@@ -866,9 +157,8 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
-      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^1.2.0"
       },
@@ -878,9 +168,8 @@
     },
     "node_modules/@vitest/runner": {
       "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
-      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/utils": "2.1.9",
         "pathe": "^1.1.2"
@@ -891,9 +180,8 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
-      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "2.1.9",
         "magic-string": "^0.30.12",
@@ -905,9 +193,8 @@
     },
     "node_modules/@vitest/spy": {
       "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
-      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tinyspy": "^3.0.2"
       },
@@ -917,9 +204,8 @@
     },
     "node_modules/@vitest/utils": {
       "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "2.1.9",
         "loupe": "^3.1.2",
@@ -931,8 +217,7 @@
     },
     "node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -946,8 +231,7 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -962,27 +246,24 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/cac": {
       "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/chai": {
       "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -996,8 +277,7 @@
     },
     "node_modules/chalk": {
       "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -1007,26 +287,23 @@
     },
     "node_modules/check-error": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 16"
       }
     },
     "node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1041,25 +318,22 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1094,31 +368,26 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "funding": [
         {
           "type": "github",
@@ -1128,27 +397,13 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
       ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
+      "license": "BSD-3-Clause"
     },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -1158,47 +413,39 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -1206,6 +453,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -1215,29 +463,24 @@
     },
     "node_modules/pathe": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/postcss": {
       "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -1253,6 +496,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -1264,8 +508,7 @@
     },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "retry": "^0.12.0",
@@ -1274,34 +517,30 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/rollup": {
       "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -1343,80 +582,69 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "license": "ISC"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinypool": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/tinyrainbow": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
-      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/tinyspy": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/tsx": {
       "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -1431,369 +659,16 @@
         "fsevents": "~2.3.3"
       }
     },
-    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tsx/node_modules/@esbuild/linux-x64": {
       "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -1801,10 +676,9 @@
     },
     "node_modules/tsx/node_modules/esbuild": {
       "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1842,9 +716,8 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1855,15 +728,13 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -1920,9 +791,8 @@
     },
     "node_modules/vite-node": {
       "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
-      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.3.7",
@@ -1942,9 +812,8 @@
     },
     "node_modules/vitest": {
       "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
-      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -2007,9 +876,8 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
@@ -2023,9 +891,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.1.0",
+        "@pulsemcp/air-sdk": "0.2.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -2044,7 +912,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -2061,9 +929,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.1.0"
+        "@pulsemcp/air-core": "0.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2076,9 +944,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.1.0"
+        "@pulsemcp/air-core": "0.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2091,9 +959,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.1.0",
+        "@pulsemcp/air-core": "0.2.0",
         "proper-lockfile": "^4.1.2"
       },
       "devDependencies": {
@@ -2108,9 +976,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.1.0"
+        "@pulsemcp/air-core": "0.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2123,9 +991,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.1.0"
+        "@pulsemcp/air-core": "0.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -2138,9 +1006,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.1.0"
+        "@pulsemcp/air-core": "0.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -891,9 +891,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.2.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.2.0",
+        "@pulsemcp/air-sdk": "0.1.1",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -912,7 +912,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.2.0",
+      "version": "0.1.1",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -929,9 +929,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.2.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.2.0"
+        "@pulsemcp/air-core": "0.1.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -944,9 +944,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.2.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.2.0"
+        "@pulsemcp/air-core": "0.1.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -959,9 +959,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.2.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.2.0",
+        "@pulsemcp/air-core": "0.1.1",
         "proper-lockfile": "^4.1.2"
       },
       "devDependencies": {
@@ -976,9 +976,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.2.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.2.0"
+        "@pulsemcp/air-core": "0.1.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -991,9 +991,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.2.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.2.0"
+        "@pulsemcp/air-core": "0.1.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1006,9 +1006,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.2.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.2.0"
+        "@pulsemcp/air-core": "0.1.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.2.0",
+    "@pulsemcp/air-sdk": "0.1.1",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.1.0",
+    "@pulsemcp/air-sdk": "0.2.0",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/src/commands/resolve.ts
+++ b/packages/cli/src/commands/resolve.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { resolveFullArtifacts } from "@pulsemcp/air-sdk";
+import { resolveFullArtifacts, stripScopes } from "@pulsemcp/air-sdk";
 import { parseGitProtocolFlag } from "./git-protocol.js";
 
 export function resolveCommand(): Command {
@@ -16,6 +16,10 @@ export function resolveCommand(): Command {
       "Emit JSON output (default and currently the only supported format; accepted for forward-compat)"
     )
     .option(
+      "--no-scope",
+      "Emit shortname-keyed output instead of the default qualified-ID (@scope/id) keys. Hard-fails if any shortname is contributed by more than one scope. Use only when committed to a single-scope universe."
+    )
+    .option(
       "--git-protocol <protocol>",
       "Protocol used by git-based catalog providers: \"ssh\" (default) or \"https\". Overrides the gitProtocol field in air.json."
     )
@@ -23,6 +27,7 @@ export function resolveCommand(): Command {
       async (options: {
         config?: string;
         json?: boolean;
+        scope?: boolean;
         gitProtocol?: string;
       }) => {
         const gitProtocol = parseGitProtocolFlag(options.gitProtocol);
@@ -31,7 +36,10 @@ export function resolveCommand(): Command {
             config: options.config,
             gitProtocol,
           });
-          console.log(JSON.stringify(artifacts, null, 2));
+          // Commander's `--no-scope` sets `options.scope` to false.
+          const output =
+            options.scope === false ? stripScopes(artifacts) : artifacts;
+          console.log(JSON.stringify(output, null, 2));
         } catch (err) {
           const message = err instanceof Error ? err.message : "Unknown error";
           console.error(`Error: ${message}`);

--- a/packages/cli/tests/resolve-command.test.ts
+++ b/packages/cli/tests/resolve-command.test.ts
@@ -283,6 +283,161 @@ export default {
     ]);
   });
 
+  describe("--no-scope flag", () => {
+    it("rewrites all keys to bare shortnames in a single-scope universe", () => {
+      const catalog = createTemp({
+        "air.json": {
+          name: "test",
+          mcp: ["./mcp.json"],
+          skills: ["./skills.json"],
+          roots: ["./roots.json"],
+        },
+        "mcp.json": {
+          github: {
+            type: "stdio",
+            command: "npx",
+            args: ["-y", "@mcp/github"],
+          },
+        },
+        "skills.json": {
+          deploy: {
+            description: "Deploy skill",
+            path: "skills/deploy",
+          },
+        },
+        "skills/deploy/SKILL.md": "# Deploy",
+        "roots.json": {
+          default: {
+            description: "Default root",
+            default_mcp_servers: ["github"],
+            default_skills: ["deploy"],
+          },
+        },
+      });
+
+      const result = tryRun(
+        `resolve --no-scope --config ${join(catalog, "air.json")}`
+      );
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+
+      // Top-level keys are bare shortnames.
+      expect(output.mcp["github"]).toBeDefined();
+      expect(output.mcp["@local/github"]).toBeUndefined();
+      expect(output.skills["deploy"]).toBeDefined();
+      expect(output.skills["@local/deploy"]).toBeUndefined();
+      expect(output.roots["default"]).toBeDefined();
+      expect(output.roots["@local/default"]).toBeUndefined();
+
+      // Reference fields inside entries are bare too.
+      expect(output.roots["default"].default_mcp_servers).toEqual(["github"]);
+      expect(output.roots["default"].default_skills).toEqual(["deploy"]);
+    });
+
+    it("rewrites reference fields across plugins, hooks, and skills", () => {
+      const catalog = createTemp({
+        "air.json": {
+          name: "test",
+          mcp: ["./mcp.json"],
+          skills: ["./skills.json"],
+          plugins: ["./plugins.json"],
+        },
+        "mcp.json": {
+          gh: { type: "stdio", command: "npx", args: ["gh"] },
+        },
+        "skills.json": {
+          deploy: {
+            description: "Deploy",
+            path: "skills/deploy",
+          },
+        },
+        "skills/deploy/SKILL.md": "# Deploy",
+        "plugins.json": {
+          quality: {
+            description: "Quality",
+            skills: ["deploy"],
+            mcp_servers: ["gh"],
+          },
+        },
+      });
+
+      const result = tryRun(
+        `resolve --no-scope --config ${join(catalog, "air.json")}`
+      );
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      expect(output.plugins["quality"].skills).toEqual(["deploy"]);
+      expect(output.plugins["quality"].mcp_servers).toEqual(["gh"]);
+    });
+
+    it("hard-fails on cross-scope shortname collisions with the documented error format", () => {
+      // Two scopes contribute the same shortname `github`: @local from
+      // ./local-mcp.json and @acme via the stub provider's getScope.
+      const catalog = createTemp({
+        "air.json": {
+          name: "test",
+          extensions: ["./stub-provider-ext.js"],
+          mcp: ["./local-mcp.json", "stub://acme-mcp"],
+        },
+        "local-mcp.json": {
+          github: { type: "stdio", command: "npx", args: ["local-gh"] },
+        },
+        "stub-provider-ext.js": `
+export default {
+  name: "stub-provider-ext",
+  provider: {
+    scheme: "stub",
+    getScope() { return "acme"; },
+    async resolve(uri) {
+      return {
+        github: { type: "stdio", command: "npx", args: ["acme-gh"] },
+      };
+    },
+    resolveSourceDir() { return "/tmp"; },
+  },
+};
+`,
+      });
+
+      const result = tryRun(
+        `resolve --no-scope --config ${join(catalog, "air.json")}`
+      );
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain(
+        "--no-scope requires unique shortnames across all scopes"
+      );
+      expect(result.stderr).toContain(
+        'shortname "github" maps to multiple qualified IDs'
+      );
+      expect(result.stderr).toContain("- @local/github");
+      expect(result.stderr).toContain("- @acme/github");
+      expect(result.stderr).toContain("air.json#exclude");
+    });
+
+    it("default behavior (no flag) is unchanged — keys remain qualified", () => {
+      const catalog = createTemp({
+        "air.json": {
+          name: "test",
+          mcp: ["./mcp.json"],
+        },
+        "mcp.json": {
+          github: { type: "stdio", command: "npx", args: ["gh"] },
+        },
+      });
+
+      const result = tryRun(
+        `resolve --config ${join(catalog, "air.json")}`
+      );
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      expect(output.mcp["@local/github"]).toBeDefined();
+      expect(output.mcp["github"]).toBeUndefined();
+    });
+  });
+
   it("expands plugins into their constituent artifacts", () => {
     const catalog = createTemp({
       "air.json": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,6 +62,10 @@ export {
 } from "./scope.js";
 export type { QualifiedId, ReferenceResolution } from "./scope.js";
 
+// Scope stripping (powers `air resolve --no-scope`)
+export { stripScopes, ShortnameCollisionError } from "./strip-scopes.js";
+export type { ShortnameCollision } from "./strip-scopes.js";
+
 // Validation
 export { validateJson } from "./validator.js";
 export type { ValidationResult, ValidationError } from "./validator.js";

--- a/packages/core/src/strip-scopes.ts
+++ b/packages/core/src/strip-scopes.ts
@@ -1,0 +1,176 @@
+/**
+ * Transform a fully-qualified `ResolvedArtifacts` (keys of the form
+ * `@scope/id`) into a shortname-keyed equivalent. Reference fields inside
+ * entries (e.g. `default_skills`, `mcp_servers`, `references`) are also
+ * rewritten to bare shortnames.
+ *
+ * This is the machinery behind `air resolve --no-scope` — an opt-in
+ * convenience for consumers committed to a single-scope universe. The
+ * transformation hard-fails (via {@link ShortnameCollisionError}) when any
+ * shortname is contributed by more than one scope within the same artifact
+ * category, so the caller never silently picks a winner.
+ */
+
+import type {
+  HookEntry,
+  McpServerEntry,
+  PluginEntry,
+  ReferenceEntry,
+  ResolvedArtifacts,
+  RootEntry,
+  SkillEntry,
+} from "./types.js";
+import { isQualified, parseQualifiedId, type QualifiedId } from "./scope.js";
+
+/** A single category × shortname collision detected by {@link stripScopes}. */
+export interface ShortnameCollision {
+  category: keyof ResolvedArtifacts;
+  shortname: string;
+  qualifiedIds: QualifiedId[];
+}
+
+/**
+ * Thrown by {@link stripScopes} when one or more shortnames are contributed
+ * by more than one scope within the same artifact category.
+ */
+export class ShortnameCollisionError extends Error {
+  readonly collisions: ShortnameCollision[];
+
+  constructor(collisions: ShortnameCollision[]) {
+    super(formatCollisionMessage(collisions));
+    this.name = "ShortnameCollisionError";
+    this.collisions = collisions;
+  }
+}
+
+function formatCollisionMessage(collisions: ShortnameCollision[]): string {
+  const lines: string[] = [
+    "--no-scope requires unique shortnames across all scopes, but",
+  ];
+  for (const c of collisions) {
+    lines.push(
+      `  shortname "${c.shortname}" maps to multiple qualified IDs:`
+    );
+    for (const q of c.qualifiedIds) {
+      lines.push(`    - ${q}`);
+    }
+  }
+  lines.push(
+    "  Either use the default qualified output, or exclude one of them",
+    "  via air.json#exclude."
+  );
+  return lines.join("\n");
+}
+
+function stripIfQualified(ref: string): string {
+  return isQualified(ref) ? parseQualifiedId(ref).id : ref;
+}
+
+function stripList(refs: string[] | undefined): string[] | undefined {
+  return refs?.map(stripIfQualified);
+}
+
+function shortnameKey(qualified: string): string {
+  return isQualified(qualified) ? parseQualifiedId(qualified).id : qualified;
+}
+
+function detectCollisions(
+  artifacts: ResolvedArtifacts
+): ShortnameCollision[] {
+  const collisions: ShortnameCollision[] = [];
+  const categories = Object.keys(artifacts) as (keyof ResolvedArtifacts)[];
+  for (const category of categories) {
+    const pool = artifacts[category];
+    const byShortname = new Map<string, QualifiedId[]>();
+    for (const qualified of Object.keys(pool)) {
+      if (!isQualified(qualified)) continue;
+      const { id } = parseQualifiedId(qualified);
+      const list = byShortname.get(id);
+      if (list) {
+        list.push(qualified);
+      } else {
+        byShortname.set(id, [qualified]);
+      }
+    }
+    for (const [shortname, qualifiedIds] of byShortname) {
+      if (qualifiedIds.length > 1) {
+        collisions.push({
+          category,
+          shortname,
+          qualifiedIds: [...qualifiedIds].sort(),
+        });
+      }
+    }
+  }
+  return collisions;
+}
+
+/**
+ * Convert a `ResolvedArtifacts` whose keys are qualified IDs into the
+ * equivalent shortname-keyed shape. The result is a new object; the input
+ * is not mutated.
+ *
+ * @throws {@link ShortnameCollisionError} when any shortname is contributed
+ * by more than one scope within the same artifact category.
+ */
+export function stripScopes(artifacts: ResolvedArtifacts): ResolvedArtifacts {
+  const collisions = detectCollisions(artifacts);
+  if (collisions.length > 0) {
+    throw new ShortnameCollisionError(collisions);
+  }
+
+  const skills: Record<string, SkillEntry> = {};
+  for (const [qualified, entry] of Object.entries(artifacts.skills)) {
+    skills[shortnameKey(qualified)] =
+      entry.references === undefined
+        ? entry
+        : { ...entry, references: stripList(entry.references) };
+  }
+
+  const references: Record<string, ReferenceEntry> = {};
+  for (const [qualified, entry] of Object.entries(artifacts.references)) {
+    references[shortnameKey(qualified)] = entry;
+  }
+
+  const mcp: Record<string, McpServerEntry> = {};
+  for (const [qualified, entry] of Object.entries(artifacts.mcp)) {
+    mcp[shortnameKey(qualified)] = entry;
+  }
+
+  const plugins: Record<string, PluginEntry> = {};
+  for (const [qualified, entry] of Object.entries(artifacts.plugins)) {
+    const next: PluginEntry = { ...entry };
+    if (entry.skills !== undefined) next.skills = stripList(entry.skills);
+    if (entry.mcp_servers !== undefined)
+      next.mcp_servers = stripList(entry.mcp_servers);
+    if (entry.hooks !== undefined) next.hooks = stripList(entry.hooks);
+    if (entry.plugins !== undefined) next.plugins = stripList(entry.plugins);
+    plugins[shortnameKey(qualified)] = next;
+  }
+
+  const roots: Record<string, RootEntry> = {};
+  for (const [qualified, entry] of Object.entries(artifacts.roots)) {
+    const next: RootEntry = { ...entry };
+    if (entry.default_mcp_servers !== undefined)
+      next.default_mcp_servers = stripList(entry.default_mcp_servers);
+    if (entry.default_skills !== undefined)
+      next.default_skills = stripList(entry.default_skills);
+    if (entry.default_plugins !== undefined)
+      next.default_plugins = stripList(entry.default_plugins);
+    if (entry.default_hooks !== undefined)
+      next.default_hooks = stripList(entry.default_hooks);
+    if (entry.default_subagent_roots !== undefined)
+      next.default_subagent_roots = stripList(entry.default_subagent_roots);
+    roots[shortnameKey(qualified)] = next;
+  }
+
+  const hooks: Record<string, HookEntry> = {};
+  for (const [qualified, entry] of Object.entries(artifacts.hooks)) {
+    hooks[shortnameKey(qualified)] =
+      entry.references === undefined
+        ? entry
+        : { ...entry, references: stripList(entry.references) };
+  }
+
+  return { skills, references, mcp, plugins, roots, hooks };
+}

--- a/packages/core/tests/strip-scopes.test.ts
+++ b/packages/core/tests/strip-scopes.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect } from "vitest";
+import {
+  stripScopes,
+  ShortnameCollisionError,
+} from "../src/strip-scopes.js";
+import type { ResolvedArtifacts } from "../src/types.js";
+
+function emptyArtifacts(): ResolvedArtifacts {
+  return {
+    skills: {},
+    references: {},
+    mcp: {},
+    plugins: {},
+    roots: {},
+    hooks: {},
+  };
+}
+
+describe("stripScopes — happy path", () => {
+  it("rewrites all category keys from qualified to bare shortnames", () => {
+    const artifacts: ResolvedArtifacts = {
+      ...emptyArtifacts(),
+      skills: {
+        "@local/deploy": { description: "Deploy", path: "/abs/skills/deploy" },
+      },
+      references: {
+        "@local/style-guide": {
+          description: "Style guide",
+          path: "/abs/refs/style-guide.md",
+        },
+      },
+      mcp: {
+        "@local/github": {
+          type: "stdio",
+          command: "npx",
+          args: ["-y", "@mcp/github"],
+        },
+      },
+      plugins: {
+        "@local/quality": { description: "Quality", skills: ["@local/deploy"] },
+      },
+      roots: {
+        "@local/default": {
+          description: "Default",
+          default_skills: ["@local/deploy"],
+          default_mcp_servers: ["@local/github"],
+        },
+      },
+      hooks: {
+        "@local/audit": {
+          description: "Audit",
+          path: "/abs/hooks/audit",
+        },
+      },
+    };
+
+    const result = stripScopes(artifacts);
+
+    expect(Object.keys(result.skills)).toEqual(["deploy"]);
+    expect(Object.keys(result.references)).toEqual(["style-guide"]);
+    expect(Object.keys(result.mcp)).toEqual(["github"]);
+    expect(Object.keys(result.plugins)).toEqual(["quality"]);
+    expect(Object.keys(result.roots)).toEqual(["default"]);
+    expect(Object.keys(result.hooks)).toEqual(["audit"]);
+  });
+
+  it("rewrites reference fields inside entries to bare shortnames", () => {
+    const artifacts: ResolvedArtifacts = {
+      ...emptyArtifacts(),
+      skills: {
+        "@local/deploy": {
+          description: "Deploy",
+          path: "/abs/skills/deploy",
+          references: ["@local/style-guide"],
+        },
+      },
+      references: {
+        "@local/style-guide": {
+          description: "Style guide",
+          path: "/abs/refs/style-guide.md",
+        },
+      },
+      mcp: {
+        "@local/github": { type: "stdio", command: "npx", args: ["gh"] },
+      },
+      plugins: {
+        "@local/quality": {
+          description: "Quality",
+          skills: ["@local/deploy"],
+          mcp_servers: ["@local/github"],
+          hooks: ["@local/audit"],
+          plugins: ["@local/inner"],
+        },
+        "@local/inner": { description: "Inner" },
+      },
+      roots: {
+        "@local/default": {
+          description: "Default",
+          default_skills: ["@local/deploy"],
+          default_mcp_servers: ["@local/github"],
+          default_hooks: ["@local/audit"],
+          default_plugins: ["@local/quality"],
+          default_subagent_roots: ["@local/sub"],
+        },
+        "@local/sub": { description: "Sub" },
+      },
+      hooks: {
+        "@local/audit": {
+          description: "Audit",
+          path: "/abs/hooks/audit",
+          references: ["@local/style-guide"],
+        },
+      },
+    };
+
+    const result = stripScopes(artifacts);
+
+    expect(result.skills["deploy"].references).toEqual(["style-guide"]);
+    expect(result.plugins["quality"].skills).toEqual(["deploy"]);
+    expect(result.plugins["quality"].mcp_servers).toEqual(["github"]);
+    expect(result.plugins["quality"].hooks).toEqual(["audit"]);
+    expect(result.plugins["quality"].plugins).toEqual(["inner"]);
+    expect(result.roots["default"].default_skills).toEqual(["deploy"]);
+    expect(result.roots["default"].default_mcp_servers).toEqual(["github"]);
+    expect(result.roots["default"].default_hooks).toEqual(["audit"]);
+    expect(result.roots["default"].default_plugins).toEqual(["quality"]);
+    expect(result.roots["default"].default_subagent_roots).toEqual(["sub"]);
+    expect(result.hooks["audit"].references).toEqual(["style-guide"]);
+  });
+
+  it("preserves non-reference entry fields verbatim", () => {
+    const artifacts: ResolvedArtifacts = {
+      ...emptyArtifacts(),
+      mcp: {
+        "@local/github": {
+          type: "stdio",
+          command: "npx",
+          args: ["-y", "@mcp/github"],
+          env: { GITHUB_TOKEN: "x" },
+          title: "GitHub",
+          description: "GitHub MCP server",
+        },
+      },
+    };
+
+    const result = stripScopes(artifacts);
+    expect(result.mcp["github"]).toEqual(artifacts.mcp["@local/github"]);
+  });
+
+  it("does not mutate the input", () => {
+    const artifacts: ResolvedArtifacts = {
+      ...emptyArtifacts(),
+      skills: {
+        "@local/deploy": { description: "Deploy", path: "/abs/skills/deploy" },
+      },
+    };
+
+    stripScopes(artifacts);
+    expect(Object.keys(artifacts.skills)).toEqual(["@local/deploy"]);
+  });
+
+  it("succeeds when a shortname recurs across different categories (separate namespaces)", () => {
+    // Same shortname `foo` in two different categories is not a collision —
+    // each category is its own namespace in the output.
+    const artifacts: ResolvedArtifacts = {
+      ...emptyArtifacts(),
+      skills: {
+        "@local/foo": { description: "skill foo", path: "/abs/skills/foo" },
+      },
+      mcp: {
+        "@local/foo": { type: "stdio", command: "echo" },
+      },
+    };
+
+    const result = stripScopes(artifacts);
+    expect(result.skills["foo"]).toBeDefined();
+    expect(result.mcp["foo"]).toBeDefined();
+  });
+});
+
+describe("stripScopes — collisions", () => {
+  it("throws ShortnameCollisionError when two scopes contribute the same shortname", () => {
+    const artifacts: ResolvedArtifacts = {
+      ...emptyArtifacts(),
+      mcp: {
+        "@local/github": { type: "stdio", command: "npx", args: ["local-gh"] },
+        "@acme/skills/github": {
+          type: "stdio",
+          command: "npx",
+          args: ["acme-gh"],
+        },
+      },
+    };
+
+    expect(() => stripScopes(artifacts)).toThrow(ShortnameCollisionError);
+  });
+
+  it("error message names the colliding shortname and qualified IDs", () => {
+    const artifacts: ResolvedArtifacts = {
+      ...emptyArtifacts(),
+      mcp: {
+        "@local/github": { type: "stdio", command: "npx" },
+        "@reframe-systems/agentic-engineering/github": {
+          type: "stdio",
+          command: "npx",
+        },
+      },
+    };
+
+    let err: ShortnameCollisionError | null = null;
+    try {
+      stripScopes(artifacts);
+    } catch (e) {
+      err = e as ShortnameCollisionError;
+    }
+    expect(err).toBeInstanceOf(ShortnameCollisionError);
+    expect(err!.message).toContain(
+      "--no-scope requires unique shortnames across all scopes"
+    );
+    expect(err!.message).toContain('shortname "github" maps to multiple qualified IDs');
+    expect(err!.message).toContain("- @local/github");
+    expect(err!.message).toContain(
+      "- @reframe-systems/agentic-engineering/github"
+    );
+    expect(err!.message).toContain("air.json#exclude");
+  });
+
+  it("collects every collision instead of bailing on the first one", () => {
+    const artifacts: ResolvedArtifacts = {
+      ...emptyArtifacts(),
+      mcp: {
+        "@local/github": { type: "stdio", command: "npx" },
+        "@acme/github": { type: "stdio", command: "npx" },
+      },
+      skills: {
+        "@local/deploy": { description: "Local deploy", path: "/abs/d" },
+        "@acme/deploy": { description: "Acme deploy", path: "/abs/d2" },
+      },
+    };
+
+    let err: ShortnameCollisionError | null = null;
+    try {
+      stripScopes(artifacts);
+    } catch (e) {
+      err = e as ShortnameCollisionError;
+    }
+    expect(err).toBeInstanceOf(ShortnameCollisionError);
+    expect(err!.collisions).toHaveLength(2);
+    const shortnames = err!.collisions.map((c) => c.shortname).sort();
+    expect(shortnames).toEqual(["deploy", "github"]);
+  });
+
+  it("treats collisions as per-category — same shortname in different categories is fine", () => {
+    const artifacts: ResolvedArtifacts = {
+      ...emptyArtifacts(),
+      mcp: {
+        "@local/foo": { type: "stdio", command: "echo" },
+        "@acme/foo": { type: "stdio", command: "echo" },
+      },
+      skills: {
+        // Same shortname `foo` in skills, but only one scope — not a collision.
+        "@local/foo": { description: "skill", path: "/abs/foo" },
+      },
+    };
+
+    let err: ShortnameCollisionError | null = null;
+    try {
+      stripScopes(artifacts);
+    } catch (e) {
+      err = e as ShortnameCollisionError;
+    }
+    expect(err).toBeInstanceOf(ShortnameCollisionError);
+    // Only one collision: the mcp one.
+    expect(err!.collisions).toHaveLength(1);
+    expect(err!.collisions[0].category).toBe("mcp");
+    expect(err!.collisions[0].shortname).toBe("foo");
+  });
+});

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.2.0"
+    "@pulsemcp/air-core": "0.1.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.1.0"
+    "@pulsemcp/air-core": "0.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.1.0"
+    "@pulsemcp/air-core": "0.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.2.0"
+    "@pulsemcp/air-core": "0.1.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.1.0",
+    "@pulsemcp/air-core": "0.2.0",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.2.0",
+    "@pulsemcp/air-core": "0.1.1",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.2.0"
+    "@pulsemcp/air-core": "0.1.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.1.0"
+    "@pulsemcp/air-core": "0.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.1.0"
+    "@pulsemcp/air-core": "0.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.2.0"
+    "@pulsemcp/air-core": "0.1.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.2.0"
+    "@pulsemcp/air-core": "0.1.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.1.0"
+    "@pulsemcp/air-core": "0.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -18,6 +18,8 @@ export {
   buildShortnameIndex,
   lookupArtifactId,
   resolveReference,
+  stripScopes,
+  ShortnameCollisionError,
   // Validation
   validateJson,
   // Schemas
@@ -85,6 +87,7 @@ export type {
   // Scoped identity types
   QualifiedId,
   ReferenceResolution,
+  ShortnameCollision,
 } from "@pulsemcp/air-core";
 
 // Adapter registry


### PR DESCRIPTION
## Summary

Implements [#116](https://github.com/pulsemcp/air/issues/116): adds an opt-in `--no-scope` flag to `air resolve` for shortname-keyed output.

- `air resolve` now accepts `--no-scope` to rewrite both top-level keys (`@local/github` → `github`) and reference fields inside entries (`default_skills`, `default_mcp_servers`, `skills.references`, `plugins.{skills,mcp_servers,hooks,plugins}`, `hooks.references`) to bare shortnames.
- The flag **hard-fails** when a shortname is contributed by more than one scope within the same artifact category. The error lists every colliding qualified ID with the format from the issue:

  ```
  --no-scope requires unique shortnames across all scopes, but
    shortname "github" maps to multiple qualified IDs:
      - @local/github
      - @reframe-systems/agentic-engineering/github
    Either use the default qualified output, or exclude one of them
    via air.json#exclude.
  ```
- Default behavior (qualified output) is unchanged. There is no silent later-wins.
- New exports: `stripScopes` and `ShortnameCollisionError` (plus `ShortnameCollision` type) from both `@pulsemcp/air-core` and `@pulsemcp/air-sdk`.

The transformation lives in `@pulsemcp/air-core/src/strip-scopes.ts` (per the "CLI stays thin" principle) and is wired into the CLI via Commander's `--no-scope` option.

## Test plan

- [x] Build core, sdk, cli — all green
- [x] 9 new unit tests in `packages/core/tests/strip-scopes.test.ts` (key/reference rewriting, collision detection, error format, no input mutation)
- [x] 4 new integration tests in `packages/cli/tests/resolve-command.test.ts` covering single-scope rewriting, plugin/hook/skill reference rewriting, cross-scope collision, default unchanged
- [x] Full core test suite passes (203 tests)
- [x] Docs updated in `docs/cli.md`, `docs/guides/running-sessions.md`, `docs/guides/composition-and-overrides.md`
- [x] CHANGELOG entry for v0.2.0
- [x] Version bumped across all `packages/*/package.json` and lockfile regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)