### PR TITLE
feat: per-type exclude with wildcards (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-04-26
+
+### Breaking
+- **`air.json#exclude` is now a per-type object with wildcard support.** The previous flat-array shape (`exclude: ["@scope/id"]`) is no longer accepted — resolution hard-fails with a migration error. The new shape is an object keyed by artifact type: `exclude: { skills: [...], references: [...], mcp: [...], plugins: [...], roots: [...], hooks: [...] }`. Each value is a list of qualified-ID patterns where `*` matches one full segment (no boundary spanning). This makes exclusion type-safe — excluding a skill named `github` no longer drops an MCP server with the same shortname — and lets callers drop whole groups (e.g. `@vendor/legacy/*`) without enumerating every entry. Each pattern is matched against its declared type only, and entries that match nothing are surfaced as per-type/per-pattern warnings so typos are easy to catch. **Migration:** replace `"exclude": ["@a/x"]` with `"exclude": { "<type>": ["@a/x"] }`, where `<type>` is the artifact kind that `@a/x` was meant to drop. The schema (`schemas/air.schema.json`) and all docs have been updated. Resolves [#118](https://github.com/pulsemcp/air/issues/118).
+
 ## [0.1.1] - 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ AIR expands each catalog into all six artifact arrays automatically — missing 
     "github://acme/air-frontend"
   ],
   "mcp": ["./mcp/mcp.json"],
-  "exclude": ["@acme/air-org/legacy-server"]
+  "exclude": {
+    "mcp": ["@acme/air-org/legacy-server"]
+  }
 }
 ```
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -59,7 +59,7 @@ For each artifact type:
 1. **Disjoint qualified IDs** accumulate (additive union)
 2. **Duplicate qualified IDs** hard-fail — you cannot silently override an artifact
 3. **Cross-scope shortname collisions** warn but keep both — disambiguate with the qualified form
-4. **`exclude`** is the only way to drop an artifact (takes a list of qualified IDs)
+4. **`exclude`** is the only way to drop an artifact. It takes a per-type object (keys: `skills`, `references`, `mcp`, `plugins`, `roots`, `hooks`) where each value is a list of qualified-ID patterns. `*` is allowed within a single segment (matches one full segment, no boundary spanning).
 
 ### Example
 
@@ -71,14 +71,16 @@ For each artifact type:
     "github://acme/air-frontend"
   ],
   "mcp": ["./mcp/mcp.json"],
-  "exclude": ["@acme/air-org/legacy-server"]
+  "exclude": {
+    "mcp": ["@acme/air-org/legacy-server"]
+  }
 }
 ```
 
 - **Org catalog** ships under `@acme/air-org/...`
 - **Frontend team catalog** ships under `@acme/air-frontend/...`
 - **Local `mcp.json`** ships under `@local/...`
-- `exclude` drops `@acme/air-org/legacy-server`. To replace an upstream artifact, exclude it and ship a replacement under your own scope.
+- `exclude.mcp` drops the MCP server `@acme/air-org/legacy-server`. To replace an upstream artifact, exclude it under the right type and ship a replacement under your own scope.
 
 ## Design Principles
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,9 +99,13 @@ If you want to drop the org's `slack` server:
 ```json
 {
   "catalogs": ["github://acme/air-org"],
-  "exclude": ["@acme/air-org/slack"]
+  "exclude": {
+    "mcp": ["@acme/air-org/slack"]
+  }
 }
 ```
+
+`exclude` is an object keyed by artifact type (`skills`, `references`, `mcp`, `plugins`, `roots`, `hooks`); each value is a list of qualified-ID patterns where `*` matches a single segment.
 
 If you want a different `github` configuration, ship it under `@local/`:
 
@@ -109,7 +113,9 @@ If you want a different `github` configuration, ship it under `@local/`:
 {
   "catalogs": ["github://acme/air-org"],
   "mcp": ["./mcp/mcp.json"],
-  "exclude": ["@acme/air-org/github"]
+  "exclude": {
+    "mcp": ["@acme/air-org/github"]
+  }
 }
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,7 +69,7 @@ For each artifact type:
 1. **Different qualified IDs** accumulate (additive union)
 2. **Duplicate qualified IDs** hard-fail — you cannot silently override an artifact
 3. **Cross-scope shortname collisions** warn but keep both — disambiguate with the qualified form
-4. **`exclude`** is the only way to drop an artifact (takes a list of qualified IDs)
+4. **`exclude`** is the only way to drop an artifact. Provide an object keyed by artifact type (`skills`, `references`, `mcp`, `plugins`, `roots`, `hooks`); each value is a list of qualified-ID patterns where `*` matches one full segment.
 
 See [Composition and Overrides](guides/composition-and-overrides.md) for the full rules and examples.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -120,10 +120,10 @@ The consumer pulls in the customer's catalog, then drops the entries that don't 
     "github://customer-co/their-air-config",
     "./local-catalog"
   ],
-  "exclude": [
-    "@customer-co/their-air-config/legacy-deploy",
-    "@customer-co/their-air-config/internal-only-mcp"
-  ]
+  "exclude": {
+    "skills": ["@customer-co/their-air-config/legacy-deploy"],
+    "mcp": ["@customer-co/their-air-config/internal-only-mcp"]
+  }
 }
 ```
 
@@ -148,9 +148,9 @@ A user composing two community catalogs plus their own local layer:
     "github://oss-author-2/air-toolkit",
     "./my-local-catalog"
   ],
-  "exclude": [
-    "@oss-author-2/air-toolkit/aggressive-cleanup-hook"
-  ]
+  "exclude": {
+    "hooks": ["@oss-author-2/air-toolkit/aggressive-cleanup-hook"]
+  }
 }
 ```
 

--- a/docs/guides/composition-and-overrides.md
+++ b/docs/guides/composition-and-overrides.md
@@ -79,7 +79,7 @@ The artifacts both stay in the resolved set — the warning just tells you that 
 
 ### 4. `exclude` drops artifacts by qualified ID
 
-`exclude` is the only composition control. It takes a list of **qualified** IDs to remove from the resolved set:
+`exclude` is the only composition control. It is an **object keyed by artifact type** (`skills`, `references`, `mcp`, `plugins`, `roots`, `hooks`); each value is a list of qualified IDs — or wildcard patterns — to drop from that type:
 
 ```json
 {
@@ -89,20 +89,62 @@ The artifacts both stay in the resolved set — the warning just tells you that 
     "github://acme/air-org",
     "./platform-team-catalog"
   ],
-  "exclude": [
-    "@acme/air-org/legacy-deploy",
-    "@acme/air-org/dont-use-this-mcp-server"
-  ]
+  "exclude": {
+    "skills": ["@acme/air-org/legacy-deploy"],
+    "mcp": ["@acme/air-org/dont-use-this-mcp-server"]
+  }
+}
+```
+
+Per-type matching is strict: an entry under `exclude.skills` only removes skills, never an MCP server with the same shortname. This matters because the same shortname (e.g. `github`) can legitimately exist as both a skill and an MCP server within a single scope — the legacy flat-array form silently fanned out across types and is no longer accepted.
+
+#### Wildcards
+
+Each entry may be either a literal qualified ID or a wildcard pattern. A `*` segment matches one or more non-slash characters within a single qualified-ID segment; `*` does **not** span segment boundaries:
+
+| Pattern | Matches |
+|---------|---------|
+| `@vendor/legacy/*` | Every artifact of this type contributed by `@vendor/legacy` (drops the entire scope's contribution to one type) |
+| `@vendor/*/github` | The `github` shortname under every repo whose scope's first segment is `vendor` |
+| `@*/agentic-engineering/*` | Every artifact of this type contributed by any repo named `agentic-engineering`, regardless of the scope's first segment |
+
+Example:
+
+```json
+{
+  "exclude": {
+    "skills": [
+      "@customer/agentic-engineering/github",
+      "@vendor/legacy/*",
+      "@*/agentic-engineering/*"
+    ],
+    "mcp": ["@some-scope/some-repo/github"],
+    "hooks": ["@other-scope/some-repo/legacy-hook"]
+  }
 }
 ```
 
 Notes:
 
-- Entries **must** be qualified — bare shortnames are rejected with a hard error.
-- An `exclude` entry that does not match any resolved artifact emits a warning (typo guard, not an error).
+- Each entry must be a qualified ID (`@scope/id`) or a wildcard pattern of the same shape — bare shortnames are rejected with a hard error.
+- An entry — exact or wildcard — that does not match any resolved artifact of its type emits a warning that names both the type and the offending pattern (typo guard, not an error).
 - `exclude` runs after composition, so a catalog you depend on cannot bypass it.
+- Omitting a key means "don't exclude anything of that type."
 
 There is no field-level patch, no "override this one field" knob. If you want a different behavior for a skill, ship a new skill under your own scope.
+
+#### Migrating from the legacy flat-array form
+
+Earlier versions of AIR (≤ 0.1.x) accepted `exclude` as a flat array of qualified IDs. That shape is now rejected at resolution time with a migration error:
+
+```
+air.json "exclude" must be an object keyed by artifact type
+(skills, references, mcp, plugins, roots, hooks), not an array.
+Migration: replace exclude: ["@a/x"] with exclude: { "<type>": ["@a/x"] },
+where <type> is the artifact kind "@a/x" was meant to drop.
+```
+
+Pick the artifact type you intended to drop and move the entry under that key. There is no dual-shape acceptance — you must update every `air.json` in your tree before resolution will succeed.
 
 ## Reference syntax
 
@@ -268,14 +310,24 @@ Three scopes coexist: `@acme/air-org/...`, `@acme/air-platform-team/...`, and `@
 {
   "extensions": ["@pulsemcp/air-provider-github"],
   "catalogs": ["github://acme/air-org"],
-  "exclude": [
-    "@acme/air-org/legacy-deploy",
-    "@acme/air-org/old-mcp-server"
-  ]
+  "exclude": {
+    "skills": ["@acme/air-org/legacy-deploy"],
+    "mcp": ["@acme/air-org/old-mcp-server"]
+  }
 }
 ```
 
 The two excluded artifacts disappear from the resolved set; everything else from `@acme/air-org` is kept.
+
+To drop an entire scope's contribution of one type, use a wildcard:
+
+```json
+{
+  "exclude": {
+    "skills": ["@acme/legacy-org/*"]
+  }
+}
+```
 
 ## Remote configuration with providers
 
@@ -365,7 +417,9 @@ Subagent root references follow the same short / qualified rules.
 ```json
 {
   "catalogs": ["github://acme/air-org"],
-  "exclude": ["@acme/air-org/skill-i-dont-want"]
+  "exclude": {
+    "skills": ["@acme/air-org/skill-i-dont-want"]
+  }
 }
 ```
 
@@ -378,9 +432,12 @@ There is no "disabled" flag, no override-with-empty-entry trick. If you want a t
 | Different scopes contribute different shortnames | All artifacts kept (additive) |
 | Different scopes contribute the same shortname | All kept; warning logged; short refs must qualify |
 | Same scope, two indexes, same shortname | Hard-fail (duplicate qualified ID) |
-| `exclude` matches a qualified ID | Artifact removed from the resolved set |
-| `exclude` entry matches nothing | Warning logged; resolution continues |
-| `exclude` entry is not qualified | Hard-fail (must be `@scope/id`) |
+| `exclude.<type>` matches a qualified ID | Artifact of that type removed from the resolved set; identically-named artifacts of other types untouched |
+| `exclude.<type>` matches a wildcard pattern | Every qualified ID of that type matching the pattern is removed |
+| `exclude.<type>` entry matches nothing | Per-type/per-pattern warning logged; resolution continues |
+| `exclude.<type>` entry is not a qualified ID or wildcard | Hard-fail with the offending entry |
+| `exclude` is an array (legacy shape) | Hard-fail with a migration error pointing at the per-type object form |
+| `exclude` key is not a valid artifact type | Hard-fail naming the unknown key and listing valid keys |
 | Short reference, unambiguous | Resolved to its qualified ID |
 | Short reference, ambiguous | Hard-fail with candidate list |
 | Short reference inside a catalog index | Resolved to the catalog's own scope first |

--- a/docs/guides/understanding-air-json.md
+++ b/docs/guides/understanding-air-json.md
@@ -102,7 +102,7 @@ Composition is additive:
 1. **Disjoint qualified IDs** accumulate (union)
 2. **Duplicate qualified IDs** hard-fail — you cannot silently override an artifact
 3. **Cross-scope shortname collisions** warn but keep both — disambiguate with the qualified form
-4. **`exclude`** is the only way to drop an artifact (takes a list of qualified IDs)
+4. **`exclude`** is the only way to drop an artifact. It takes a per-type object — keys are artifact types (`skills`, `references`, `mcp`, `plugins`, `roots`, `hooks`) and values are arrays of qualified-ID patterns. Each segment of a pattern may be a literal or `*` (matches one full segment).
 
 ```json
 {
@@ -111,7 +111,9 @@ Composition is additive:
     "./platform-team-catalog"
   ],
   "mcp": ["./mcp/local.json"],
-  "exclude": ["@acme/air-org/legacy-server"]
+  "exclude": {
+    "mcp": ["@acme/air-org/legacy-server"]
+  }
 }
 ```
 
@@ -174,7 +176,9 @@ These resolve to two distinct artifacts: `@acme/air-org/github` and `@local/gith
 {
   "catalogs": ["github://acme/air-org"],
   "mcp": ["./mcp/local.json"],
-  "exclude": ["@acme/air-org/github"]
+  "exclude": {
+    "mcp": ["@acme/air-org/github"]
+  }
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "air-main-1777160302-cfd02f86",
+  "name": "air-main-1777217496-952355a0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -891,9 +891,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.1.1",
+        "@pulsemcp/air-sdk": "0.2.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -912,7 +912,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -929,9 +929,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.1.1"
+        "@pulsemcp/air-core": "0.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -944,9 +944,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.1.1"
+        "@pulsemcp/air-core": "0.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -959,9 +959,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.1.1",
+        "@pulsemcp/air-core": "0.2.0",
         "proper-lockfile": "^4.1.2"
       },
       "devDependencies": {
@@ -976,9 +976,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.1.1"
+        "@pulsemcp/air-core": "0.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -991,9 +991,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.1.1"
+        "@pulsemcp/air-core": "0.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1006,9 +1006,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.1.1"
+        "@pulsemcp/air-core": "0.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.1.1",
+    "@pulsemcp/air-sdk": "0.2.0",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/cli/tests/resolve-command.test.ts
+++ b/packages/cli/tests/resolve-command.test.ts
@@ -169,7 +169,7 @@ describe("resolve command", () => {
       "air.json": {
         name: "test",
         mcp: ["./mcp.json"],
-        exclude: ["@local/dropped"],
+        exclude: { mcp: ["@local/dropped"] },
       },
       "mcp.json": {
         kept: { type: "stdio", command: "npx", args: ["kept"] },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -3,6 +3,7 @@ import { resolve, dirname } from "path";
 import ignore, { type Ignore } from "ignore";
 import type {
   AirConfig,
+  ExcludeConfig,
   ResolvedArtifacts,
   SkillEntry,
   ReferenceEntry,
@@ -547,7 +548,7 @@ async function expandAllCatalogs(
  */
 function canonicalizeReferences(
   artifacts: ResolvedArtifacts,
-  excluded: Set<QualifiedId>,
+  excluded: Map<ArtifactType, Set<QualifiedId>>,
   errors: string[]
 ): ResolvedArtifacts {
   type RefField =
@@ -567,16 +568,26 @@ function canonicalizeReferences(
 
   /**
    * For a `missing` reference, decide whether the target was specifically
-   * dropped by `air.json#exclude`. Exact qualified-ID match wins; otherwise a
-   * short reference matches any excluded entry whose shortname matches `ref`.
-   * The list of matching excluded IDs is returned so the error can name them.
+   * dropped by `air.json#exclude` for the same artifact type as the pool
+   * being resolved. Exact qualified-ID match wins; otherwise a short
+   * reference matches any excluded entry of that type whose shortname
+   * equals `ref`. The list of matching excluded IDs is returned so the
+   * error can name them.
+   *
+   * Per-type scoping matters here: a skill named `github` excluded under
+   * `exclude.skills` should not produce a "removed by exclude" error when
+   * a missing MCP-server reference happens to also be named `github`.
    */
-  function excludedMatches(ref: string): QualifiedId[] {
+  function excludedMatches(
+    ref: string,
+    artifactType: ArtifactType
+  ): QualifiedId[] {
+    const set = excluded.get(artifactType) ?? new Set<QualifiedId>();
     if (isQualified(ref)) {
-      return excluded.has(ref) ? [ref] : [];
+      return set.has(ref) ? [ref] : [];
     }
     const matches: QualifiedId[] = [];
-    for (const id of excluded) {
+    for (const id of set) {
       if (parseQualifiedId(id).id === ref) matches.push(id);
     }
     return matches;
@@ -587,6 +598,7 @@ function canonicalizeReferences(
     pool: Record<string, unknown>,
     fromScope: string,
     poolType: string,
+    artifactType: ArtifactType,
     ownerLabel: string,
     field: string
   ): string[] | undefined {
@@ -597,7 +609,7 @@ function canonicalizeReferences(
       if (res.status === "ok") {
         out.push(res.qualified);
       } else if (res.status === "missing") {
-        const matches = excludedMatches(ref);
+        const matches = excludedMatches(ref, artifactType);
         if (matches.length > 0) {
           errors.push(
             `${ownerLabel}.${field} references ${poolType} "${ref}", ` +
@@ -636,6 +648,7 @@ function canonicalizeReferences(
         result.references,
         scope,
         "reference",
+        "references",
         ownerLabel,
         "references"
       );
@@ -648,6 +661,7 @@ function canonicalizeReferences(
         result.skills,
         scope,
         "skill",
+        "skills",
         ownerLabel,
         "skills"
       );
@@ -655,6 +669,7 @@ function canonicalizeReferences(
         next.mcp_servers,
         result.mcp,
         scope,
+        "mcp",
         "mcp",
         ownerLabel,
         "mcp_servers"
@@ -664,6 +679,7 @@ function canonicalizeReferences(
         result.hooks,
         scope,
         "hook",
+        "hooks",
         ownerLabel,
         "hooks"
       );
@@ -672,6 +688,7 @@ function canonicalizeReferences(
         result.plugins,
         scope,
         "plugin",
+        "plugins",
         ownerLabel,
         "plugins"
       );
@@ -683,6 +700,7 @@ function canonicalizeReferences(
         result.skills,
         scope,
         "skill",
+        "skills",
         ownerLabel,
         "default_skills"
       );
@@ -690,6 +708,7 @@ function canonicalizeReferences(
         next.default_mcp_servers,
         result.mcp,
         scope,
+        "mcp",
         "mcp",
         ownerLabel,
         "default_mcp_servers"
@@ -699,6 +718,7 @@ function canonicalizeReferences(
         result.plugins,
         scope,
         "plugin",
+        "plugins",
         ownerLabel,
         "default_plugins"
       );
@@ -707,6 +727,7 @@ function canonicalizeReferences(
         result.hooks,
         scope,
         "hook",
+        "hooks",
         ownerLabel,
         "default_hooks"
       );
@@ -715,6 +736,7 @@ function canonicalizeReferences(
         result.roots,
         scope,
         "root",
+        "roots",
         ownerLabel,
         "default_subagent_roots"
       );
@@ -748,27 +770,162 @@ function listIds(pool: Record<string, unknown>): string {
 }
 
 /**
- * Apply `air.json#exclude` to a resolved artifact set. Excluded qualified IDs
- * disappear from every artifact map; entries that don't match anything are
- * surfaced as warnings so typos in `exclude` are visible to authors.
+ * Empty per-type excluded map — one entry per artifact type, each with an
+ * empty `Set<QualifiedId>`. Used as the default return when `exclude` is
+ * absent from `air.json`, and as the seed for the populated form returned
+ * by `applyExclude`.
+ */
+function emptyExcludedByType(): Map<ArtifactType, Set<QualifiedId>> {
+  return new Map(
+    ARTIFACT_TYPES.map((t) => [t, new Set<QualifiedId>()])
+  );
+}
+
+/**
+ * Compile a single exclude entry containing `*` into a regex matching
+ * qualified IDs. Each `*` matches one or more non-slash characters within
+ * a single qualified-ID segment; segment boundaries are preserved because
+ * `[^/]+` excludes `/`.
+ */
+function compileExcludePattern(pattern: string): RegExp {
+  // Escape regex specials except `*`, which is replaced with the segment
+  // wildcard `[^/]+`.
+  let out = "";
+  for (const ch of pattern) {
+    if (ch === "*") {
+      out += "[^/]+";
+    } else if (/[.+?^${}()|[\]\\]/.test(ch)) {
+      out += "\\" + ch;
+    } else {
+      out += ch;
+    }
+  }
+  return new RegExp(`^${out}$`);
+}
+
+/**
+ * Validate the structural shape of an exclude entry: either a qualified ID
+ * (`@scope/id`) or a wildcard pattern of the same shape with `*` segments
+ * permitted. The compiled pattern handles the actual matching; this guard
+ * just rules out obvious nonsense (bare shortnames, missing `@`, empty
+ * segments).
+ */
+function isValidExcludeEntry(entry: string): boolean {
+  return /^@[^/]+(?:\/[^/]+)+$/.test(entry);
+}
+
+/**
+ * Apply `air.json#exclude` to a resolved artifact set. Each artifact type
+ * has its own list of qualified IDs / wildcard patterns; matching is
+ * scoped strictly to that type, so excluding a skill named `github` does
+ * not drop an MCP server with the same shortname. Entries that do not
+ * match anything of their type are surfaced as warnings naming both the
+ * type and the offending pattern so typos are easy to fix.
+ *
+ * The legacy flat-array shape (`exclude: ["@a/x"]`) is rejected with a
+ * migration error; there is no dual-shape acceptance.
+ *
+ * The returned `excluded` map keys artifact types to the resolved
+ * qualified IDs that were dropped — wildcard patterns are already
+ * expanded so downstream consumers (e.g. reference canonicalization) do
+ * not need to know about wildcards.
  */
 function applyExclude(
   artifacts: ResolvedArtifacts,
-  exclude: string[],
+  exclude: ExcludeConfig | string[] | undefined,
   warnings: string[]
-): { artifacts: ResolvedArtifacts; excluded: Set<string> } {
-  if (exclude.length === 0) {
-    return { artifacts, excluded: new Set() };
+): {
+  artifacts: ResolvedArtifacts;
+  excluded: Map<ArtifactType, Set<QualifiedId>>;
+} {
+  if (exclude === undefined) {
+    return { artifacts, excluded: emptyExcludedByType() };
   }
 
-  const excludeSet = new Set<string>();
-  for (const id of exclude) {
-    if (!isQualified(id)) {
+  // Hard-reject the legacy flat-array shape. The error must point at the
+  // new shape clearly enough that the fix is obvious from the message
+  // alone.
+  if (Array.isArray(exclude)) {
+    throw new Error(
+      `air.json "exclude" must be an object keyed by artifact type ` +
+        `(${ARTIFACT_TYPES.join(", ")}), not an array. ` +
+        `Migration: replace exclude: ["@a/x"] with ` +
+        `exclude: { "<type>": ["@a/x"] }, where <type> is the artifact ` +
+        `kind "@a/x" was meant to drop.`
+    );
+  }
+  if (typeof exclude !== "object" || exclude === null) {
+    throw new Error(
+      `air.json "exclude" must be an object keyed by artifact type ` +
+        `(${ARTIFACT_TYPES.join(", ")}); got ${typeof exclude}.`
+    );
+  }
+
+  for (const key of Object.keys(exclude)) {
+    if (!ARTIFACT_TYPES.includes(key as ArtifactType)) {
       throw new Error(
-        `air.json "exclude" entries must be qualified IDs (@scope/id); got "${id}".`
+        `air.json "exclude" key "${key}" is not a valid artifact type. ` +
+          `Valid keys: ${ARTIFACT_TYPES.join(", ")}.`
       );
     }
-    excludeSet.add(id);
+  }
+
+  interface CompiledExclude {
+    exact: Set<QualifiedId>;
+    patterns: { source: string; regex: RegExp; matched: boolean }[];
+  }
+  const compiled: Record<ArtifactType, CompiledExclude> = {
+    skills: { exact: new Set(), patterns: [] },
+    references: { exact: new Set(), patterns: [] },
+    mcp: { exact: new Set(), patterns: [] },
+    plugins: { exact: new Set(), patterns: [] },
+    roots: { exact: new Set(), patterns: [] },
+    hooks: { exact: new Set(), patterns: [] },
+  };
+  const exactSeen: Record<ArtifactType, Set<QualifiedId>> = {
+    skills: new Set(),
+    references: new Set(),
+    mcp: new Set(),
+    plugins: new Set(),
+    roots: new Set(),
+    hooks: new Set(),
+  };
+
+  const excludeRecord = exclude as Record<string, unknown>;
+  for (const type of ARTIFACT_TYPES) {
+    const entries = excludeRecord[type];
+    if (entries === undefined) continue;
+    if (!Array.isArray(entries)) {
+      throw new Error(
+        `air.json "exclude.${type}" must be an array of qualified IDs ` +
+          `or wildcard patterns; got ${typeof entries}.`
+      );
+    }
+    for (const raw of entries) {
+      if (typeof raw !== "string") {
+        throw new Error(
+          `air.json "exclude.${type}" entries must be strings; got ` +
+            `${typeof raw}.`
+        );
+      }
+      if (!isValidExcludeEntry(raw)) {
+        throw new Error(
+          `air.json "exclude.${type}" entry "${raw}" must be a qualified ` +
+            `ID (@scope/id) or a wildcard pattern of the same shape ` +
+            `(\`*\` matches one or more non-slash characters within a ` +
+            `single segment).`
+        );
+      }
+      if (raw.includes("*")) {
+        compiled[type].patterns.push({
+          source: raw,
+          regex: compileExcludePattern(raw),
+          matched: false,
+        });
+      } else {
+        compiled[type].exact.add(raw);
+      }
+    }
   }
 
   const result: ResolvedArtifacts = {
@@ -779,30 +936,58 @@ function applyExclude(
     roots: {},
     hooks: {},
   };
-  const seen = new Set<string>();
+  const excludedByType = emptyExcludedByType();
 
   for (const type of ARTIFACT_TYPES) {
     const src = artifacts[type] as Record<string, unknown>;
     const dst = result[type] as Record<string, unknown>;
+    const c = compiled[type];
+    const dropped = excludedByType.get(type)!;
+
     for (const [id, entry] of Object.entries(src)) {
-      if (excludeSet.has(id)) {
-        seen.add(id);
-        continue;
+      let drop = false;
+      if (c.exact.has(id)) {
+        drop = true;
+        exactSeen[type].add(id);
       }
-      dst[id] = entry;
+      // Always test wildcard patterns so each one tracks its own match
+      // status — needed for the per-pattern stale-entry warning.
+      for (const pat of c.patterns) {
+        if (pat.regex.test(id)) {
+          drop = true;
+          pat.matched = true;
+        }
+      }
+      if (drop) {
+        dropped.add(id);
+      } else {
+        dst[id] = entry;
+      }
     }
   }
 
-  for (const id of excludeSet) {
-    if (!seen.has(id)) {
-      warnings.push(
-        `air.json "exclude" entry "${id}" did not match any resolved ` +
-          `artifact. Remove it or check for typos.`
-      );
+  for (const type of ARTIFACT_TYPES) {
+    const c = compiled[type];
+    for (const id of c.exact) {
+      if (!exactSeen[type].has(id)) {
+        warnings.push(
+          `air.json "exclude.${type}" entry "${id}" did not match any ` +
+            `resolved ${type} artifact. Remove it or check for typos.`
+        );
+      }
+    }
+    for (const pat of c.patterns) {
+      if (!pat.matched) {
+        warnings.push(
+          `air.json "exclude.${type}" pattern "${pat.source}" did not ` +
+            `match any resolved ${type} artifact. Remove it or check ` +
+            `for typos.`
+        );
+      }
     }
   }
 
-  return { artifacts: result, excluded: excludeSet };
+  return { artifacts: result, excluded: excludedByType };
 }
 
 /**
@@ -892,7 +1077,7 @@ export async function resolveArtifacts(
   // satisfy references and a clear "missing reference" error surfaces.
   const { artifacts: filtered, excluded } = applyExclude(
     resolved,
-    airConfig.exclude || [],
+    airConfig.exclude,
     warnings
   );
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -33,12 +33,25 @@ export interface AirConfig {
   roots?: string[];
   hooks?: string[];
   /**
-   * Qualified IDs (`@scope/id`) to drop from the resolved artifact set. This
-   * is the only composition control: there is no override, no field-level
-   * patching. An entry that does not match any resolved artifact is reported
-   * as a warning so typos surface immediately.
+   * Per-type lists of qualified IDs (`@scope/id`) — or wildcard patterns —
+   * to drop from the resolved artifact set. This is the only composition
+   * control: there is no override, no field-level patching.
+   *
+   * Keys are artifact-type names (`skills`, `references`, `mcp`, `plugins`,
+   * `roots`, `hooks`); each value is an array of qualified IDs or wildcard
+   * patterns scoped to that type. A `*` segment in a pattern matches one or
+   * more non-slash characters within a single qualified-ID segment and does
+   * not span segment boundaries (e.g. `@vendor/legacy/*` drops every
+   * artifact of this type contributed by `@vendor/legacy`).
+   *
+   * An entry — exact or wildcard — that does not match any resolved
+   * artifact of its type is reported as a warning so typos surface
+   * immediately.
+   *
+   * The legacy flat-array form (`exclude: ["@a/x"]`) is no longer accepted;
+   * resolution hard-fails with a migration error pointing at the new shape.
    */
-  exclude?: string[];
+  exclude?: ExcludeConfig;
   /**
    * Protocol used by git-based catalog providers (e.g., github://) when
    * cloning remote repositories. Defaults to "ssh". Set to "https" for
@@ -56,6 +69,21 @@ export interface ResolvedArtifacts {
   plugins: Record<string, PluginEntry>;
   roots: Record<string, RootEntry>;
   hooks: Record<string, HookEntry>;
+}
+
+/**
+ * Per-type exclude configuration. Each key is an artifact-type name and
+ * its value is the list of qualified IDs (or wildcard patterns) of that
+ * type to drop from the resolved set. Omitted keys exclude nothing of
+ * their type.
+ */
+export interface ExcludeConfig {
+  skills?: string[];
+  references?: string[];
+  mcp?: string[];
+  plugins?: string[];
+  roots?: string[];
+  hooks?: string[];
 }
 
 export interface SkillEntry {

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -12,6 +12,36 @@ export interface ValidationError {
   message: string;
 }
 
+const ARTIFACT_TYPES = [
+  "skills",
+  "references",
+  "mcp",
+  "plugins",
+  "roots",
+  "hooks",
+] as const;
+
+/**
+ * If `data` is an air.json with the legacy flat-array `exclude` shape,
+ * return a migration error tuned for that case. The default AJV message
+ * (`/exclude must be object`) does not point users at the new shape, so
+ * `air validate` would otherwise leave them guessing.
+ */
+function detectLegacyExcludeShape(data: unknown): ValidationError | null {
+  if (!data || typeof data !== "object" || Array.isArray(data)) return null;
+  const exclude = (data as Record<string, unknown>).exclude;
+  if (!Array.isArray(exclude)) return null;
+  return {
+    path: "/exclude",
+    message:
+      `air.json "exclude" must be an object keyed by artifact type ` +
+      `(${ARTIFACT_TYPES.join(", ")}), not an array. ` +
+      `Migration: replace exclude: ["@a/x"] with ` +
+      `exclude: { "<type>": ["@a/x"] }, where <type> is the artifact ` +
+      `kind "@a/x" was meant to drop.`,
+  };
+}
+
 export function validateJson(
   data: unknown,
   schemaType: SchemaType
@@ -31,6 +61,16 @@ export function validateJson(
     path: err.instancePath || "/",
     message: err.message || "Unknown validation error",
   }));
+
+  if (schemaType === "air") {
+    const legacy = detectLegacyExcludeShape(data);
+    if (legacy) {
+      return {
+        valid: false,
+        errors: [legacy, ...errors.filter((e) => e.path !== "/exclude")],
+      };
+    }
+  }
 
   return { valid: false, errors };
 }

--- a/packages/core/tests/composition.test.ts
+++ b/packages/core/tests/composition.test.ts
@@ -8,6 +8,7 @@ import {
   exampleMcpStdio,
   exampleRoot,
   exampleReference,
+  exampleHook,
 } from "./helpers.js";
 
 let cleanup: (() => void) | undefined;
@@ -364,6 +365,28 @@ describe("composition", () => {
         w.includes("did not match"),
     );
     expect(stale).toHaveLength(1);
+  });
+
+  it("wildcards work uniformly across artifact types — exclude.hooks drops a wildcard pattern", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        hooks: ["./hooks.json"],
+        exclude: { hooks: ["@local/legacy-*"] },
+      },
+      "hooks.json": {
+        "legacy-pre-commit": exampleHook("legacy-pre-commit"),
+        "legacy-post-merge": exampleHook("legacy-post-merge"),
+        "modern-pre-commit": exampleHook("modern-pre-commit"),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+
+    expect(artifacts.hooks["@local/legacy-pre-commit"]).toBeUndefined();
+    expect(artifacts.hooks["@local/legacy-post-merge"]).toBeUndefined();
+    expect(artifacts.hooks["@local/modern-pre-commit"]).toBeDefined();
   });
 
   it("wildcard segments do not span '/' boundaries", async () => {

--- a/packages/core/tests/composition.test.ts
+++ b/packages/core/tests/composition.test.ts
@@ -77,7 +77,7 @@ describe("composition", () => {
       "air.json": {
         name: "test",
         skills: ["./skills.json"],
-        exclude: ["@local/lint"],
+        exclude: { skills: ["@local/lint"] },
       },
       "skills.json": {
         deploy: exampleSkill("deploy"),
@@ -91,13 +91,13 @@ describe("composition", () => {
     expect(artifacts.skills["@local/lint"]).toBeUndefined();
   });
 
-  it("exclude entry that does not match anything emits a warning", async () => {
+  it("exclude entry that does not match anything emits a warning naming the type and id", async () => {
     const warnings: string[] = [];
     const { dir, cleanup: c } = createTempAirDir({
       "air.json": {
         name: "test",
         skills: ["./skills.json"],
-        exclude: ["@local/missing"],
+        exclude: { skills: ["@local/missing"] },
       },
       "skills.json": {
         deploy: exampleSkill("deploy"),
@@ -109,7 +109,14 @@ describe("composition", () => {
       onWarning: (m) => warnings.push(m),
     });
 
-    expect(warnings.some((w) => w.includes("@local/missing"))).toBe(true);
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("@local/missing") &&
+          w.includes("exclude.skills") &&
+          w.includes("did not match"),
+      ),
+    ).toBe(true);
   });
 
   it("non-qualified exclude entry hard-fails", async () => {
@@ -117,7 +124,7 @@ describe("composition", () => {
       "air.json": {
         name: "test",
         skills: ["./skills.json"],
-        exclude: ["lint"],
+        exclude: { skills: ["lint"] },
       },
       "skills.json": {
         lint: exampleSkill("lint"),
@@ -126,8 +133,277 @@ describe("composition", () => {
     cleanup = c;
 
     await expect(resolveArtifacts(join(dir, "air.json"))).rejects.toThrow(
-      /must be qualified IDs/,
+      /must be a qualified ID/,
     );
+  });
+
+  it("legacy array shape for exclude is hard-rejected with a migration error", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        exclude: ["@local/lint"],
+      },
+      "skills.json": {
+        lint: exampleSkill("lint"),
+      },
+    });
+    cleanup = c;
+
+    await expect(resolveArtifacts(join(dir, "air.json"))).rejects.toThrow(
+      /must be an object keyed by artifact type[^]*not an array[^]*Migration[^]*exclude:\s*\["@a\/x"\][^]*"<type>":\s*\["@a\/x"\]/,
+    );
+  });
+
+  it("invalid exclude key is hard-rejected", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        exclude: { not_a_real_type: ["@local/lint"] },
+      },
+      "skills.json": {
+        lint: exampleSkill("lint"),
+      },
+    });
+    cleanup = c;
+
+    await expect(resolveArtifacts(join(dir, "air.json"))).rejects.toThrow(
+      /key "not_a_real_type" is not a valid artifact type/,
+    );
+  });
+
+  it("exclude is per-type — excluding a skill named 'github' does not drop an MCP server with the same shortname", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        mcp: ["./mcp.json"],
+        exclude: { skills: ["@local/github"] },
+      },
+      "skills.json": {
+        github: exampleSkill("github", { description: "Github skill" }),
+        deploy: exampleSkill("deploy"),
+      },
+      "mcp.json": {
+        github: exampleMcpStdio({ title: "Github MCP" }),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"));
+
+    expect(artifacts.skills["@local/github"]).toBeUndefined();
+    expect(artifacts.skills["@local/deploy"]).toBeDefined();
+    expect(artifacts.mcp["@local/github"]).toBeDefined();
+  });
+
+  it("wildcard pattern '@scope/*' drops every artifact of that type under the scope", async () => {
+    const warnings: string[] = [];
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["mock://vendor/legacy"],
+        skills: ["./local-skills.json"],
+        exclude: { skills: ["@vendor/legacy/*"] },
+      },
+      "local-skills.json": {
+        kept: exampleSkill("kept"),
+      },
+      "remote/skills/skills.json": {
+        a: exampleSkill("a"),
+        b: exampleSkill("b"),
+        c: exampleSkill("c"),
+      },
+    });
+    cleanup = c;
+
+    const provider: CatalogProvider = {
+      scheme: "mock",
+      async resolveCatalogDir(): Promise<string> {
+        return join(dir, "remote");
+      },
+      async resolve(): Promise<Record<string, unknown>> {
+        return {};
+      },
+      getScope: () => "vendor/legacy",
+    };
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      providers: [provider],
+      onWarning: (m) => warnings.push(m),
+    });
+
+    expect(artifacts.skills["@local/kept"]).toBeDefined();
+    expect(artifacts.skills["@vendor/legacy/a"]).toBeUndefined();
+    expect(artifacts.skills["@vendor/legacy/b"]).toBeUndefined();
+    expect(artifacts.skills["@vendor/legacy/c"]).toBeUndefined();
+    expect(
+      warnings.filter((w) => w.includes('exclude.skills') && w.includes("did not match")).length,
+    ).toBe(0);
+  });
+
+  it("wildcard pattern '@scope/*/shortname' drops a shortname across every repo under a scope", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["mock://vendor/repo-a", "mock://vendor/repo-b"],
+        exclude: { mcp: ["@vendor/*/github"] },
+      },
+      "remote-a/mcp/mcp.json": {
+        github: exampleMcpStdio({ title: "A github" }),
+        slack: exampleMcpStdio({ title: "A slack" }),
+      },
+      "remote-b/mcp/mcp.json": {
+        github: exampleMcpStdio({ title: "B github" }),
+        jira: exampleMcpStdio({ title: "B jira" }),
+      },
+    });
+    cleanup = c;
+
+    const provider: CatalogProvider = {
+      scheme: "mock",
+      async resolveCatalogDir(uri: string): Promise<string> {
+        if (uri === "mock://vendor/repo-a") return join(dir, "remote-a");
+        return join(dir, "remote-b");
+      },
+      async resolve(): Promise<Record<string, unknown>> {
+        return {};
+      },
+      getScope: (uri: string) =>
+        uri === "mock://vendor/repo-a" ? "vendor/repo-a" : "vendor/repo-b",
+    };
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      providers: [provider],
+    });
+
+    expect(artifacts.mcp["@vendor/repo-a/github"]).toBeUndefined();
+    expect(artifacts.mcp["@vendor/repo-b/github"]).toBeUndefined();
+    expect(artifacts.mcp["@vendor/repo-a/slack"]).toBeDefined();
+    expect(artifacts.mcp["@vendor/repo-b/jira"]).toBeDefined();
+  });
+
+  it("wildcard pattern '@*/repo/*' drops a whole repo's contribution regardless of scope first segment", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: [
+          "mock://customer/agentic-engineering",
+          "mock://other-customer/agentic-engineering",
+          "mock://customer/other-repo",
+        ],
+        exclude: { skills: ["@*/agentic-engineering/*"] },
+      },
+      "remote-1/skills/skills.json": {
+        review: exampleSkill("review"),
+      },
+      "remote-2/skills/skills.json": {
+        review: exampleSkill("review"),
+      },
+      "remote-3/skills/skills.json": {
+        deploy: exampleSkill("deploy"),
+      },
+    });
+    cleanup = c;
+
+    const provider: CatalogProvider = {
+      scheme: "mock",
+      async resolveCatalogDir(uri: string): Promise<string> {
+        if (uri === "mock://customer/agentic-engineering")
+          return join(dir, "remote-1");
+        if (uri === "mock://other-customer/agentic-engineering")
+          return join(dir, "remote-2");
+        return join(dir, "remote-3");
+      },
+      async resolve(): Promise<Record<string, unknown>> {
+        return {};
+      },
+      getScope: (uri: string) => {
+        if (uri === "mock://customer/agentic-engineering")
+          return "customer/agentic-engineering";
+        if (uri === "mock://other-customer/agentic-engineering")
+          return "other-customer/agentic-engineering";
+        return "customer/other-repo";
+      },
+    };
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      providers: [provider],
+    });
+
+    expect(artifacts.skills["@customer/agentic-engineering/review"]).toBeUndefined();
+    expect(
+      artifacts.skills["@other-customer/agentic-engineering/review"],
+    ).toBeUndefined();
+    expect(artifacts.skills["@customer/other-repo/deploy"]).toBeDefined();
+  });
+
+  it("a stale wildcard pattern produces a per-type per-pattern warning that names both", async () => {
+    const warnings: string[] = [];
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        exclude: { skills: ["@vendor/nonexistent/*"] },
+      },
+      "skills.json": {
+        deploy: exampleSkill("deploy"),
+      },
+    });
+    cleanup = c;
+
+    await resolveArtifacts(join(dir, "air.json"), {
+      onWarning: (m) => warnings.push(m),
+    });
+
+    const stale = warnings.filter(
+      (w) =>
+        w.includes("exclude.skills") &&
+        w.includes('"@vendor/nonexistent/*"') &&
+        w.includes("did not match"),
+    );
+    expect(stale).toHaveLength(1);
+  });
+
+  it("wildcard segments do not span '/' boundaries", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        catalogs: ["mock://vendor/a", "mock://vendor-extra/legacy"],
+        exclude: { skills: ["@vendor/*/keep"] },
+      },
+      "remote-a/skills/skills.json": {
+        keep: exampleSkill("keep"),
+      },
+      "remote-b/skills/skills.json": {
+        keep: exampleSkill("keep"),
+      },
+    });
+    cleanup = c;
+
+    const provider: CatalogProvider = {
+      scheme: "mock",
+      async resolveCatalogDir(uri: string): Promise<string> {
+        if (uri === "mock://vendor/a") return join(dir, "remote-a");
+        return join(dir, "remote-b");
+      },
+      async resolve(): Promise<Record<string, unknown>> {
+        return {};
+      },
+      getScope: (uri: string) =>
+        uri === "mock://vendor/a" ? "vendor/a" : "vendor-extra/legacy",
+    };
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      providers: [provider],
+    });
+
+    // `@vendor/*/keep` matches `@vendor/a/keep` (one segment between vendor and keep)
+    expect(artifacts.skills["@vendor/a/keep"]).toBeUndefined();
+    // It must NOT match `@vendor-extra/legacy/keep` because `*` cannot span `/`
+    // and `vendor-extra` is a different first segment than `vendor`.
+    expect(artifacts.skills["@vendor-extra/legacy/keep"]).toBeDefined();
   });
 
   it("different artifact types compose independently", async () => {
@@ -243,7 +519,7 @@ describe("composition", () => {
         name: "test",
         skills: ["./skills.json"],
         references: ["./refs.json"],
-        exclude: ["@local/git-workflow"],
+        exclude: { references: ["@local/git-workflow"] },
       },
       "skills.json": {
         deploy: exampleSkill("deploy", { references: ["git-workflow"] }),
@@ -308,7 +584,7 @@ describe("composition", () => {
         name: "test",
         catalogs: ["mock://acme"],
         skills: ["./local-skills.json"],
-        exclude: ["@acme/skills/review"],
+        exclude: { skills: ["@acme/skills/review"] },
       },
       "local-skills.json": {
         review: exampleSkill("review"),

--- a/packages/core/tests/validator.test.ts
+++ b/packages/core/tests/validator.test.ts
@@ -66,6 +66,19 @@ describe("validateJson", () => {
       expect(result.valid).toBe(false);
     });
 
+    it("returns a migration-friendly error for the legacy flat-array exclude shape", () => {
+      const result = validateJson(
+        { name: "legacy", exclude: ["@local/lint"] },
+        "air"
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].path).toBe("/exclude");
+      expect(result.errors[0].message).toMatch(
+        /must be an object keyed by artifact type/
+      );
+      expect(result.errors[0].message).toMatch(/Migration/);
+    });
+
     it("rejects an exclude object with an unknown artifact-type key", () => {
       const result = validateJson(
         {

--- a/packages/core/tests/validator.test.ts
+++ b/packages/core/tests/validator.test.ts
@@ -37,6 +37,45 @@ describe("validateJson", () => {
       );
       expect(result.valid).toBe(true);
     });
+
+    it("accepts the per-type exclude object shape with exact and wildcard entries", () => {
+      const result = validateJson(
+        {
+          name: "with-exclude",
+          exclude: {
+            skills: [
+              "@customer/agentic-engineering/github",
+              "@vendor/legacy/*",
+              "@vendor/*/github",
+              "@*/agentic-engineering/*",
+            ],
+            mcp: ["@some-scope/some-repo/github"],
+            hooks: ["@other-scope/some-repo/legacy-hook"],
+          },
+        },
+        "air"
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects the legacy flat-array exclude shape", () => {
+      const result = validateJson(
+        { name: "legacy", exclude: ["@local/lint"] },
+        "air"
+      );
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects an exclude object with an unknown artifact-type key", () => {
+      const result = validateJson(
+        {
+          name: "bad-key",
+          exclude: { not_a_real_type: ["@local/lint"] },
+        },
+        "air"
+      );
+      expect(result.valid).toBe(false);
+    });
   });
 
   describe("skills.json", () => {

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.1.1"
+    "@pulsemcp/air-core": "0.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.1.1"
+    "@pulsemcp/air-core": "0.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.1.1",
+    "@pulsemcp/air-core": "0.2.0",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.1.1"
+    "@pulsemcp/air-core": "0.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.1.1"
+    "@pulsemcp/air-core": "0.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.1.1"
+    "@pulsemcp/air-core": "0.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/schemas/air.schema.json
+++ b/schemas/air.schema.json
@@ -32,9 +32,35 @@
       "description": "Paths or URIs to artifact catalogs. AIR walks each catalog up to 3 directory levels deep and discovers artifact index files (skills, references, mcp, plugins, roots, hooks) by filename or `$schema`. Every artifact discovered in a catalog is qualified `@scope/id`, where scope is supplied by the catalog provider (e.g. `owner/repo` for github://) or `local` for filesystem catalogs. Composition is union-only — duplicate qualified IDs across catalogs are an error; same shortname under different scopes is allowed and reported as a warning."
     },
     "exclude": {
-      "type": "array",
-      "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-/]+/[^/]+$" },
-      "description": "Qualified IDs (`@scope/id`) to drop from the resolved artifact set. This is the only composition control AIR offers — there is no override or field-level patching. Entries that do not match a resolved artifact surface as warnings."
+      "type": "object",
+      "description": "Per-type lists of qualified IDs (`@scope/id`) — or wildcard patterns of the same shape — to drop from the resolved artifact set. This is the only composition control AIR offers; there is no override or field-level patching. Each `*` segment matches one or more non-slash characters within a single qualified-ID segment and does not span segment boundaries. Entries that do not match any resolved artifact of their type surface as warnings naming both the type and the offending pattern. The legacy flat-array form (e.g. `exclude: [\"@a/x\"]`) is rejected — use `exclude: { \"<type>\": [\"@a/x\"] }` instead.",
+      "properties": {
+        "skills": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-/*]+/[a-zA-Z0-9._\\-*]+$" }
+        },
+        "references": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-/*]+/[a-zA-Z0-9._\\-*]+$" }
+        },
+        "mcp": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-/*]+/[a-zA-Z0-9._\\-*]+$" }
+        },
+        "plugins": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-/*]+/[a-zA-Z0-9._\\-*]+$" }
+        },
+        "roots": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-/*]+/[a-zA-Z0-9._\\-*]+$" }
+        },
+        "hooks": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-/*]+/[a-zA-Z0-9._\\-*]+$" }
+        }
+      },
+      "additionalProperties": false
     },
     "skills": {
       "type": "array",

--- a/schemas/air.schema.json
+++ b/schemas/air.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/pulsemcp/air/main/schemas/air.schema.json",
   "title": "AIR Configuration",
-  "description": "Root configuration file for the AIR framework. Points to artifact catalogs and per-type index files. Every resolved artifact is canonically addressed as `@scope/id`: catalog providers supply scope (e.g. the GitHub provider returns `owner/repo`); local catalogs and per-type arrays use scope `local`. Composition is union-only — there is no override or field-level patching. Use the `exclude` array to drop specific qualified IDs from the resolved set.",
+  "description": "Root configuration file for the AIR framework. Points to artifact catalogs and per-type index files. Every resolved artifact is canonically addressed as `@scope/id`: catalog providers supply scope (e.g. the GitHub provider returns `owner/repo`); local catalogs and per-type arrays use scope `local`. Composition is union-only — there is no override or field-level patching. Use the `exclude` object (keyed by artifact type) to drop specific qualified IDs or wildcard patterns from the resolved set.",
   "type": "object",
   "properties": {
     "$schema": {
@@ -37,27 +37,27 @@
       "properties": {
         "skills": {
           "type": "array",
-          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-/*]+/[a-zA-Z0-9._\\-*]+$" }
+          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-*]+(?:/[a-zA-Z0-9._\\-*]+)+$" }
         },
         "references": {
           "type": "array",
-          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-/*]+/[a-zA-Z0-9._\\-*]+$" }
+          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-*]+(?:/[a-zA-Z0-9._\\-*]+)+$" }
         },
         "mcp": {
           "type": "array",
-          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-/*]+/[a-zA-Z0-9._\\-*]+$" }
+          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-*]+(?:/[a-zA-Z0-9._\\-*]+)+$" }
         },
         "plugins": {
           "type": "array",
-          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-/*]+/[a-zA-Z0-9._\\-*]+$" }
+          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-*]+(?:/[a-zA-Z0-9._\\-*]+)+$" }
         },
         "roots": {
           "type": "array",
-          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-/*]+/[a-zA-Z0-9._\\-*]+$" }
+          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-*]+(?:/[a-zA-Z0-9._\\-*]+)+$" }
         },
         "hooks": {
           "type": "array",
-          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-/*]+/[a-zA-Z0-9._\\-*]+$" }
+          "items": { "type": "string", "pattern": "^@[a-zA-Z0-9._\\-*]+(?:/[a-zA-Z0-9._\\-*]+)+$" }
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

- Replaces `air.json#exclude` flat-array shape with a per-type object: keys are artifact types (`skills`, `references`, `mcp`, `plugins`, `roots`, `hooks`); each value is a list of qualified-ID patterns. Excluding a skill named `github` no longer drops an MCP server with the same shortname.
- Adds `*` wildcard support inside each per-type list — `*` matches one full segment (`[^/]+`) and does not span `/` boundaries. Lets users drop whole groups like `@vendor/legacy/*` without enumerating every entry.
- Hard-rejects the legacy flat-array shape with a migration-friendly error: ``air.json "exclude" must be an object keyed by artifact type … Migration: replace exclude: ["@a/x"] with exclude: { "<type>": ["@a/x"] } …``.
- Per-type/per-pattern stale-entry warnings name both the type and the offending pattern so typos surface immediately.
- Schema (`schemas/air.schema.json`), all docs in `docs/guides/` and `docs/`, and the CHANGELOG are updated. `air-version-bump minor` brings every package and lockfile entry to **0.2.0**.

Resolves #118.

## Verification

All 811 tests pass under `npx vitest run` (`44 passed (44)` files), including the new tests added for this issue and all existing CLI/SDK e2e suites.

Beyond the test suite, I ran each acceptance criterion from #118 against the built `@pulsemcp/air-core` to confirm the behavior end-to-end:

```
=== AC1: per-type segmentation — exclude.skills['@local/github'] does NOT drop the mcp 'github' ===
  resolved skills: [ '@local/other' ]
  resolved mcp:    [ '@local/github', '@local/other' ]

=== AC2: legacy flat-array shape hard-fails with migration error ===
  ERROR: air.json "exclude" must be an object keyed by artifact type (skills, references, mcp, plugins, roots, hooks), not an array. Migration: replace exclude: ["@a/x"] with exclude: { "<type>": ["@a/x"] }, where <type> is the artifact kind "@a/x" was meant to drop.

=== AC3: wildcard '*' matches one full segment, no boundary spanning ===
  [PASS] /@vendor/legacy/*/.test(@vendor/legacy/x) → true
  [PASS] /@vendor/legacy/*/.test(@vendor/legacy/x/y) → false
  [PASS] /@vendor/legacy/*/.test(@other/legacy/x) → false
  [PASS] /@vendor/*/github/.test(@vendor/foo/github) → true
  [PASS] /@vendor/*/github/.test(@vendor/foo/bar/github) → false
  [PASS] /@*/agentic-engineering/*/.test(@a/agentic-engineering/x) → true
  [PASS] /@*/agentic-engineering/*/.test(@a/b/agentic-engineering/x) → false

=== AC4: wildcard '@local/*' drops every local skill ===
  resolved skills (expect 0): 0

=== AC5: stale exclude entries (exact + wildcard) warn naming type and pattern ===
  warnings:
    - air.json "exclude.skills" entry "@local/does-not-exist" did not match any resolved skills artifact. Remove it or check for typos.
    - air.json "exclude.skills" pattern "@vendor/missing/*" did not match any resolved skills artifact. Remove it or check for typos.

=== AC6: invalid artifact-type key in exclude hard-fails ===
  ERROR: air.json "exclude" key "not_a_real_type" is not a valid artifact type. Valid keys: skills, references, mcp, plugins, roots, hooks.

=== AC7: schema validation rejects legacy array & unknown keys, accepts new shape ===
  [PASS] object with exact + wildcards: valid=true
  [PASS] legacy flat-array form: valid=false
  [PASS] unknown artifact-type key: valid=false
```

Behavior matches every acceptance criterion in the issue.

## Test plan

- [x] `npx vitest run` — 811/811 pass (composition + validator suites cover both wildcard and exact-match paths, segmentation, stale warnings, the legacy-shape migration error, schema accepts/rejects)
- [x] Acceptance proofs above run against the built `@pulsemcp/air-core`
- [x] Examples in `examples/` revalidated by the existing "validates all example files from the repo" test

🤖 Generated with [Claude Code](https://claude.com/claude-code)