### PR TITLE
Fix air-version-bump skill: skip docs-only PRs

### DIFF
--- a/.claude/skills/air-version-bump/SKILL.md
+++ b/.claude/skills/air-version-bump/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: air-version-bump
-description: 'Bump versions in lockstep across the AIR monorepo when a PR ships new package contents to npm. TRIGGER when the PR changes publishable code under `packages/*/src/`, JSON schemas under `schemas/` or `packages/core/schemas/`, or shipped fields (dependencies, peerDependencies, bin, exports, main, files) in a `packages/*/package.json`. SKIP when the PR is scoped to non-published files only: `README.md`, `docs/`, `CHANGELOG.md`, `examples/`, `tests/` (root or `packages/*/test/`), `.github/`, `.claude/`, or root config files such as `tsconfig.base.json`, `vitest.workspace.ts`, `.gitignore`, root `package.json` — none of those ship to npm.'
+description: 'Bump versions in lockstep across the AIR monorepo when a PR ships new package contents to npm. TRIGGER when the PR changes publishable code under `packages/*/src/`, JSON schemas under `schemas/` or `packages/core/schemas/`, or shipped fields (dependencies, peerDependencies, bin, exports, main, files) in a `packages/*/package.json`. SKIP when the PR is scoped to non-published files only: `README.md`, `docs/`, `CHANGELOG.md`, `examples/`, `tests/` (root or `packages/*/tests/`), `.github/`, `.claude/`, or root config files such as `tsconfig.base.json`, `vitest.workspace.ts`, `.gitignore`, root `package.json` — none of those ship to npm.'
 user-invocable: true
 argument-hint: '[patch|minor|major]'
 ---
@@ -19,7 +19,7 @@ Versioning exists to publish new package contents to npm — `publish.yml` only 
 - `docs/` — user-facing documentation
 - `CHANGELOG.md` — written by this skill when a real bump happens; never the trigger
 - `examples/` — sample configs, not bundled in any package
-- `tests/` (repo-root) and `packages/*/test/` — never published; only `dist/` (and `schemas/` for core) ships
+- `tests/` (repo-root) and `packages/*/tests/` — never published; only `dist/` (and `schemas/` for core) ships
 - `.github/` — CI and workflow config
 - `.claude/` — Claude / AO session resources (generally gitignored)
 - Root config files: `tsconfig.base.json`, `vitest.workspace.ts`, `.gitignore`, root `package.json` (workspace metadata)

--- a/.claude/skills/air-version-bump/SKILL.md
+++ b/.claude/skills/air-version-bump/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: air-version-bump
+description: 'Bump versions in lockstep across the AIR monorepo when a PR ships new package contents to npm. TRIGGER when the PR changes publishable code under `packages/*/src/`, JSON schemas under `schemas/` or `packages/core/schemas/`, or shipped fields (dependencies, peerDependencies, bin, exports, main, files) in a `packages/*/package.json`. SKIP when the PR is scoped to non-published files only: `README.md`, `docs/`, `CHANGELOG.md`, `examples/`, `tests/` (root or `packages/*/test/`), `.github/`, `.claude/`, or root config files such as `tsconfig.base.json`, `vitest.workspace.ts`, `.gitignore`, root `package.json` — none of those ship to npm.'
+user-invocable: true
+argument-hint: '[patch|minor|major]'
+---
+
+# AIR Version Bump
+
+Bump type: $ARGUMENTS (default: patch)
+
+## When NOT to bump
+
+Versioning exists to publish new package contents to npm — `publish.yml` only publishes a package when its `version` does not already exist on the registry. Files that do not ship in any npm package have no functional reason to bump.
+
+**Skip this skill entirely** when the PR's diff is scoped to one or more of:
+
+- `README.md` and other repo-root markdown
+- `docs/` — user-facing documentation
+- `CHANGELOG.md` — written by this skill when a real bump happens; never the trigger
+- `examples/` — sample configs, not bundled in any package
+- `tests/` (repo-root) and `packages/*/test/` — never published; only `dist/` (and `schemas/` for core) ships
+- `.github/` — CI and workflow config
+- `.claude/` — Claude / AO session resources (generally gitignored)
+- Root config files: `tsconfig.base.json`, `vitest.workspace.ts`, `.gitignore`, root `package.json` (workspace metadata)
+- Asset files referenced only by docs (e.g., `assets/` containing screenshots or videos)
+
+If the PR only touches files in those categories, do NOT bump versions, do NOT edit any `packages/*/package.json`, do NOT add a `CHANGELOG.md` entry, and do NOT regenerate the lockfile. Open the PR without invoking this skill.
+
+A mixed PR that touches both publishable and non-publishable files DOES need a bump — the trigger is whether any publishable file changed, not the proportion.
+
+## What to bump
+
+AIR is an npm workspaces monorepo where all packages are versioned in lockstep. A complete version bump must touch every category below:
+
+1. **Every `package.json` in `packages/`** — update the `version` field in each one to the new version.
+
+2. **Internal dependency references** — packages depend on each other (e.g., sdk depends on core, cli depends on sdk). Search each `package.json` for `dependencies` entries that reference other `@pulsemcp/air-*` packages and update those version strings to match.
+
+3. **Hardcoded version strings in source code** — the CLI entry point has a hardcoded `.version()` call that must match. Grep the source for the old version string to find it and any others that may have been added.
+
+4. **`CHANGELOG.md`** — add a new entry at the top of the changelog (below the header) for the new version. The file lives at the repo root and follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
+
+   ```markdown
+   ## [x.y.z] - YYYY-MM-DD
+
+   ### Added
+   - Description of new features or capabilities
+
+   ### Fixed
+   - Description of bug fixes
+
+   ### Changed
+   - Description of changes to existing functionality
+   ```
+
+   Categorize the PR's changes under the appropriate subsections (`Added`, `Fixed`, `Changed`, `Removed`, etc.). Only include subsections that apply. Use today's date in `YYYY-MM-DD` format.
+
+5. **The lockfile** — run `npm install` after all edits to regenerate `package-lock.json`.
+
+## Verification
+
+After making all changes, verify nothing was missed:
+
+- Check that every `package.json` under `packages/` shows the same `version` value
+- Check that every internal `@pulsemcp/air-*` dependency reference matches the new version
+- Check that `CHANGELOG.md` has a new entry for the bumped version with today's date
+- Grep the entire repo for the old version string — there should be zero hits outside of `node_modules/` and `package-lock.json`
+
+## Build and test
+
+```bash
+npm run build -w packages/core   # core must build first (others depend on it)
+npm run build                     # build remaining packages
+npx vitest run                    # run all tests
+```
+
+## Publishing
+
+Publishing is automatic. The `publish.yml` workflow runs on every push to `main` and publishes any package whose version doesn't already exist on npm. Packages are published in dependency order.
+
+## Key things to watch for
+
+- `CHANGELOG.md` must be updated with every version bump — it's easy to forget since it's not a `package.json` or source file
+- The CLI has a hardcoded `.version()` call in its entry point that is easy to forget since it's not in a `package.json`
+- Internal dependency references (e.g., sdk's dependency on `@pulsemcp/air-core`) must match — updating just the `version` field without updating cross-references breaks installs
+- Always run `npm install` to update the lockfile, otherwise CI will fail
+- When opening a PR that includes a version bump, include the new version number in the PR title (e.g., "Fix init roots generation (v0.0.17)") — this helps reviewers and the git log immediately see which version a PR targets


### PR DESCRIPTION
## Summary

The `air-version-bump` skill description said "MANDATORY for any PR that includes meaningful changes" with "No exceptions", which pulled the skill into action on README/docs-only PRs. Two recent examples:

- PR #123 — README pitch + demo videos → bumped 0.2.0 → 0.2.1
- Commit 1d5477f — README inline-video tweak → bumped 0.2.1 → 0.2.2

Both touched only `README.md` / `assets/` / `CHANGELOG.md` and didn't ship anything to npm. The bumps were unnecessary churn — `publish.yml` only publishes when a package's `version` doesn't already exist on the registry, so files outside published `dist/` bundles have no reason to drive a version change.

This PR rewrites the skill's frontmatter `description` so the trigger is unambiguously about publishable code, drops the "MANDATORY / no exceptions" phrasing, and adds a "When NOT to bump" body section near the top so the carve-out is visible before the procedure. The actual bump procedure is unchanged — it's correct for cases that do need a bump.

Note: this skill file was not previously tracked in git (`.claude/` is gitignored). It is committed here with `git add -f` because the AO docs say "if a skill already exists in the repo at the same path, the repo version takes priority" — so committing the file is the documented way to override the centralized catalog version for this repo.

## Frontmatter `description` — before / after

**Before:**

```yaml
description: 'MANDATORY for any PR that includes meaningful changes. Before opening or finalizing a PR, you MUST invoke this skill to bump the version. This ensures all packages, internal dependency references, and hardcoded version strings stay in lockstep. No exceptions — every publishable change needs a version bump.'
```

**After:**

```yaml
description: 'Bump versions in lockstep across the AIR monorepo when a PR ships new package contents to npm. TRIGGER when the PR changes publishable code under `packages/*/src/`, JSON schemas under `schemas/` or `packages/core/schemas/`, or shipped fields (dependencies, peerDependencies, bin, exports, main, files) in a `packages/*/package.json`. SKIP when the PR is scoped to non-published files only: `README.md`, `docs/`, `CHANGELOG.md`, `examples/`, `tests/` (root or `packages/*/tests/`), `.github/`, `.claude/`, or root config files such as `tsconfig.base.json`, `vitest.workspace.ts`, `.gitignore`, root `package.json` — none of those ship to npm.'
```

The "MANDATORY... no exceptions" phrasing is gone. The TRIGGER and SKIP keywords give the model an explicit decision rule.

## New "When NOT to bump" body section

Inserted between the title and the existing `## What to bump` section, so a reader sees the carve-out before the procedure:

```markdown
## When NOT to bump

Versioning exists to publish new package contents to npm — `publish.yml` only publishes a package when its `version` does not already exist on the registry. Files that do not ship in any npm package have no functional reason to bump.

**Skip this skill entirely** when the PR's diff is scoped to one or more of:

- `README.md` and other repo-root markdown
- `docs/` — user-facing documentation
- `CHANGELOG.md` — written by this skill when a real bump happens; never the trigger
- `examples/` — sample configs, not bundled in any package
- `tests/` (repo-root) and `packages/*/tests/` — never published; only `dist/` (and `schemas/` for core) ships
- `.github/` — CI and workflow config
- `.claude/` — Claude / AO session resources (generally gitignored)
- Root config files: `tsconfig.base.json`, `vitest.workspace.ts`, `.gitignore`, root `package.json` (workspace metadata)
- Asset files referenced only by docs (e.g., `assets/` containing screenshots or videos)

If the PR only touches files in those categories, do NOT bump versions, do NOT edit any `packages/*/package.json`, do NOT add a `CHANGELOG.md` entry, and do NOT regenerate the lockfile. Open the PR without invoking this skill.

A mixed PR that touches both publishable and non-publishable files DOES need a bump — the trigger is whether any publishable file changed, not the proportion.
```

## Verification

- [x] **Frontmatter `description` rewrite** — diff above; "MANDATORY"/"No exceptions" phrasing removed and replaced with explicit TRIGGER/SKIP rule.
- [x] **New "When NOT to bump" body section** — content above; placed before the `## What to bump` procedure so the carve-out is visible first.
- [x] **Diff scope** — `git diff main --stat` shows only the single skill file changed:

  ```
   .claude/skills/air-version-bump/SKILL.md | 88 ++++++++++++++++++++++++++++++++
   1 file changed, 88 insertions(+)
  ```

  No `package.json`, no `CHANGELOG.md`, no `package-lock.json`, no source files. The very rule this PR adds was applied to itself.
- [x] **Self-applied dogfood** — this PR is a `.claude/`-only change, so per the new rule no version bump was performed. (The previous "MANDATORY... no exceptions" wording would have demanded one — the fact that we skipped it here is exactly the bug being fixed.)
- [x] **CI green** — all 5 checks pass on commit `0b0ac6f`:
  - `e2e` — pass (54s)
  - `test (18)` — pass (1m34s)
  - `test (20)` — pass (1m35s)
  - `test (22)` — pass (1m28s)
  - `validate-schemas` — pass (29s)
- [x] **Subagent fresh-eyes review** — completed; one warning addressed in commit `0b0ac6f`. The reviewer caught that the per-package test directory was written as `packages/*/test/` (singular) but the repo actually uses `packages/*/tests/` (plural — see `packages/{core,sdk,cli}/tests/`). A literal LLM matcher could have missed the carve-out for that path. Both occurrences (frontmatter description and body bullet) were corrected. All other findings were nit-level or LGTM. Specifically validated:
  - TRIGGER list correctly omits `scripts` (doesn't ship at runtime) and includes `dependencies/peerDependencies/bin/exports/main/files` (do ship).
  - SKIP list cross-checked against actual `files` field in every `packages/*/package.json` — they all ship `dist/` only (core also ships `schemas/`), so the "non-published" categories listed are accurate.
  - "When NOT to bump" placed before "What to bump" is the right order — readers see the gating decision before the procedure.
  - Mixed-PR clause ("the trigger is whether any publishable file changed, not the proportion") is unambiguous.

## How this fix is effective

The skill description is what the model uses to decide whether to invoke a skill. Concrete TRIGGER/SKIP rules (with file-path globs) tied to a clear "ships to npm" mental model give a much better signal than a blanket "MANDATORY". The body section provides a second checkpoint if the description does pull the skill in for a borderline case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)