### PR TITLE
feat: hooks x-config overlay + github:// path scheme (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-14
+
+### Added
+- **`x-config` overlay on hook index entries.** `hooks.json` entries can now carry an optional `x-config` object that AIR deep-merges into the materialized `HOOK.json`'s own `x-config` at resolve time. Consumer values win on conflicts; objects merge recursively, arrays replace wholesale, and scalars replace. The merged value flows through `air resolve --json`, gets written into the materialized `HOOK.json` during `air prepare` / `air start`, and runs through the existing transform pipeline (so `${VAR}` interpolation via `@pulsemcp/air-secrets-env` / `-secrets-file` works inside `x-config` values too). The shape is intentionally permissive (`additionalProperties: true` in the schema) — hook authors define and document their own `x-config` schema. New core export `mergeXConfig(base, overlay)` for consumers who want the same deep-merge semantics. Resolves [#127](https://github.com/pulsemcp/air/issues/127).
+- **`github://` scheme on the hook `path` field.** A `hooks.json` entry's `path` can now point at a remote hook directory living in another GitHub repo, e.g. `"path": "github://acme/air-org@v1.2.0/hooks/notify-session-start"`. The same `@pulsemcp/air-provider-github` extension that resolves `catalogs` and per-type index URIs handles this lookup; the same `AIR_GITHUB_TOKEN` and `gitProtocol` settings apply. Refs that look like a 40-character SHA are treated as immutable and content-addressed in the cache (`~/.air/cache/github/{owner}/{repo}/{ref}/`); branch and tag refs are mutable and refresh on `air update`. Path-style URIs work for every artifact type with a `path` field, not only hooks (skills can use this too). Resolves [#127](https://github.com/pulsemcp/air/issues/127).
+
+### Changed
+- **`@pulsemcp/air-provider-github` now supports SHA-pinned refs.** Previously, the provider always shelled out to `git clone --depth 1 --branch <ref>`, which fails for full 40-character SHAs (Git refuses `--branch <SHA>`). The provider now detects immutable refs and switches to `git init` + `git remote add origin` + `git fetch --depth 1 origin <sha>` + `git checkout FETCH_HEAD`, which works for any ref shape that the remote will resolve. Branch and tag refs continue to use the existing `git clone --branch` path.
+
 ## [0.3.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ Hooks are shell commands that fire at agent lifecycle events. Use them for notif
 }
 ```
 
+A hook entry can also point its `path` at a remote directory (e.g. `"path": "github://acme/air-org@v1.2.0/hooks/notify-session-start"`) and carry an `x-config` overlay that AIR deep-merges into the materialized `HOOK.json`'s `x-config` at resolve time — so consumers can override defaults without forking the hook. See the [hooks guide](docs/guides/hooks.md) for details.
+
 ## Scope
 
 AIR is a **single-session configuration layer** — it resolves, validates, and translates agent configs for one session at a time. It is not an orchestration platform.

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -52,8 +52,9 @@ Add entries to `~/.air/hooks/hooks.json`:
 | `id` | Yes | Unique identifier. Must match the key. |
 | `description` | Yes | What this hook does. Max 500 characters. |
 | `title` | No | Human-readable name. Max 100 characters. |
-| `path` | Yes | Relative path to the hook directory containing `HOOK.json`. |
+| `path` | Yes | Path to the hook directory containing `HOOK.json`. Either a relative path inside the same catalog, or a remote URI handled by an installed catalog provider (e.g. `github://owner/repo[@ref]/path/to/hook-dir`). |
 | `references` | No | IDs of reference documents this hook depends on. |
+| `x-config` | No | Consumer-supplied config overlay that AIR deep-merges into the materialized `HOOK.json`'s `x-config` at resolve time. See [Consumer config overlay (`x-config`)](#consumer-config-overlay-x-config). |
 
 ### Step 2: Create the hook directory with HOOK.json
 
@@ -80,6 +81,104 @@ Each hook directory contains a `HOOK.json` file with the runtime definition, plu
 | `env` | No | Environment variables for the hook process. Values support `${VAR}` interpolation. |
 | `timeout_seconds` | No | Maximum execution time before the hook is killed (minimum: 1). |
 | `matcher` | No | Regex pattern — hook only fires when matched against event data. |
+| `x-config` | No | Hook-defined configuration block. Consumers can layer overrides via `x-config` in the index entry; AIR deep-merges them at resolve time. See [Consumer config overlay (`x-config`)](#consumer-config-overlay-x-config). |
+
+## Consumer config overlay (`x-config`)
+
+Hook authors can publish defaults inside `HOOK.json`, and consumers can override those defaults from their own `hooks.json` index entry — without forking the hook directory. AIR deep-merges the two `x-config` blocks at `air resolve` (and at `air prepare` / `air start`) time.
+
+The shape of `x-config` is intentionally permissive: AIR does not validate the inner keys. Each hook author defines and documents their own schema. AIR treats it as an opaque blob that flows through resolution and materialization.
+
+### Merge rules
+
+- **Objects** merge recursively (consumer wins on key conflicts).
+- **Arrays** are replaced wholesale — consumer arrays do not concatenate with source arrays.
+- **Scalars** (strings, numbers, booleans, `null`) are replaced.
+- **Missing on either side** — whichever side is present wins. If neither side has `x-config`, the field is omitted from the output.
+
+### Example
+
+Hook author publishes `hooks/notify-session-start/HOOK.json`:
+
+```json
+{
+  "event": "session_start",
+  "command": "./notify.sh",
+  "x-config": {
+    "channel": "#general",
+    "tags": ["info", "default"],
+    "thresholds": { "warn_minutes": 30 }
+  }
+}
+```
+
+Consumer overlays in their own `hooks.json`:
+
+```json
+{
+  "notify-session-start": {
+    "description": "Slack notify on session start",
+    "path": "github://acme/air-org@v1.2.0/hooks/notify-session-start",
+    "x-config": {
+      "channel": "#agent-events",
+      "tags": ["consumer-a"],
+      "thresholds": { "warn_minutes": 5 }
+    }
+  }
+}
+```
+
+Resolved (and materialized to `.claude/hooks/notify-session-start/HOOK.json`):
+
+```json
+{
+  "event": "session_start",
+  "command": "./notify.sh",
+  "x-config": {
+    "channel": "#agent-events",
+    "tags": ["consumer-a"],
+    "thresholds": { "warn_minutes": 5 }
+  }
+}
+```
+
+### Interpolation
+
+`${VAR}` references inside `x-config` values are resolved by the same secrets transforms that handle the rest of the config (e.g. `@pulsemcp/air-secrets-env`, `@pulsemcp/air-secrets-file`). This means consumers can reference environment variables or secret-file values without the hook author needing to wire anything special:
+
+```json
+{
+  "notify-session-start": {
+    "description": "Slack notify on session start",
+    "path": "hooks/notify-session-start",
+    "x-config": {
+      "credentials": { "token": "${SLACK_BOT_TOKEN}" }
+    }
+  }
+}
+```
+
+### Where the merged value shows up
+
+- `air resolve --json` — the merged `x-config` appears under the resolved hook entry.
+- `air prepare --target <dir>` and `air start` — the merged `x-config` is written into the materialized `HOOK.json` inside the agent's working directory (e.g. `.claude/hooks/{id}/HOOK.json`), then run through the transform pipeline (which resolves `${VAR}` interpolation).
+
+## Remote hook directories (`github://`)
+
+The `path` field accepts catalog provider URIs in addition to relative paths. With `@pulsemcp/air-provider-github` installed, a hook directory can live in a separate GitHub repo:
+
+```json
+{
+  "remote-hook": {
+    "description": "Hook from a shared catalog",
+    "path": "github://acme/air-org@v1.2.0/hooks/notify-session-start"
+  }
+}
+```
+
+The provider shallow-clones the referenced ref into `~/.air/cache/github/{owner}/{repo}/{ref}/` and AIR reads the hook directory from there, just like a local path. Refs that look like a 40-character SHA are treated as immutable and content-addressed (the cache directory will not be re-fetched). Branch names and tags are mutable from AIR's point of view and are refreshed on `air update`.
+
+The same `AIR_GITHUB_TOKEN` and `gitProtocol` settings used for `catalogs` apply to `path` URIs — the provider is reused, not re-instantiated.
 
 ## Lifecycle events
 
@@ -193,7 +292,7 @@ Without a root, all hooks are available.
 
 ## Secret resolution in hooks
 
-Hook fields (`command`, `args`, `env`) support `${VAR}` interpolation, and these patterns are resolved by the same secrets transforms that handle MCP server configs. During `air prepare`, the transform pipeline processes all config files returned by the adapter — including `.mcp.json`, `.claude/settings.json`, and all injected `HOOK.json` files:
+Hook fields (`command`, `args`, `env`, and any `x-config` values) support `${VAR}` interpolation, and these patterns are resolved by the same secrets transforms that handle MCP server configs. During `air prepare`, the transform pipeline processes all config files returned by the adapter — including `.mcp.json`, `.claude/settings.json`, and all injected `HOOK.json` files:
 
 - **`@pulsemcp/air-secrets-env`** resolves `${VAR}` and `${VAR:-default}` from process environment variables
 - **`@pulsemcp/air-secrets-file`** resolves `${VAR}` from a JSON secrets file (via `--secrets-file`)

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -176,7 +176,7 @@ The `path` field accepts catalog provider URIs in addition to relative paths. Wi
 }
 ```
 
-The provider shallow-clones the referenced ref into `~/.air/cache/github/{owner}/{repo}/{ref}/` and AIR reads the hook directory from there, just like a local path. Refs that look like a 40-character SHA are treated as immutable and content-addressed (the cache directory will not be re-fetched). Branch names and tags are mutable from AIR's point of view and are refreshed on `air update`.
+The provider shallow-clones the referenced ref into `~/.air/cache/github/{owner}/{repo}/{ref}/` (where `{ref}` is the literal ref string — the branch name, tag name, or full 40-character SHA) and AIR reads the hook directory from there, just like a local path. Refs that look like a 40-character SHA are treated as immutable and content-addressed (the cache directory will not be re-fetched). Branch names and tags are mutable from AIR's point of view and are refreshed on `air update`. Note that AIR does not deduplicate a SHA-pinned ref against a branch that resolves to the same commit — they live in separate cache directories.
 
 The same `AIR_GITHUB_TOKEN` and `gitProtocol` settings used for `catalogs` apply to `path` URIs — the provider is reused, not re-instantiated.
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -45,8 +45,9 @@ Hooks are registered in `hooks.json`:
 |-------|----------|-------------|
 | `title` | No | Human-readable display name. |
 | `description` | Yes | What this hook does. |
-| `path` | Yes | Relative path to the hook directory containing `HOOK.json`. |
+| `path` | Yes | Path to the hook directory containing `HOOK.json`. Either a relative path inside the catalog, or a remote URI handled by an installed catalog provider (e.g. `github://owner/repo[@ref]/path/to/hook-dir`). |
 | `references` | No | IDs of reference documents this hook depends on. |
+| `x-config` | No | Consumer-supplied configuration overlay; deep-merged into the materialized `HOOK.json`'s `x-config` at resolve time (consumer wins on conflicts). Values support `${VAR}` interpolation. See the [hooks guide](guides/hooks.md#consumer-config-overlay-x-config) for details. |
 
 ## Hook Directory
 
@@ -86,6 +87,7 @@ The `HOOK.json` file defines how the hook executes:
 | `env` | No | Environment variables. Values support `${VAR}` interpolation. |
 | `timeout_seconds` | No | Maximum execution time before the hook is killed. |
 | `matcher` | No | Regex pattern to filter events. Hook only fires when matched. |
+| `x-config` | No | Hook-defined configuration block. Consumers can layer overrides via `x-config` in the index entry; AIR deep-merges them at resolve time. See the [hooks guide](guides/hooks.md#consumer-config-overlay-x-config). |
 
 ## Lifecycle Events
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "air-main-1777411108-5e3ed683",
+  "name": "air",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "air",
       "workspaces": [
         "packages/core",
         "packages/sdk",
@@ -891,9 +892,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.3.0",
+        "@pulsemcp/air-sdk": "0.4.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -912,7 +913,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -929,9 +930,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.3.0"
+        "@pulsemcp/air-core": "0.4.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -944,9 +945,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.3.0"
+        "@pulsemcp/air-core": "0.4.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -959,9 +960,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.3.0",
+        "@pulsemcp/air-core": "0.4.0",
         "proper-lockfile": "^4.1.2"
       },
       "devDependencies": {
@@ -976,9 +977,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.3.0"
+        "@pulsemcp/air-core": "0.4.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -991,9 +992,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.3.0"
+        "@pulsemcp/air-core": "0.4.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1006,9 +1007,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.3.0"
+        "@pulsemcp/air-core": "0.4.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.3.0",
+    "@pulsemcp/air-sdk": "0.4.0",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -128,7 +128,8 @@ interface ArtifactContribution<T> {
 async function loadContributions<T>(
   paths: { path: string; scope: string }[],
   baseDir: string,
-  providers: CatalogProvider[]
+  providers: CatalogProvider[],
+  artifactType: string
 ): Promise<ArtifactContribution<T>[]> {
   const contributions: ArtifactContribution<T>[] = [];
 
@@ -159,7 +160,7 @@ async function loadContributions<T>(
       entries,
       sourceDir,
       providers,
-      "artifact"
+      artifactType
     );
     contributions.push({ scope, source: p, entries: resolved });
   }
@@ -1094,7 +1095,7 @@ export async function resolveArtifacts(
 
   async function load<T>(type: ArtifactType): Promise<Record<string, T>> {
     const paths = pathsFor(type);
-    const contributions = await loadContributions<T>(paths, baseDir, providers);
+    const contributions = await loadContributions<T>(paths, baseDir, providers, type);
     const { merged, sources } = mergeContributions<T>(contributions, type);
     sourcesByType[type] = sources;
     return merged;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -56,20 +56,51 @@ function getScheme(path: string): string | null {
 }
 
 /**
- * Resolve relative `path` fields in artifact entries to absolute paths.
- * sourceDir is the directory containing the index file (local or remote clone).
+ * Resolve `path` fields in artifact entries to absolute local paths.
+ *
+ * Three cases:
+ *   1. Absolute filesystem path — left as-is.
+ *   2. Provider URI (e.g. `github://owner/repo[@ref]/dir`) — delegated to a
+ *      registered provider's `resolveCatalogDir`, which fetches the source
+ *      to a local cache and returns the directory within it. The same
+ *      provider used for catalog roots is reused, so authentication, SHA
+ *      caching, and refresh semantics are unchanged.
+ *   3. Relative path — joined against `sourceDir` (the index file's
+ *      directory, local or in a provider's local cache).
  */
-function resolveEntryPaths<T>(
+async function resolveEntryPaths<T>(
   entries: Record<string, T>,
-  sourceDir: string
-): Record<string, T> {
+  sourceDir: string,
+  providers: CatalogProvider[],
+  artifactType: string
+): Promise<Record<string, T>> {
   const resolved: Record<string, T> = {};
   for (const [key, entry] of Object.entries(entries)) {
     const e = entry as Record<string, unknown>;
     const updated = { ...e };
 
-    if (typeof e.path === "string" && !e.path.startsWith("/")) {
-      updated.path = resolve(sourceDir, e.path as string);
+    if (typeof e.path === "string") {
+      const scheme = getScheme(e.path);
+      if (scheme) {
+        const provider = providers.find((prov) => prov.scheme === scheme);
+        if (!provider) {
+          throw new Error(
+            `No catalog provider registered for scheme "${scheme}://" ` +
+              `referenced by ${artifactType} "${key}" path "${e.path}". ` +
+              `Install an extension that handles this scheme.`
+          );
+        }
+        if (!provider.resolveCatalogDir) {
+          throw new Error(
+            `Provider for "${scheme}://" cannot resolve directory paths — ` +
+              `it lacks resolveCatalogDir(). Upgrade the provider extension ` +
+              `or replace the URI with a vendored relative path.`
+          );
+        }
+        updated.path = await provider.resolveCatalogDir(e.path);
+      } else if (!e.path.startsWith("/")) {
+        updated.path = resolve(sourceDir, e.path as string);
+      }
     }
     resolved[key] = updated as T;
   }
@@ -124,7 +155,12 @@ async function loadContributions<T>(
     }
 
     const entries = stripSchema(data) as Record<string, T>;
-    const resolved = resolveEntryPaths(entries, sourceDir);
+    const resolved = await resolveEntryPaths(
+      entries,
+      sourceDir,
+      providers,
+      "artifact"
+    );
     contributions.push({ scope, source: p, entries: resolved });
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,9 @@ export type { QualifiedId, ReferenceResolution } from "./scope.js";
 export { stripScopes, ShortnameCollisionError } from "./strip-scopes.js";
 export type { ShortnameCollision } from "./strip-scopes.js";
 
+// x-config deep-merge (used by hook materialization)
+export { mergeXConfig } from "./x-config.js";
+
 // Validation
 export { validateJson } from "./validator.js";
 export type { ValidationResult, ValidationError } from "./validator.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -158,10 +158,27 @@ export interface RootEntry {
 export interface HookEntry {
   title?: string;
   description: string;
-  /** Relative path to the hook directory containing HOOK.json and associated scripts. */
+  /**
+   * Path to the hook directory containing HOOK.json and associated scripts.
+   * Either an absolute filesystem path, or — at index-authoring time — a
+   * relative path within the same catalog or a provider URI (e.g.
+   * `github://owner/repo[@ref]/path`). `resolveArtifacts` converts both forms
+   * to absolute local paths in the returned `ResolvedArtifacts`.
+   */
   path: string;
   /** IDs of reference documents this hook depends on. */
   references?: string[];
+  /**
+   * Consumer-supplied configuration overrides that get deep-merged into the
+   * materialized HOOK.json's `x-config` at resolve time. Objects merge
+   * recursively (consumer wins on conflict), arrays replace, scalars replace.
+   * AIR does not validate the shape — hook-specific validation is the hook
+   * author's responsibility.
+   *
+   * The TypeScript field name is intentionally quoted to match the JSON
+   * Schema property name (`x-config`).
+   */
+  "x-config"?: Record<string, unknown>;
 }
 
 // ============================================================

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -346,6 +346,15 @@ export interface PreparedSession {
   skillPaths: string[];
   /** Paths to hook directories created */
   hookPaths: string[];
+  /**
+   * Optional: short-id → qualified-id mapping for the hooks the adapter
+   * activated. When present, lets the SDK look up the exact resolved hook
+   * entry that was materialized at the corresponding `hookPaths` directory.
+   * Required to disambiguate cross-scope shortname collisions in the
+   * resolved set; when absent, the SDK falls back to a short-id lookup that
+   * picks the first match.
+   */
+  hookActivations?: Array<{ short: string; qualified: string }>;
   /** The command to start the agent in the prepared directory */
   startCommand: StartCommand;
   /**

--- a/packages/core/src/x-config.ts
+++ b/packages/core/src/x-config.ts
@@ -1,0 +1,38 @@
+/**
+ * Deep-merge a consumer's `x-config` overlay onto a base value pulled from
+ * the materialized HOOK.json. Pure function — no I/O, no env interpolation.
+ *
+ * Merge rules:
+ *   - Two plain objects merge recursively, overlay wins on per-key conflict.
+ *   - Arrays in the overlay replace the base array entirely (no concat).
+ *   - Scalars and mismatched-shape values in the overlay replace the base.
+ *   - `undefined` overlay returns the base unchanged; `undefined` base returns
+ *     the overlay unchanged. Either side may be absent.
+ *
+ * Returns a new value — neither input is mutated.
+ */
+export function mergeXConfig(base: unknown, overlay: unknown): unknown {
+  if (overlay === undefined) return base;
+  if (base === undefined) return overlay;
+
+  if (!isPlainObject(base) || !isPlainObject(overlay)) {
+    // Arrays, scalars, nulls, or shape mismatches: overlay replaces wholesale.
+    return overlay;
+  }
+
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(overlay)) {
+    result[key] = mergeXConfig(result[key], value);
+  }
+  return result;
+}
+
+/**
+ * True for non-array, non-null plain object values. Arrays and nulls are
+ * intentionally excluded — they are leaf values for merge purposes.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" && value !== null && !Array.isArray(value)
+  );
+}

--- a/packages/core/tests/provider-uri-paths.test.ts
+++ b/packages/core/tests/provider-uri-paths.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { join } from "path";
+import { resolveArtifacts } from "../src/config.js";
+import type { CatalogProvider } from "../src/types.js";
+import { createTempAirDir, exampleHook, exampleSkill } from "./helpers.js";
+
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
+
+describe("provider URI in artifact `path` fields", () => {
+  it("resolves a github:// hook path via the registered provider", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        hooks: ["./hooks.json"],
+      },
+      "hooks.json": {
+        "remote-hook": {
+          description: "remote hook",
+          path: "github://acme/things@v1.2.0/hooks/remote-hook",
+        },
+      },
+      // Pretend the hook directory was already cloned at this location
+      "fake-clone/hooks/remote-hook/HOOK.json": JSON.stringify({
+        event: "Stop",
+      }),
+    });
+    cleanup = c;
+
+    const calls: string[] = [];
+    const provider: CatalogProvider = {
+      scheme: "github",
+      async resolveCatalogDir(uri: string): Promise<string> {
+        calls.push(uri);
+        return join(dir, "fake-clone/hooks/remote-hook");
+      },
+      async resolve(): Promise<Record<string, unknown>> {
+        throw new Error("resolve() should not be called for path resolution");
+      },
+    };
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      providers: [provider],
+    });
+
+    expect(calls).toEqual(["github://acme/things@v1.2.0/hooks/remote-hook"]);
+    expect(artifacts.hooks["@local/remote-hook"].path).toBe(
+      join(dir, "fake-clone/hooks/remote-hook")
+    );
+  });
+
+  it("resolves a github:// skill path via the registered provider", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+      },
+      "skills.json": {
+        "remote-skill": {
+          description: "remote skill",
+          path: "github://acme/things/skills/remote-skill",
+        },
+      },
+      "remote-skill/SKILL.md": "remote",
+    });
+    cleanup = c;
+
+    const provider: CatalogProvider = {
+      scheme: "github",
+      async resolveCatalogDir(): Promise<string> {
+        return join(dir, "remote-skill");
+      },
+      async resolve(): Promise<Record<string, unknown>> {
+        throw new Error("resolve() should not be called for path resolution");
+      },
+    };
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      providers: [provider],
+    });
+
+    expect(artifacts.skills["@local/remote-skill"].path).toBe(
+      join(dir, "remote-skill")
+    );
+  });
+
+  it("delegates one provider call per github:// ref/path combination", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        hooks: ["./hooks.json"],
+      },
+      "hooks.json": {
+        "hook-main": {
+          description: "main hook",
+          path: "github://acme/things@main/hooks/main",
+        },
+        "hook-v1": {
+          description: "v1 hook",
+          path: "github://acme/things@v1.0.0/hooks/v1",
+        },
+        "hook-sha": {
+          description: "sha-pinned hook",
+          path: "github://acme/things@abc123def456abc123def456abc123def456abcd/hooks/pinned",
+        },
+      },
+    });
+    cleanup = c;
+
+    const calls: string[] = [];
+    const provider: CatalogProvider = {
+      scheme: "github",
+      async resolveCatalogDir(uri: string): Promise<string> {
+        calls.push(uri);
+        return join(dir, "fake-clone");
+      },
+      async resolve(): Promise<Record<string, unknown>> {
+        return {};
+      },
+    };
+
+    await resolveArtifacts(join(dir, "air.json"), { providers: [provider] });
+
+    expect(calls).toEqual([
+      "github://acme/things@main/hooks/main",
+      "github://acme/things@v1.0.0/hooks/v1",
+      "github://acme/things@abc123def456abc123def456abc123def456abcd/hooks/pinned",
+    ]);
+  });
+
+  it("throws a clear error when github:// path has no registered provider", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": { name: "test", hooks: ["./hooks.json"] },
+      "hooks.json": {
+        "remote-hook": {
+          description: "remote hook",
+          path: "github://acme/things@v1.0.0/hooks/x",
+        },
+      },
+    });
+    cleanup = c;
+
+    await expect(resolveArtifacts(join(dir, "air.json"))).rejects.toThrow(
+      /No catalog provider registered for scheme "github:\/\/"/
+    );
+  });
+
+  it("relative path falls through to filesystem resolution unchanged", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": { name: "test", hooks: ["./hooks.json"] },
+      "hooks.json": {
+        "local-hook": exampleHook("local-hook"),
+      },
+      "hooks/local-hook/HOOK.json": JSON.stringify({ event: "Stop" }),
+    });
+    cleanup = c;
+
+    const calls: string[] = [];
+    const provider: CatalogProvider = {
+      scheme: "github",
+      async resolveCatalogDir(uri: string): Promise<string> {
+        calls.push(uri);
+        return "/should/not/be/used";
+      },
+      async resolve(): Promise<Record<string, unknown>> {
+        return {};
+      },
+    };
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      providers: [provider],
+    });
+
+    expect(calls).toEqual([]);
+    expect(artifacts.hooks["@local/local-hook"].path).toBe(
+      join(dir, "hooks/local-hook")
+    );
+  });
+
+  it("absolute path is left as-is and provider is not called", async () => {
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": { name: "test", skills: ["./skills.json"] },
+      "skills.json": {
+        deploy: exampleSkill("deploy", { path: "/absolute/skills/deploy" }),
+      },
+    });
+    cleanup = c;
+
+    const calls: string[] = [];
+    const provider: CatalogProvider = {
+      scheme: "github",
+      async resolveCatalogDir(uri: string): Promise<string> {
+        calls.push(uri);
+        return "/should/not/be/used";
+      },
+      async resolve(): Promise<Record<string, unknown>> {
+        return {};
+      },
+    };
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      providers: [provider],
+    });
+
+    expect(calls).toEqual([]);
+    expect(artifacts.skills["@local/deploy"].path).toBe(
+      "/absolute/skills/deploy"
+    );
+  });
+});

--- a/packages/core/tests/x-config.test.ts
+++ b/packages/core/tests/x-config.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { mergeXConfig } from "../src/x-config.js";
+
+describe("mergeXConfig", () => {
+  describe("absent inputs", () => {
+    it("returns base when overlay is undefined", () => {
+      expect(mergeXConfig({ a: 1 }, undefined)).toEqual({ a: 1 });
+    });
+
+    it("returns overlay when base is undefined", () => {
+      expect(mergeXConfig(undefined, { a: 1 })).toEqual({ a: 1 });
+    });
+
+    it("returns undefined when both are undefined", () => {
+      expect(mergeXConfig(undefined, undefined)).toBeUndefined();
+    });
+  });
+
+  describe("scalar replacement", () => {
+    it("overlay scalar replaces base scalar", () => {
+      expect(mergeXConfig("foo", "bar")).toBe("bar");
+      expect(mergeXConfig(1, 2)).toBe(2);
+      expect(mergeXConfig(true, false)).toBe(false);
+    });
+
+    it("overlay scalar replaces base object", () => {
+      expect(mergeXConfig({ a: 1 }, "bar")).toBe("bar");
+    });
+
+    it("overlay object replaces base scalar", () => {
+      expect(mergeXConfig("foo", { a: 1 })).toEqual({ a: 1 });
+    });
+
+    it("overlay null replaces base value", () => {
+      expect(mergeXConfig({ a: 1 }, null)).toBeNull();
+    });
+  });
+
+  describe("array replacement", () => {
+    it("overlay array replaces base array entirely (no concat)", () => {
+      expect(mergeXConfig([1, 2, 3], [4, 5])).toEqual([4, 5]);
+    });
+
+    it("overlay array replaces base object", () => {
+      expect(mergeXConfig({ a: 1 }, [1, 2])).toEqual([1, 2]);
+    });
+
+    it("overlay object replaces base array", () => {
+      expect(mergeXConfig([1, 2], { a: 1 })).toEqual({ a: 1 });
+    });
+
+    it("nested arrays inside objects are replaced, not merged", () => {
+      const merged = mergeXConfig(
+        { tags: ["a", "b"], extra: 1 },
+        { tags: ["c"] }
+      );
+      expect(merged).toEqual({ tags: ["c"], extra: 1 });
+    });
+  });
+
+  describe("object deep merge", () => {
+    it("merges disjoint top-level keys", () => {
+      expect(mergeXConfig({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 });
+    });
+
+    it("overlay key wins on flat scalar conflict", () => {
+      expect(mergeXConfig({ a: 1, b: 2 }, { b: 3 })).toEqual({ a: 1, b: 3 });
+    });
+
+    it("recursively merges nested objects", () => {
+      const base = { outer: { a: 1, b: 2 }, untouched: "x" };
+      const overlay = { outer: { b: 99, c: 3 } };
+      expect(mergeXConfig(base, overlay)).toEqual({
+        outer: { a: 1, b: 99, c: 3 },
+        untouched: "x",
+      });
+    });
+
+    it("merges three levels deep", () => {
+      const base = { l1: { l2: { l3: { a: 1, b: 2 } } } };
+      const overlay = { l1: { l2: { l3: { b: 99, c: 3 } } } };
+      expect(mergeXConfig(base, overlay)).toEqual({
+        l1: { l2: { l3: { a: 1, b: 99, c: 3 } } },
+      });
+    });
+  });
+
+  describe("immutability", () => {
+    it("does not mutate the base input", () => {
+      const base = { a: { b: 1 }, c: [1, 2] };
+      const overlay = { a: { b: 99, d: 3 } };
+      mergeXConfig(base, overlay);
+      expect(base).toEqual({ a: { b: 1 }, c: [1, 2] });
+    });
+
+    it("does not mutate the overlay input", () => {
+      const base = { a: { b: 1 } };
+      const overlay = { a: { b: 99, d: 3 } };
+      mergeXConfig(base, overlay);
+      expect(overlay).toEqual({ a: { b: 99, d: 3 } });
+    });
+  });
+});

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.3.0"
+    "@pulsemcp/air-core": "0.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/adapter-claude/src/claude-adapter.ts
+++ b/packages/extensions/adapter-claude/src/claude-adapter.ts
@@ -270,6 +270,7 @@ export class ClaudeAdapter implements AgentAdapter {
     // 6. Validate and inject path-based hooks into .claude/hooks/<short>/.
     const prevHookIds = new Set(prevManifest?.hooks ?? []);
     const registeredHookShortIds: string[] = [];
+    const registeredHookActivations: Array<{ short: string; qualified: string }> = [];
     for (const a of hookActs) {
       const hook = artifacts.hooks[a.qualified];
 
@@ -291,6 +292,7 @@ export class ClaudeAdapter implements AgentAdapter {
 
       hookPaths.push(hookTargetDir);
       registeredHookShortIds.push(a.short);
+      registeredHookActivations.push({ short: a.short, qualified: a.qualified });
     }
 
     // 7. Register AIR-owned hooks in .claude/settings.json.
@@ -333,7 +335,14 @@ export class ClaudeAdapter implements AgentAdapter {
       startCommand.args.push("--append-system-prompt", subagentContext);
     }
 
-    return { configFiles, skillPaths, hookPaths, startCommand, subagentContext };
+    return {
+      configFiles,
+      skillPaths,
+      hookPaths,
+      hookActivations: registeredHookActivations,
+      startCommand,
+      subagentContext,
+    };
   }
 
   /**

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.3.0"
+    "@pulsemcp/air-core": "0.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.3.0",
+    "@pulsemcp/air-core": "0.4.0",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/extensions/provider-github/src/github-provider.ts
+++ b/packages/extensions/provider-github/src/github-provider.ts
@@ -562,14 +562,39 @@ export class GitHubCatalogProvider implements CatalogProvider {
       const tmpDir = mkdtempSync(`${cloneDir}.tmp-`);
 
       try {
-        // git clone refuses a non-empty target; mkdtempSync gave us an
-        // empty directory which git accepts.
-        const args =
-          ref === "HEAD"
-            ? ["clone", "--depth", "1", repoUrl, tmpDir]
-            : ["clone", "--depth", "1", "--branch", ref, repoUrl, tmpDir];
+        if (isImmutableRef(ref)) {
+          // `git clone --branch <sha>` does not work — git treats --branch as
+          // a ref name lookup. For commit SHAs we init + fetch + checkout so
+          // the SHA-pinned cache is content-addressed and immutable.
+          execFileSync("git", ["init", "--quiet", tmpDir], {
+            stdio: "pipe",
+            timeout: 30_000,
+          });
+          execFileSync("git", ["remote", "add", "origin", repoUrl], {
+            cwd: tmpDir,
+            stdio: "pipe",
+            timeout: 10_000,
+          });
+          execFileSync(
+            "git",
+            ["fetch", "--depth", "1", "origin", ref],
+            { cwd: tmpDir, stdio: "pipe", timeout: 60_000 }
+          );
+          execFileSync("git", ["checkout", "--quiet", "FETCH_HEAD"], {
+            cwd: tmpDir,
+            stdio: "pipe",
+            timeout: 10_000,
+          });
+        } else {
+          // git clone refuses a non-empty target; mkdtempSync gave us an
+          // empty directory which git accepts.
+          const args =
+            ref === "HEAD"
+              ? ["clone", "--depth", "1", repoUrl, tmpDir]
+              : ["clone", "--depth", "1", "--branch", ref, repoUrl, tmpDir];
 
-        execFileSync("git", args, { stdio: "pipe", timeout: 60_000 });
+          execFileSync("git", args, { stdio: "pipe", timeout: 60_000 });
+        }
 
         // Atomic publish: readers only ever see a complete clone at
         // cloneDir, never a half-populated one.

--- a/packages/extensions/provider-github/tests/github-provider.test.ts
+++ b/packages/extensions/provider-github/tests/github-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
+import { execFileSync } from "child_process";
 import { existsSync, rmSync } from "fs";
 import { resolve } from "path";
 import {
@@ -380,6 +381,47 @@ describe("GitHubCatalogProvider", () => {
       )
     ).rejects.toThrow(/Catalog path not found/);
   }, 30000);
+
+  it("resolveCatalogDir resolves a hook directory path at the default branch", async () => {
+    // Same call shape used by core when a hook entry's `path` is a github:// URI.
+    const catalogDir = await provider.resolveCatalogDir(
+      "github://pulsemcp/air/examples/hooks/hooks/notify-session-start"
+    );
+    expect(existsSync(catalogDir)).toBe(true);
+    expect(catalogDir).toContain("examples/hooks/hooks/notify-session-start");
+  }, 30000);
+
+  it("resolveCatalogDir caches by branch ref — repeat calls share a clone", async () => {
+    const dirA = await provider.resolveCatalogDir(
+      "github://pulsemcp/air@main/examples/hooks"
+    );
+    const dirB = await provider.resolveCatalogDir(
+      "github://pulsemcp/air@main/examples/hooks/hooks/lint-pre-commit"
+    );
+    const cloneRoot = getClonePath("pulsemcp", "air", "main");
+    expect(dirA.startsWith(cloneRoot)).toBe(true);
+    expect(dirB.startsWith(cloneRoot)).toBe(true);
+    expect(existsSync(resolve(cloneRoot, ".git"))).toBe(true);
+  }, 60000);
+
+  it("resolveCatalogDir caches a SHA-pinned ref under the SHA", async () => {
+    // Resolve `main` first to land a clone we can read the HEAD SHA from. The
+    // SHA-keyed clone is then content-addressed and never re-resolves.
+    await provider.resolveCatalogDir("github://pulsemcp/air@main/examples");
+    const sha = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: getClonePath("pulsemcp", "air", "main"),
+      encoding: "utf-8",
+    }).trim();
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+
+    const dir = await provider.resolveCatalogDir(
+      `github://pulsemcp/air@${sha}/examples/hooks`
+    );
+    expect(dir).toBe(
+      resolve(getClonePath("pulsemcp", "air", sha), "examples/hooks")
+    );
+    expect(existsSync(dir)).toBe(true);
+  }, 60000);
 
   it("throws when file not found in clone", async () => {
     const cloneDir = getClonePath("pulsemcp", "air", "HEAD");

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.3.0"
+    "@pulsemcp/air-core": "0.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.3.0"
+    "@pulsemcp/air-core": "0.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.3.0"
+    "@pulsemcp/air-core": "0.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/src/hook-x-config.ts
+++ b/packages/sdk/src/hook-x-config.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { basename, join } from "path";
+import {
+  mergeXConfig,
+  parseQualifiedId,
+  type ResolvedArtifacts,
+  type HookEntry,
+} from "@pulsemcp/air-core";
+
+/**
+ * Read every active hook's source HOOK.json and deep-merge the consumer's
+ * `x-config` (declared in `hooks.json`) into the file's own `x-config`.
+ * Returns a new `ResolvedArtifacts` whose `hooks[*]["x-config"]` is the
+ * fully-merged value — what `air resolve --json` shows and what should be
+ * written to the materialized HOOK.json.
+ *
+ * Hooks whose source HOOK.json is missing or unparseable are returned with
+ * just the consumer's `x-config` (or undefined) — the consumer's intent is
+ * preserved even when the source is unreachable.
+ *
+ * The original HookEntry objects are not mutated.
+ */
+export function materializeHookXConfig(
+  artifacts: ResolvedArtifacts
+): ResolvedArtifacts {
+  const merged: Record<string, HookEntry> = {};
+  for (const [qualified, entry] of Object.entries(artifacts.hooks)) {
+    const sourceXConfig = readHookSourceXConfig(entry.path);
+    const consumerXConfig = entry["x-config"];
+    const result = mergeXConfig(sourceXConfig, consumerXConfig);
+    if (result === undefined || !isPlainObject(result)) {
+      // No x-config on either side — drop the field rather than emit an empty
+      // object, so consumers that conditionally render the field stay clean.
+      const { "x-config": _omit, ...rest } = entry;
+      merged[qualified] = rest;
+    } else {
+      merged[qualified] = { ...entry, "x-config": result };
+    }
+  }
+  return { ...artifacts, hooks: merged };
+}
+
+/**
+ * After the adapter has copied a hook directory into the agent's working
+ * tree, write the merged `x-config` back into the materialized HOOK.json so
+ * subsequent transforms (e.g. `${VAR}` interpolation) operate on the fully
+ * composed config.
+ *
+ * Each `hookPath` is a directory; its basename is the short ID. The matching
+ * resolved hook is found by parsing qualified IDs in `artifacts.hooks` and
+ * matching on the short component. Hooks without an `x-config` on either
+ * side are skipped — the verbatim copy made by the adapter is correct.
+ */
+export function writeMergedHookXConfigs(
+  hookPaths: string[],
+  artifacts: ResolvedArtifacts
+): void {
+  for (const hookPath of hookPaths) {
+    const shortId = basename(hookPath);
+    const entry = findHookByShortId(artifacts, shortId);
+    if (!entry) continue;
+
+    const consumerXConfig = entry["x-config"];
+    const hookJsonPath = join(hookPath, "HOOK.json");
+    if (!existsSync(hookJsonPath)) continue;
+
+    let hookJson: Record<string, unknown>;
+    try {
+      hookJson = JSON.parse(readFileSync(hookJsonPath, "utf-8"));
+    } catch {
+      continue;
+    }
+
+    const sourceXConfig = hookJson["x-config"];
+    if (consumerXConfig === undefined && sourceXConfig === undefined) continue;
+
+    const merged = mergeXConfig(sourceXConfig, consumerXConfig);
+    if (merged === undefined) continue;
+
+    const next: Record<string, unknown> = { ...hookJson, "x-config": merged };
+    writeFileSync(hookJsonPath, JSON.stringify(next, null, 2) + "\n");
+  }
+}
+
+function readHookSourceXConfig(hookDir: string): unknown {
+  const hookJsonPath = join(hookDir, "HOOK.json");
+  if (!existsSync(hookJsonPath)) return undefined;
+  try {
+    const data = JSON.parse(readFileSync(hookJsonPath, "utf-8"));
+    if (!isPlainObject(data)) return undefined;
+    return data["x-config"];
+  } catch {
+    return undefined;
+  }
+}
+
+function findHookByShortId(
+  artifacts: ResolvedArtifacts,
+  shortId: string
+): HookEntry | undefined {
+  for (const [qualified, entry] of Object.entries(artifacts.hooks)) {
+    if (parseQualifiedId(qualified).id === shortId) return entry;
+  }
+  return undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" && value !== null && !Array.isArray(value)
+  );
+}

--- a/packages/sdk/src/hook-x-config.ts
+++ b/packages/sdk/src/hook-x-config.ts
@@ -46,18 +46,31 @@ export function materializeHookXConfig(
  * subsequent transforms (e.g. `${VAR}` interpolation) operate on the fully
  * composed config.
  *
- * Each `hookPath` is a directory; its basename is the short ID. The matching
- * resolved hook is found by parsing qualified IDs in `artifacts.hooks` and
- * matching on the short component. Hooks without an `x-config` on either
- * side are skipped — the verbatim copy made by the adapter is correct.
+ * Each `hookPath` is a directory; its basename is the short ID. When
+ * `activations` is provided (a short→qualified mapping the adapter emits),
+ * the qualified ID is used to look up the exact resolved hook entry —
+ * disambiguating cross-scope shortname collisions. Without `activations`,
+ * falls back to a short-id lookup that picks the first matching entry.
+ *
+ * Hooks without an `x-config` on either side are skipped — the verbatim copy
+ * made by the adapter is correct.
  */
 export function writeMergedHookXConfigs(
   hookPaths: string[],
-  artifacts: ResolvedArtifacts
+  artifacts: ResolvedArtifacts,
+  activations?: Array<{ short: string; qualified: string }>
 ): void {
+  const qualifiedByShort = new Map<string, string>();
+  if (activations) {
+    for (const a of activations) qualifiedByShort.set(a.short, a.qualified);
+  }
+
   for (const hookPath of hookPaths) {
     const shortId = basename(hookPath);
-    const entry = findHookByShortId(artifacts, shortId);
+    const qualified = qualifiedByShort.get(shortId);
+    const entry = qualified
+      ? artifacts.hooks[qualified]
+      : findHookByShortId(artifacts, shortId);
     if (!entry) continue;
 
     const consumerXConfig = entry["x-config"];

--- a/packages/sdk/src/prepare.ts
+++ b/packages/sdk/src/prepare.ts
@@ -256,7 +256,11 @@ export async function prepareSession(
   // the merged x-config back into each materialized HOOK.json so transforms
   // (e.g. ${VAR} interpolation) operate on the fully composed config.
   if (session.hookPaths.length > 0) {
-    writeMergedHookXConfigs(session.hookPaths, artifacts);
+    writeMergedHookXConfigs(
+      session.hookPaths,
+      artifacts,
+      session.hookActivations
+    );
   }
 
   // Run transforms in extension-list order on all config files (e.g., .mcp.json, settings.json)

--- a/packages/sdk/src/prepare.ts
+++ b/packages/sdk/src/prepare.ts
@@ -14,6 +14,10 @@ import { detectRoot } from "./root-detection.js";
 import { loadExtensions, type LoadedExtensions } from "./extension-loader.js";
 import { runTransforms } from "./transform-runner.js";
 import { checkProviderFreshness } from "./cache-freshness.js";
+import {
+  materializeHookXConfig,
+  writeMergedHookXConfigs,
+} from "./hook-x-config.js";
 import { existsSync, readFileSync } from "fs";
 import {
   findUnresolvedVars,
@@ -161,10 +165,11 @@ export async function prepareSession(
   if (options.gitProtocol !== undefined) {
     providerOptions.gitProtocol = options.gitProtocol;
   }
-  const artifacts = await resolveArtifacts(airJsonPath, {
+  const rawArtifacts = await resolveArtifacts(airJsonPath, {
     providers,
     providerOptions,
   });
+  const artifacts = materializeHookXConfig(rawArtifacts);
 
   // Check freshness of provider caches (non-blocking — warnings only)
   const warnings = await checkProviderFreshness(airConfig, providers);
@@ -246,6 +251,13 @@ export async function prepareSession(
       skipSubagentMerge: options.skipSubagentMerge,
     }
   );
+
+  // After the adapter copies hook directories into the target tree, write
+  // the merged x-config back into each materialized HOOK.json so transforms
+  // (e.g. ${VAR} interpolation) operate on the fully composed config.
+  if (session.hookPaths.length > 0) {
+    writeMergedHookXConfigs(session.hookPaths, artifacts);
+  }
 
   // Run transforms in extension-list order on all config files (e.g., .mcp.json, settings.json)
   if (loaded.transforms.length > 0 && session.configFiles.length > 0) {

--- a/packages/sdk/src/resolve.ts
+++ b/packages/sdk/src/resolve.ts
@@ -6,6 +6,7 @@ import {
   type ResolvedArtifacts,
 } from "@pulsemcp/air-core";
 import { loadExtensions } from "./extension-loader.js";
+import { materializeHookXConfig } from "./hook-x-config.js";
 
 export interface ResolveFullArtifactsOptions {
   /** Path to air.json. Uses AIR_CONFIG env or ~/.air/air.json if not set. */
@@ -48,5 +49,9 @@ export async function resolveFullArtifacts(
     providerOptions.gitProtocol = options.gitProtocol;
   }
 
-  return resolveArtifacts(airJsonPath, { providers, providerOptions });
+  const artifacts = await resolveArtifacts(airJsonPath, {
+    providers,
+    providerOptions,
+  });
+  return materializeHookXConfig(artifacts);
 }

--- a/packages/sdk/tests/hook-x-config.test.ts
+++ b/packages/sdk/tests/hook-x-config.test.ts
@@ -10,6 +10,8 @@ import {
 import { tmpdir } from "os";
 import { prepareSession } from "../src/prepare.js";
 import { resolveFullArtifacts } from "../src/resolve.js";
+import { writeMergedHookXConfigs } from "../src/hook-x-config.js";
+import type { ResolvedArtifacts } from "@pulsemcp/air-core";
 
 const tempDirs: string[] = [];
 
@@ -352,6 +354,99 @@ describe("hook x-config materialization", () => {
           process.env.SDK_TEST_XCONFIG_SECRET = savedVal;
         }
       }
+    });
+  });
+
+  describe("writeMergedHookXConfigs (cross-scope shortname collision)", () => {
+    it("uses activations to pick the correct entry when two scopes ship the same shortname", () => {
+      const target = createTemp({
+        // The adapter would have copied this from @local/notify's source
+        ".claude/hooks/notify/HOOK.json": JSON.stringify({
+          event: "Stop",
+          "x-config": { from: "source", greeting: "hello" },
+        }),
+      });
+
+      // Two distinct hooks with the same shortname under different scopes —
+      // exactly the cross-scope collision case warnCrossScopeShortnames warns
+      // about. The adapter activates one of them; the SDK must use the
+      // activation's qualified ID to pick the right consumer x-config.
+      const artifacts: ResolvedArtifacts = {
+        skills: {},
+        references: {},
+        mcp: {},
+        plugins: {},
+        roots: {},
+        hooks: {
+          "@local/notify": {
+            description: "local",
+            path: "ignored",
+            "x-config": { greeting: "from-local-consumer" },
+          },
+          "@acme/repo/notify": {
+            description: "acme",
+            path: "ignored",
+            "x-config": { greeting: "from-acme-consumer" },
+          },
+        },
+      };
+
+      writeMergedHookXConfigs(
+        [resolve(target, ".claude/hooks/notify")],
+        artifacts,
+        [{ short: "notify", qualified: "@acme/repo/notify" }]
+      );
+
+      const hookJson = JSON.parse(
+        readFileSync(
+          resolve(target, ".claude/hooks/notify/HOOK.json"),
+          "utf-8"
+        )
+      );
+      expect(hookJson["x-config"]).toEqual({
+        from: "source",
+        greeting: "from-acme-consumer",
+      });
+    });
+
+    it("falls back to short-id lookup when activations are not provided", () => {
+      const target = createTemp({
+        ".claude/hooks/notify/HOOK.json": JSON.stringify({
+          event: "Stop",
+          "x-config": { from: "source" },
+        }),
+      });
+
+      const artifacts: ResolvedArtifacts = {
+        skills: {},
+        references: {},
+        mcp: {},
+        plugins: {},
+        roots: {},
+        hooks: {
+          "@local/notify": {
+            description: "local",
+            path: "ignored",
+            "x-config": { extra: "from-consumer" },
+          },
+        },
+      };
+
+      writeMergedHookXConfigs(
+        [resolve(target, ".claude/hooks/notify")],
+        artifacts
+      );
+
+      const hookJson = JSON.parse(
+        readFileSync(
+          resolve(target, ".claude/hooks/notify/HOOK.json"),
+          "utf-8"
+        )
+      );
+      expect(hookJson["x-config"]).toEqual({
+        from: "source",
+        extra: "from-consumer",
+      });
     });
   });
 });

--- a/packages/sdk/tests/hook-x-config.test.ts
+++ b/packages/sdk/tests/hook-x-config.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { resolve, join } from "path";
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { prepareSession } from "../src/prepare.js";
+import { resolveFullArtifacts } from "../src/resolve.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    if (existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  tempDirs.length = 0;
+});
+
+function createTemp(files: Record<string, unknown>): string {
+  const dir = resolve(
+    tmpdir(),
+    `air-sdk-hook-xconfig-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  tempDirs.push(dir);
+  for (const [name, content] of Object.entries(files)) {
+    const path = resolve(dir, name);
+    mkdirSync(resolve(path, ".."), { recursive: true });
+    writeFileSync(
+      path,
+      typeof content === "string" ? content : JSON.stringify(content, null, 2)
+    );
+  }
+  return dir;
+}
+
+describe("hook x-config materialization", () => {
+  describe("resolveFullArtifacts", () => {
+    it("merges consumer x-config into source HOOK.json x-config", async () => {
+      const catalog = createTemp({
+        "air.json": {
+          name: "test",
+          hooks: ["./hooks.json"],
+        },
+        "hooks.json": {
+          "tagged-hook": {
+            description: "tagged hook",
+            path: "hooks/tagged-hook",
+            "x-config": {
+              tags: ["consumer-a"],
+              defaults: { greeting: "hi" },
+            },
+          },
+        },
+        "hooks/tagged-hook/HOOK.json": JSON.stringify({
+          event: "Stop",
+          "x-config": {
+            defaults: { greeting: "hello", farewell: "bye" },
+            owner: "source",
+          },
+        }),
+      });
+
+      const artifacts = await resolveFullArtifacts({
+        config: join(catalog, "air.json"),
+      });
+
+      const hook = artifacts.hooks["@local/tagged-hook"];
+      expect(hook["x-config"]).toEqual({
+        // tags is from consumer (replaced source absent)
+        tags: ["consumer-a"],
+        // greeting overridden by consumer; farewell preserved from source
+        defaults: { greeting: "hi", farewell: "bye" },
+        // owner kept from source (absent on consumer)
+        owner: "source",
+      });
+    });
+
+    it("returns consumer x-config alone when source HOOK.json has none", async () => {
+      const catalog = createTemp({
+        "air.json": { name: "test", hooks: ["./hooks.json"] },
+        "hooks.json": {
+          "consumer-only": {
+            description: "consumer only",
+            path: "hooks/consumer-only",
+            "x-config": { foo: "bar" },
+          },
+        },
+        "hooks/consumer-only/HOOK.json": JSON.stringify({ event: "Stop" }),
+      });
+
+      const artifacts = await resolveFullArtifacts({
+        config: join(catalog, "air.json"),
+      });
+      expect(artifacts.hooks["@local/consumer-only"]["x-config"]).toEqual({
+        foo: "bar",
+      });
+    });
+
+    it("returns source x-config alone when consumer has none", async () => {
+      const catalog = createTemp({
+        "air.json": { name: "test", hooks: ["./hooks.json"] },
+        "hooks.json": {
+          "source-only": {
+            description: "source only",
+            path: "hooks/source-only",
+          },
+        },
+        "hooks/source-only/HOOK.json": JSON.stringify({
+          event: "Stop",
+          "x-config": { greeting: "hello" },
+        }),
+      });
+
+      const artifacts = await resolveFullArtifacts({
+        config: join(catalog, "air.json"),
+      });
+      expect(artifacts.hooks["@local/source-only"]["x-config"]).toEqual({
+        greeting: "hello",
+      });
+    });
+
+    it("omits x-config field when neither side has one", async () => {
+      const catalog = createTemp({
+        "air.json": { name: "test", hooks: ["./hooks.json"] },
+        "hooks.json": {
+          "no-config": {
+            description: "no config",
+            path: "hooks/no-config",
+          },
+        },
+        "hooks/no-config/HOOK.json": JSON.stringify({ event: "Stop" }),
+      });
+
+      const artifacts = await resolveFullArtifacts({
+        config: join(catalog, "air.json"),
+      });
+      expect("x-config" in artifacts.hooks["@local/no-config"]).toBe(false);
+    });
+
+    it("consumer overlay arrays replace source arrays (no concatenation)", async () => {
+      const catalog = createTemp({
+        "air.json": { name: "test", hooks: ["./hooks.json"] },
+        "hooks.json": {
+          "arr-hook": {
+            description: "arr hook",
+            path: "hooks/arr-hook",
+            "x-config": { tags: ["only-this"] },
+          },
+        },
+        "hooks/arr-hook/HOOK.json": JSON.stringify({
+          event: "Stop",
+          "x-config": { tags: ["a", "b", "c"] },
+        }),
+      });
+
+      const artifacts = await resolveFullArtifacts({
+        config: join(catalog, "air.json"),
+      });
+      expect(artifacts.hooks["@local/arr-hook"]["x-config"]).toEqual({
+        tags: ["only-this"],
+      });
+    });
+
+    it("preserves consumer x-config when source HOOK.json is missing", async () => {
+      const catalog = createTemp({
+        "air.json": { name: "test", hooks: ["./hooks.json"] },
+        "hooks.json": {
+          "no-source": {
+            description: "no source HOOK.json",
+            path: "hooks/no-source",
+            "x-config": { foo: "bar" },
+          },
+        },
+      });
+
+      const artifacts = await resolveFullArtifacts({
+        config: join(catalog, "air.json"),
+      });
+      expect(artifacts.hooks["@local/no-source"]["x-config"]).toEqual({
+        foo: "bar",
+      });
+    });
+  });
+
+  describe("prepareSession writes merged x-config to HOOK.json", () => {
+    it("writes consumer-merged x-config back into materialized HOOK.json", async () => {
+      const catalog = createTemp({
+        "air.json": {
+          name: "test",
+          hooks: ["./hooks.json"],
+          roots: ["./roots.json"],
+        },
+        "hooks.json": {
+          "merge-hook": {
+            description: "merge hook",
+            path: "hooks/merge-hook",
+            "x-config": {
+              defaults: { greeting: "hi" },
+              tags: ["c"],
+            },
+          },
+        },
+        "hooks/merge-hook/HOOK.json": JSON.stringify({
+          event: "Stop",
+          command: "node",
+          "x-config": {
+            defaults: { greeting: "hello", farewell: "bye" },
+            tags: ["a", "b"],
+            owner: "src",
+          },
+        }),
+        "roots.json": {
+          default: {
+            description: "Default",
+            default_hooks: ["merge-hook"],
+          },
+        },
+      });
+
+      const target = createTemp({});
+
+      await prepareSession({
+        config: join(catalog, "air.json"),
+        adapter: "claude",
+        root: "default",
+        target,
+      });
+
+      const hookJson = JSON.parse(
+        readFileSync(
+          join(target, ".claude", "hooks", "merge-hook", "HOOK.json"),
+          "utf-8"
+        )
+      );
+
+      expect(hookJson.event).toBe("Stop");
+      expect(hookJson.command).toBe("node");
+      expect(hookJson["x-config"]).toEqual({
+        defaults: { greeting: "hi", farewell: "bye" },
+        tags: ["c"],
+        owner: "src",
+      });
+    });
+
+    it("leaves source x-config untouched when consumer has no x-config", async () => {
+      const catalog = createTemp({
+        "air.json": {
+          name: "test",
+          hooks: ["./hooks.json"],
+          roots: ["./roots.json"],
+        },
+        "hooks.json": {
+          "passthrough-hook": {
+            description: "passthrough",
+            path: "hooks/passthrough-hook",
+          },
+        },
+        "hooks/passthrough-hook/HOOK.json": JSON.stringify({
+          event: "Stop",
+          command: "node",
+          "x-config": { greeting: "hello" },
+        }),
+        "roots.json": {
+          default: {
+            description: "Default",
+            default_hooks: ["passthrough-hook"],
+          },
+        },
+      });
+
+      const target = createTemp({});
+
+      await prepareSession({
+        config: join(catalog, "air.json"),
+        adapter: "claude",
+        root: "default",
+        target,
+      });
+
+      const hookJson = JSON.parse(
+        readFileSync(
+          join(target, ".claude", "hooks", "passthrough-hook", "HOOK.json"),
+          "utf-8"
+        )
+      );
+      expect(hookJson["x-config"]).toEqual({ greeting: "hello" });
+    });
+
+    it("resolves ${VAR} interpolation inside x-config via secrets-env", async () => {
+      const savedVal = process.env.SDK_TEST_XCONFIG_SECRET;
+      process.env.SDK_TEST_XCONFIG_SECRET = "interpolated-value";
+
+      try {
+        const catalog = createTemp({
+          "air.json": {
+            name: "test",
+            extensions: ["@pulsemcp/air-secrets-env"],
+            hooks: ["./hooks.json"],
+            roots: ["./roots.json"],
+          },
+          "hooks.json": {
+            "interp-hook": {
+              description: "interp hook",
+              path: "hooks/interp-hook",
+              "x-config": {
+                credentials: { token: "${SDK_TEST_XCONFIG_SECRET}" },
+              },
+            },
+          },
+          "hooks/interp-hook/HOOK.json": JSON.stringify({
+            event: "Stop",
+            command: "node",
+            "x-config": { credentials: { user: "alice" } },
+          }),
+          "roots.json": {
+            default: {
+              description: "Default",
+              default_hooks: ["interp-hook"],
+            },
+          },
+        });
+
+        const target = createTemp({});
+
+        await prepareSession({
+          config: join(catalog, "air.json"),
+          adapter: "claude",
+          root: "default",
+          target,
+        });
+
+        const hookJson = JSON.parse(
+          readFileSync(
+            join(target, ".claude", "hooks", "interp-hook", "HOOK.json"),
+            "utf-8"
+          )
+        );
+        expect(hookJson["x-config"]).toEqual({
+          credentials: { user: "alice", token: "interpolated-value" },
+        });
+      } finally {
+        if (savedVal === undefined) {
+          delete process.env.SDK_TEST_XCONFIG_SECRET;
+        } else {
+          process.env.SDK_TEST_XCONFIG_SECRET = savedVal;
+        }
+      }
+    });
+  });
+});

--- a/schemas/hooks.schema.json
+++ b/schemas/hooks.schema.json
@@ -36,7 +36,7 @@
         },
         "path": {
           "type": "string",
-          "description": "Relative path to the hook directory containing HOOK.json and any associated scripts."
+          "description": "Path to the hook directory containing HOOK.json and any associated scripts. Either a relative path within the same catalog, or a remote URI handled by an installed catalog provider (e.g. github://owner/repo[@ref]/path/within/repo)."
         },
         "references": {
           "type": "array",
@@ -44,6 +44,11 @@
             "type": "string"
           },
           "description": "IDs of reference documents this hook depends on."
+        },
+        "x-config": {
+          "type": "object",
+          "description": "Consumer-supplied configuration overrides that AIR deep-merges into the materialized HOOK.json's own x-config at resolve time. Objects merge recursively (consumer wins on conflict), arrays replace, scalars replace. Values support ${VAR} interpolation via secrets transforms (e.g. @pulsemcp/air-secrets-env). The shape is intentionally permissive — hook-specific validation is the hook author's responsibility.",
+          "additionalProperties": true
         }
       },
       "required": ["description", "path"],

--- a/schemas/references.schema.json
+++ b/schemas/references.schema.json
@@ -36,7 +36,7 @@
         },
         "path": {
           "type": "string",
-          "description": "Relative path to the reference document file (typically Markdown)."
+          "description": "Path to the reference document file (typically Markdown). Either a relative path within the same catalog, or a remote URI handled by an installed catalog provider (e.g. github://owner/repo[@ref]/path/within/repo)."
         }
       },
       "required": ["description", "path"],

--- a/schemas/skills.schema.json
+++ b/schemas/skills.schema.json
@@ -36,7 +36,7 @@
         },
         "path": {
           "type": "string",
-          "description": "Relative path to the skill directory containing SKILL.md."
+          "description": "Path to the skill directory containing SKILL.md. Either a relative path within the same catalog, or a remote URI handled by an installed catalog provider (e.g. github://owner/repo[@ref]/path/within/repo)."
         },
         "references": {
           "type": "array",


### PR DESCRIPTION
Resolves [#127](https://github.com/pulsemcp/air/issues/127).

## Summary

Two composable hook authoring features that ship together:

### 1. `x-config` overlay on hooks.json index entries

Each `hooks.json` entry can now carry an optional `x-config` object. AIR deep-merges it into the materialized `HOOK.json`'s `x-config` at resolve time:

- **objects** merge recursively (consumer wins on conflicts)
- **arrays** replace wholesale (no concatenation)
- **scalars** replace
- the schema is intentionally permissive (`additionalProperties: true`) — hook authors define their own `x-config` schema

The merged value flows through `air resolve --json`, gets written back into the materialized `HOOK.json` during `air prepare` / `air start`, and runs through the existing transform pipeline (so `${VAR}` interpolation via `@pulsemcp/air-secrets-env` / `-secrets-file` works inside `x-config` values too).

### 2. `github://` scheme on the hook `path` field

A `hooks.json` entry's `path` can now point at a remote hook directory:

```json
{
  "remote-hook": {
    "description": "Hook from a shared catalog",
    "path": "github://acme/air-org@v1.2.0/hooks/notify-session-start"
  }
}
```

The same `@pulsemcp/air-provider-github` extension that resolves `catalogs` and per-type index URIs handles this; the same `AIR_GITHUB_TOKEN` and `gitProtocol` apply. Refs that look like a 40-character SHA are treated as immutable and content-addressed; branch and tag refs refresh on `air update`.

Path-style URIs are generalized in `core/src/config.ts` and work for **every** artifact type that has a `path` field (skills get this for free).

### Provider-github SHA-pinned ref support

`git clone --depth 1 --branch <SHA>` fails for full 40-character SHAs. The provider now detects immutable refs and uses `git init` + `git remote add origin` + `git fetch --depth 1 origin <sha>` + `git checkout FETCH_HEAD`. Branch and tag refs continue using the existing `git clone --branch` path.

## PR review feedback addressed (commit 4dbdccb)

A subagent reviewed the first commit with fresh eyes. All findings addressed:

- **MUST FIX — stale schema descriptions**: `schemas/skills.schema.json` and `schemas/references.schema.json` `path` descriptions now mention provider URIs (matches `hooks.schema.json`).
- **MUST FIX — README not updated**: added a paragraph in the README hooks section covering `x-config` overlay and `github://` paths.
- **SHOULD FIX — collision-safety in `findHookByShortId`**: when two scopes ship the same shortname (a *warning*, not a hard-fail), the lookup could pick the wrong scope's `x-config`. Extended `PreparedSession` with optional `hookActivations: Array<{ short, qualified }>`; the Claude adapter populates it from the activation chain, and `writeMergedHookXConfigs` uses it to look up the exact qualified entry. Falls back to short-id lookup when activations aren't provided. +2 tests cover the collision case.
- **SHOULD FIX — generic error messages**: threaded `artifactType` through `loadContributions` so resolution errors name the artifact type ("hooks", "skills", etc.) instead of saying "entries".
- **SHOULD FIX — SHA cache directory naming clarified** in `docs/guides/hooks.md`.

## Verification

- [x] `hooks.schema.json` updated; existing catalogs still validate (e2e test `air validate > validates all e2e fixture files` passes; covers full repo + examples)
- [x] `air resolve --target` writes merged `HOOK.json` with combined `x-config` (covered by `prepareSession writes merged x-config to HOOK.json` in `packages/sdk/tests/hook-x-config.test.ts`)
- [x] `air resolve --json` reports merged `x-config` (covered by `resolveFullArtifacts` tests in same file)
- [x] `${VAR}` interpolation works in `x-config` (covered by `resolves \${VAR} interpolation inside x-config via secrets-env`)
- [x] `github://owner/repo@ref/path` resolves and caches by SHA (covered by `resolveCatalogDir` tests in `packages/extensions/provider-github/tests/github-provider.test.ts` — branch ref + SHA-pinned ref + verifies cache directory naming)
- [x] Cross-scope shortname collision picks the right `x-config` (covered by `writeMergedHookXConfigs (cross-scope shortname collision)` tests)
- [x] Tests cover: missing `x-config` on either side, scalar override, nested merge, array replacement, env interpolation, github:// with branch/tag/SHA refs, cross-scope collision (875 total tests pass)
- [x] Docs updated in `docs/hooks.md`, `docs/guides/hooks.md`, README.md (added `x-config` section, github:// path support, `${VAR}` interpolation note)
- [x] Schema descriptions for `path` updated across `hooks.schema.json`, `skills.schema.json`, `references.schema.json` (all three now mention provider URIs)
- [x] Version bumped to 0.4.0 across all packages (lockstep), CHANGELOG entry added
- [x] All 875 tests across 48 files pass (`npx vitest run`)
- [x] Type-check passes (build succeeds for all packages)
- [x] Subagent PR review performed; all findings addressed in commit 4dbdccb
- [x] CI green on both commits

## Test plan

- [x] `npm run build -w packages/core && npm run build` — builds clean
- [x] `npx vitest run` — 875/875 pass
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)