### PR TITLE
fix(adapter-claude): hook event coverage + args path rewriting (v0.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-05-15
+
+### Fixed
+- **`@pulsemcp/air-adapter-claude` no longer silently drops hooks targeting Claude lifecycle events outside the original 5-event map.** The `AIR_TO_CLAUDE_EVENT` table was missing `Stop`, `SubagentStop`, `PreCompact`, and `UserPromptSubmit`, so any `HOOK.json` declaring one of those events was materialized into `.claude/hooks/<id>/` but never registered in `.claude/settings.json` — the hook would never fire. The table now covers all 9 Claude lifecycle events (`SessionStart`, `SessionEnd`, `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `SubagentStop`, `PreCompact`, `UserPromptSubmit`) via both snake_case AIR names and PascalCase Claude names (identity mappings), so hook authors targeting Claude can write either form in `HOOK.json`'s `event` field. Resolves [#129](https://github.com/pulsemcp/air/issues/129).
+- **`@pulsemcp/air-adapter-claude` warns instead of silently skipping when `HOOK.json` declares an unrecognized event.** Previously `reconcileSettingsHooks` would silently `continue` past any unmapped `event` value, leaving callers (and downstream users) with `{"hooks": {}}` and no indication that anything went wrong. The adapter now logs a `warn`-level message naming the hook id, the unrecognized event, and the list of supported events. `pre_commit` and `post_commit` still have no Claude Code equivalent and continue to be skipped — they now warn loudly rather than silently.
+- **`@pulsemcp/air-adapter-claude` rewrites hook-relative `args` paths to project-root form when materializing into `.claude/settings.json`.** Claude Code invokes hook commands from the project root, but hook authors naturally write paths relative to their own hook directory. Previously, only `command` strings starting with `./` were rewritten; `args` entries like `"dist/capture.js"` were left as-is, causing `node dist/capture.js` to fail at runtime because the project-root cwd has no `dist/capture.js`. The adapter now rewrites each `args` entry that looks like a path (contains a `/` or starts with `./`) **and** points at a real file inside the hook directory — bare command names like `lint-staged` and flags like `--quiet` pass through unchanged. The materialized command for the issue's example now becomes `node .claude/hooks/<hook-id>/dist/capture.js`.
+
 ## [0.4.0] - 2026-05-14
 
 ### Added

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -191,6 +191,12 @@ The same `AIR_GITHUB_TOKEN` and `gitProtocol` settings used for `catalogs` apply
 | `pre_commit` | Before a git commit is created |
 | `post_commit` | After a git commit is created |
 | `notification` | Agent sends a notification or message (behavior is agent-specific) |
+| `stop` | Agent finishes responding (Claude Code: `Stop`) |
+| `subagent_stop` | A subagent finishes (Claude Code: `SubagentStop`) |
+| `pre_compact` | Before context compaction (Claude Code: `PreCompact`) |
+| `user_prompt_submit` | User submits a prompt (Claude Code: `UserPromptSubmit`) |
+
+Hook authors targeting Claude Code may write the PascalCase Claude lifecycle event names (`SessionStart`, `Stop`, `PreCompact`, etc.) directly in `HOOK.json`'s `event` field — the Claude adapter accepts them as identity mappings, so no snake_case translation is required.
 
 ## Examples
 
@@ -316,10 +322,21 @@ For Claude Code, the adapter registers hooks in `.claude/settings.json` under th
 | `pre_tool_call` | `PreToolUse` | |
 | `post_tool_call` | `PostToolUse` | |
 | `notification` | `Notification` | |
+| `stop` | `Stop` | |
+| `subagent_stop` | `SubagentStop` | |
+| `pre_compact` | `PreCompact` | |
+| `user_prompt_submit` | `UserPromptSubmit` | |
 | `pre_commit` | — | No direct equivalent; use `pre_tool_call` with a `matcher` |
 | `post_commit` | — | No direct equivalent; use `post_tool_call` with a `matcher` |
 
-The `command` and `args` from `HOOK.json` are combined into a single command string. Relative paths (starting with `./`) are resolved relative to the hook's installed location. The `matcher` and `timeout_seconds` fields are carried through when present.
+The adapter also accepts the PascalCase Claude event names (`SessionStart`, `Stop`, `PreCompact`, …) as identity mappings — hook authors targeting Claude can write either form. Unknown `event` values are logged as a warning during `air prepare` / `air start` and the hook is left unregistered (the hook directory is still materialized).
+
+The `command` and `args` from `HOOK.json` are combined into a single command string. Path rewriting happens at two levels:
+
+- `command` rewrites if it starts with `./` (e.g. `./notify.sh` → `.claude/hooks/<id>/notify.sh`).
+- Each `args` entry rewrites when it looks like a path (contains a `/` separator, or starts with `./`) **and** points at a real file under the hook's installed directory. Bare command names like `lint-staged` and flags like `--quiet` pass through unchanged.
+
+The `matcher` and `timeout_seconds` fields are carried through when present.
 
 Example: a hook with this `HOOK.json`:
 
@@ -361,7 +378,7 @@ On re-runs, AIR uses the `_airHookId` marker plus the per-target manifest to pru
 
 **Limitations:**
 - The `env` field from `HOOK.json` is not forwarded to Claude Code hooks. Environment variables must be set in the shell environment before starting the session.
-- `pre_commit` and `post_commit` events have no direct Claude Code equivalent and are skipped during registration. Use `pre_tool_call` with a `matcher` to target specific tool calls instead.
+- `pre_commit` and `post_commit` events have no direct Claude Code equivalent. They are skipped during registration with a warning. Use `pre_tool_call` with a `matcher` to target specific tool calls instead.
 
 ## Listing hooks
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -100,6 +100,12 @@ The `HOOK.json` file defines how the hook executes:
 | `pre_commit` | Before a git commit is created |
 | `post_commit` | After a git commit is created |
 | `notification` | When the agent produces a user-facing notification |
+| `stop` | When the agent finishes responding (Claude Code: `Stop`) |
+| `subagent_stop` | When a subagent (Task tool call) finishes (Claude Code: `SubagentStop`) |
+| `pre_compact` | Before Claude Code compacts conversation context (Claude Code: `PreCompact`) |
+| `user_prompt_submit` | When the user submits a prompt (Claude Code: `UserPromptSubmit`) |
+
+Hook authors targeting Claude Code may write the PascalCase Claude lifecycle event names (`SessionStart`, `Stop`, `PreCompact`, etc.) directly in `HOOK.json`'s `event` field — the Claude adapter accepts them as identity mappings.
 
 ## Matchers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -892,9 +892,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.4.0",
+        "@pulsemcp/air-sdk": "0.4.1",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -913,7 +913,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -930,9 +930,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.0"
+        "@pulsemcp/air-core": "0.4.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -945,9 +945,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.0"
+        "@pulsemcp/air-core": "0.4.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -960,9 +960,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.0",
+        "@pulsemcp/air-core": "0.4.1",
         "proper-lockfile": "^4.1.2"
       },
       "devDependencies": {
@@ -977,9 +977,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.0"
+        "@pulsemcp/air-core": "0.4.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -992,9 +992,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.0"
+        "@pulsemcp/air-core": "0.4.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1007,9 +1007,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.0"
+        "@pulsemcp/air-core": "0.4.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.4.0",
+    "@pulsemcp/air-sdk": "0.4.1",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.0"
+    "@pulsemcp/air-core": "0.4.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/adapter-claude/src/claude-adapter.ts
+++ b/packages/extensions/adapter-claude/src/claude-adapter.ts
@@ -53,16 +53,38 @@ export class ClaudeAdapter implements AgentAdapter {
 
   /**
    * Map AIR lifecycle event names to Claude Code settings.json hook event names.
-   * Events without a direct Claude Code equivalent (e.g. pre_commit, post_commit)
-   * are omitted — the adapter skips unknown events rather than mapping them to
-   * lossy alternatives. Users should use pre_tool_call with a matcher instead.
+   *
+   * Accepts both snake_case AIR names and PascalCase Claude lifecycle names as
+   * identity mappings, so hook authors targeting the Claude runtime can write
+   * Claude-native event names directly without translating to snake_case.
+   *
+   * Events without a direct Claude Code equivalent (e.g. pre_commit,
+   * post_commit) are intentionally absent — `reconcileSettingsHooks` warns and
+   * skips registration when it encounters an unrecognized event. For commit
+   * hooks specifically, use pre_tool_call with a matcher instead.
    */
   private static readonly AIR_TO_CLAUDE_EVENT: Record<string, string> = {
+    // snake_case AIR names
     session_start: "SessionStart",
     session_end: "SessionEnd",
     pre_tool_call: "PreToolUse",
     post_tool_call: "PostToolUse",
     notification: "Notification",
+    stop: "Stop",
+    subagent_stop: "SubagentStop",
+    pre_compact: "PreCompact",
+    user_prompt_submit: "UserPromptSubmit",
+    // PascalCase Claude event names (identity — hook authors targeting Claude
+    // often write these directly).
+    SessionStart: "SessionStart",
+    SessionEnd: "SessionEnd",
+    PreToolUse: "PreToolUse",
+    PostToolUse: "PostToolUse",
+    Notification: "Notification",
+    Stop: "Stop",
+    SubagentStop: "SubagentStop",
+    PreCompact: "PreCompact",
+    UserPromptSubmit: "UserPromptSubmit",
   };
 
   async isAvailable(): Promise<boolean> {
@@ -832,17 +854,32 @@ export class ClaudeAdapter implements AgentAdapter {
       } catch {
         continue;
       }
-      const claudeEvent = ClaudeAdapter.AIR_TO_CLAUDE_EVENT[hookJson.event as string];
-      if (!claudeEvent || !hookJson.command) continue;
+      const hookId = hookPath.split(/[\\/]/).filter(Boolean).pop() || "";
+      const rawEvent = hookJson.event;
+      const claudeEvent =
+        typeof rawEvent === "string"
+          ? ClaudeAdapter.AIR_TO_CLAUDE_EVENT[rawEvent]
+          : undefined;
+      if (!claudeEvent) {
+        if (rawEvent !== undefined) {
+          console.warn(
+            `warning: hook "${hookId}" declares unrecognized event "${String(
+              rawEvent
+            )}" — skipping registration in .claude/settings.json. ` +
+              `Supported events: ${this.supportedEventList()}.`
+          );
+        }
+        continue;
+      }
+      if (!hookJson.command) continue;
 
       const hookRelDir = relative(targetDir, hookPath);
       const command = this.buildHookCommand(
         hookRelDir,
+        hookPath,
         hookJson.command as string,
         hookJson.args as string[] | undefined
       );
-
-      const hookId = hookPath.split(/[\\/]/).filter(Boolean).pop() || "";
 
       const hookEntry: Record<string, unknown> = {
         type: "command",
@@ -957,22 +994,77 @@ export class ClaudeAdapter implements AgentAdapter {
 
   /**
    * Build a shell command string from HOOK.json's command and args fields.
-   * Resolves relative paths (starting with ./) to be relative to the project root
-   * via the hook's installed directory path. Args containing shell metacharacters
-   * are single-quoted for safety.
+   *
+   * Claude Code invokes hook commands from the project root, but hook authors
+   * naturally write paths relative to their own hook directory. This method
+   * rewrites those hook-relative paths to project-root-relative form:
+   *
+   *   - `command` rewrites if it starts with `./` (explicit hook-relative).
+   *   - Each `args` entry rewrites if it looks like a path AND the file exists
+   *     under the hook's installed directory. We require a path-like form
+   *     (a `/` separator or an explicit `./` prefix) so command names like
+   *     `lint-staged` are not accidentally rewritten when a same-named file
+   *     happens to live in the hook directory.
+   *
+   * Args containing shell metacharacters are single-quoted for safety.
    */
-  private buildHookCommand(hookRelDir: string, command: string, args?: string[]): string {
+  private buildHookCommand(
+    hookRelDir: string,
+    hookAbsDir: string,
+    command: string,
+    args?: string[]
+  ): string {
     let cmd = command;
     if (cmd.startsWith("./")) {
       cmd = join(hookRelDir, cmd.slice(2));
     }
     if (args && args.length > 0) {
-      const escaped = args.map((a) =>
+      const rewritten = args.map((a) =>
+        this.rewriteHookArgPath(a, hookRelDir, hookAbsDir)
+      );
+      const escaped = rewritten.map((a) =>
         /[\s;&|`$"'\\]/.test(a) ? `'${a.replace(/'/g, "'\\''")}'` : a
       );
       cmd += " " + escaped.join(" ");
     }
     return cmd;
+  }
+
+  /**
+   * If `arg` is a hook-relative path that points at a real file under the
+   * hook's installed directory, rewrite it to a project-root-relative form
+   * (`.claude/hooks/<id>/<path>`). Otherwise return `arg` unchanged.
+   */
+  private rewriteHookArgPath(
+    arg: string,
+    hookRelDir: string,
+    hookAbsDir: string
+  ): string {
+    if (!arg) return arg;
+    // Flags, absolute paths, and home-relative paths are not hook-relative.
+    if (arg.startsWith("-") || arg.startsWith("/") || arg.startsWith("~")) {
+      return arg;
+    }
+    // Require a path-like form so bare command/package names (e.g. "lint-staged")
+    // are not accidentally rewritten when a same-named file exists in the hook dir.
+    const hasExplicitPrefix = arg.startsWith("./");
+    const candidate = hasExplicitPrefix ? arg.slice(2) : arg;
+    if (!hasExplicitPrefix && !candidate.includes("/")) return arg;
+    if (!existsSync(join(hookAbsDir, candidate))) return arg;
+    return join(hookRelDir, candidate);
+  }
+
+  /** Human-readable list of the supported AIR hook event names (snake_case only). */
+  private supportedEventList(): string {
+    const seen = new Set<string>();
+    const names: string[] = [];
+    for (const [key, value] of Object.entries(ClaudeAdapter.AIR_TO_CLAUDE_EVENT)) {
+      if (key === value) continue; // skip PascalCase identity entries
+      if (seen.has(key)) continue;
+      seen.add(key);
+      names.push(key);
+    }
+    return names.join(", ");
   }
 
   private copyDirRecursive(src: string, dest: string): void {

--- a/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
+++ b/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
@@ -2205,6 +2205,45 @@ describe("ClaudeAdapter", () => {
           "npx lint-staged --quiet /etc/hosts missing/file.js"
         );
       });
+
+      it("does not rewrite bare command names even when a same-named file exists in the hook dir", async () => {
+        const dir = createTempDir();
+
+        const hookSrcDir = join(dir, "..", "hooks", "bare-collision");
+        mkdirSync(hookSrcDir, { recursive: true });
+        // Create a file named "lint-staged" in the hook dir to prove the
+        // path-like guard (not just existsSync) is what prevents rewriting.
+        writeFileSync(join(hookSrcDir, "lint-staged"), "#!/bin/sh\n");
+        writeFileSync(
+          join(hookSrcDir, "HOOK.json"),
+          JSON.stringify({
+            event: "pre_tool_call",
+            command: "npx",
+            args: ["lint-staged"],
+          })
+        );
+
+        const artifacts = emptyArtifacts();
+        artifacts.hooks["@local/bare-collision"] = {
+          description: "Bare collision",
+          path: resolve(hookSrcDir),
+        };
+
+        const root: RootEntry = {
+          description: "Test",
+          default_hooks: ["bare-collision"],
+        };
+
+        await adapter.prepareSession(artifacts, dir, { root });
+
+        const settings = JSON.parse(
+          readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
+        );
+        // "lint-staged" has no `/` and no `./` prefix, so it must pass
+        // through as a bare command name even though a file with the same
+        // name happens to exist in the hook dir.
+        expect(settings.hooks.PreToolUse[0].hooks[0].command).toBe("npx lint-staged");
+      });
     });
 
     describe("plugin artifact resolution", () => {

--- a/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
+++ b/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
@@ -1905,6 +1905,306 @@ describe("ClaudeAdapter", () => {
         const settings = JSON.parse(readFileSync(join(dir, ".claude", "settings.json"), "utf-8"));
         expect(Object.keys(settings.hooks)).toHaveLength(0);
       });
+
+      it("registers hooks for all 9 Claude lifecycle events via snake_case", async () => {
+        const dir = createTempDir();
+
+        const eventMappings: [string, string][] = [
+          ["session_start", "SessionStart"],
+          ["session_end", "SessionEnd"],
+          ["pre_tool_call", "PreToolUse"],
+          ["post_tool_call", "PostToolUse"],
+          ["notification", "Notification"],
+          ["stop", "Stop"],
+          ["subagent_stop", "SubagentStop"],
+          ["pre_compact", "PreCompact"],
+          ["user_prompt_submit", "UserPromptSubmit"],
+        ];
+
+        const artifacts = emptyArtifacts();
+        for (const [i, [airEvent]] of eventMappings.entries()) {
+          const hookId = `snake-${i}`;
+          const hookSrcDir = join(dir, "..", "hooks", hookId);
+          mkdirSync(hookSrcDir, { recursive: true });
+          writeFileSync(
+            join(hookSrcDir, "HOOK.json"),
+            JSON.stringify({ event: airEvent, command: `cmd-${i}` })
+          );
+          artifacts.hooks[`@local/${hookId}`] = {
+            description: `Hook ${i}`,
+            path: resolve(hookSrcDir),
+          };
+        }
+
+        const root: RootEntry = {
+          description: "Test",
+          default_hooks: eventMappings.map((_, i) => `snake-${i}`),
+        };
+
+        await adapter.prepareSession(artifacts, dir, { root });
+
+        const settings = JSON.parse(
+          readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
+        );
+        for (const [i, [, claudeEvent]] of eventMappings.entries()) {
+          const eventHooks = settings.hooks[claudeEvent] as unknown[];
+          expect(eventHooks, `event ${claudeEvent} should be registered`).toBeDefined();
+          const entry = eventHooks.find(
+            (g: any) => g.hooks[0].command === `cmd-${i}`
+          );
+          expect(entry).toBeDefined();
+        }
+      });
+
+      it("accepts PascalCase Claude event names as identity mappings", async () => {
+        const dir = createTempDir();
+
+        const events = [
+          "SessionStart",
+          "SessionEnd",
+          "PreToolUse",
+          "PostToolUse",
+          "Notification",
+          "Stop",
+          "SubagentStop",
+          "PreCompact",
+          "UserPromptSubmit",
+        ];
+
+        const artifacts = emptyArtifacts();
+        for (const [i, event] of events.entries()) {
+          const hookId = `pascal-${i}`;
+          const hookSrcDir = join(dir, "..", "hooks", hookId);
+          mkdirSync(hookSrcDir, { recursive: true });
+          writeFileSync(
+            join(hookSrcDir, "HOOK.json"),
+            JSON.stringify({ event, command: `cmd-${i}` })
+          );
+          artifacts.hooks[`@local/${hookId}`] = {
+            description: `Hook ${i}`,
+            path: resolve(hookSrcDir),
+          };
+        }
+
+        const root: RootEntry = {
+          description: "Test",
+          default_hooks: events.map((_, i) => `pascal-${i}`),
+        };
+
+        await adapter.prepareSession(artifacts, dir, { root });
+
+        const settings = JSON.parse(
+          readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
+        );
+        for (const [i, event] of events.entries()) {
+          const eventHooks = settings.hooks[event] as unknown[];
+          expect(eventHooks, `event ${event} should be registered`).toBeDefined();
+          const entry = eventHooks.find(
+            (g: any) => g.hooks[0].command === `cmd-${i}`
+          );
+          expect(entry).toBeDefined();
+        }
+      });
+
+      it("registers a Stop hook (regression: agent-transcript-capture)", async () => {
+        // Regression test for issue #129 — HOOK.json with event "Stop" was
+        // silently dropped before the AIR_TO_CLAUDE_EVENT map was expanded.
+        const dir = createTempDir();
+
+        const hookSrcDir = join(dir, "..", "hooks", "agent-transcript-capture");
+        mkdirSync(join(hookSrcDir, "dist"), { recursive: true });
+        writeFileSync(
+          join(hookSrcDir, "HOOK.json"),
+          JSON.stringify({
+            event: "Stop",
+            command: "node",
+            args: ["dist/capture.js"],
+          })
+        );
+        writeFileSync(join(hookSrcDir, "dist", "capture.js"), "// noop");
+
+        const artifacts = emptyArtifacts();
+        artifacts.hooks["@local/agent-transcript-capture"] = {
+          description: "Transcript capture",
+          path: resolve(hookSrcDir),
+        };
+
+        const root: RootEntry = {
+          description: "Test",
+          default_hooks: ["agent-transcript-capture"],
+        };
+
+        await adapter.prepareSession(artifacts, dir, { root });
+
+        const settings = JSON.parse(
+          readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
+        );
+        expect(settings.hooks.Stop).toBeDefined();
+        expect(settings.hooks.Stop).toHaveLength(1);
+        expect(settings.hooks.Stop[0].hooks[0].command).toBe(
+          `node ${join(".claude", "hooks", "agent-transcript-capture", "dist", "capture.js")}`
+        );
+      });
+
+      it("warns when HOOK.json declares an unrecognized event", async () => {
+        const dir = createTempDir();
+
+        const hookSrcDir = join(dir, "..", "hooks", "weird-hook");
+        mkdirSync(hookSrcDir, { recursive: true });
+        writeFileSync(
+          join(hookSrcDir, "HOOK.json"),
+          JSON.stringify({ event: "made_up_event", command: "noop" })
+        );
+
+        const artifacts = emptyArtifacts();
+        artifacts.hooks["@local/weird-hook"] = {
+          description: "Weird event",
+          path: resolve(hookSrcDir),
+        };
+
+        const root: RootEntry = {
+          description: "Test",
+          default_hooks: ["weird-hook"],
+        };
+
+        const warnings: string[] = [];
+        const origWarn = console.warn;
+        console.warn = (msg: string) => warnings.push(msg);
+        try {
+          await adapter.prepareSession(artifacts, dir, { root });
+        } finally {
+          console.warn = origWarn;
+        }
+
+        expect(warnings.length).toBeGreaterThan(0);
+        const matched = warnings.find(
+          (w) =>
+            w.includes("weird-hook") &&
+            w.includes("made_up_event") &&
+            w.toLowerCase().includes("unrecognized")
+        );
+        expect(matched, `warning text was: ${JSON.stringify(warnings)}`).toBeDefined();
+      });
+
+      it("rewrites hook-relative args paths to project-root form", async () => {
+        const dir = createTempDir();
+
+        const hookSrcDir = join(dir, "..", "hooks", "capture");
+        mkdirSync(join(hookSrcDir, "dist"), { recursive: true });
+        writeFileSync(
+          join(hookSrcDir, "HOOK.json"),
+          JSON.stringify({
+            event: "Stop",
+            command: "node",
+            args: ["dist/capture.js", "--mode", "json"],
+          })
+        );
+        writeFileSync(join(hookSrcDir, "dist", "capture.js"), "// noop");
+
+        const artifacts = emptyArtifacts();
+        artifacts.hooks["@local/capture"] = {
+          description: "Capture",
+          path: resolve(hookSrcDir),
+        };
+
+        const root: RootEntry = {
+          description: "Test",
+          default_hooks: ["capture"],
+        };
+
+        await adapter.prepareSession(artifacts, dir, { root });
+
+        const settings = JSON.parse(
+          readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
+        );
+        // dist/capture.js exists in the hook dir → rewritten.
+        // --mode and json don't match a file in the hook dir → unchanged.
+        const expected = `node ${join(
+          ".claude",
+          "hooks",
+          "capture",
+          "dist",
+          "capture.js"
+        )} --mode json`;
+        expect(settings.hooks.Stop[0].hooks[0].command).toBe(expected);
+      });
+
+      it("rewrites explicit ./ args even without a path separator", async () => {
+        const dir = createTempDir();
+
+        const hookSrcDir = join(dir, "..", "hooks", "explicit-arg");
+        mkdirSync(hookSrcDir, { recursive: true });
+        writeFileSync(
+          join(hookSrcDir, "HOOK.json"),
+          JSON.stringify({
+            event: "session_start",
+            command: "bash",
+            args: ["./entry.sh"],
+          })
+        );
+        writeFileSync(join(hookSrcDir, "entry.sh"), "#!/bin/bash\n");
+
+        const artifacts = emptyArtifacts();
+        artifacts.hooks["@local/explicit-arg"] = {
+          description: "Explicit",
+          path: resolve(hookSrcDir),
+        };
+
+        const root: RootEntry = {
+          description: "Test",
+          default_hooks: ["explicit-arg"],
+        };
+
+        await adapter.prepareSession(artifacts, dir, { root });
+
+        const settings = JSON.parse(
+          readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
+        );
+        const expected = `bash ${join(".claude", "hooks", "explicit-arg", "entry.sh")}`;
+        expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(expected);
+      });
+
+      it("does not rewrite args that are not hook-relative paths", async () => {
+        const dir = createTempDir();
+
+        const hookSrcDir = join(dir, "..", "hooks", "no-rewrite");
+        mkdirSync(hookSrcDir, { recursive: true });
+        writeFileSync(
+          join(hookSrcDir, "HOOK.json"),
+          JSON.stringify({
+            event: "pre_tool_call",
+            command: "npx",
+            // None of these should be rewritten:
+            //   "lint-staged" — bare command name (no `/`), and lint-staged is
+            //     not a file in the hook dir
+            //   "--quiet" — flag
+            //   "/etc/hosts" — absolute path
+            //   "missing/file.js" — has a slash but the file doesn't exist
+            args: ["lint-staged", "--quiet", "/etc/hosts", "missing/file.js"],
+          })
+        );
+
+        const artifacts = emptyArtifacts();
+        artifacts.hooks["@local/no-rewrite"] = {
+          description: "No rewrite",
+          path: resolve(hookSrcDir),
+        };
+
+        const root: RootEntry = {
+          description: "Test",
+          default_hooks: ["no-rewrite"],
+        };
+
+        await adapter.prepareSession(artifacts, dir, { root });
+
+        const settings = JSON.parse(
+          readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
+        );
+        // "/etc/hosts" contains no shell metacharacters so passes through unquoted.
+        expect(settings.hooks.PreToolUse[0].hooks[0].command).toBe(
+          "npx lint-staged --quiet /etc/hosts missing/file.js"
+        );
+      });
     });
 
     describe("plugin artifact resolution", () => {

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.0"
+    "@pulsemcp/air-core": "0.4.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.0",
+    "@pulsemcp/air-core": "0.4.1",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.0"
+    "@pulsemcp/air-core": "0.4.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.0"
+    "@pulsemcp/air-core": "0.4.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.0"
+    "@pulsemcp/air-core": "0.4.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary

Fixes [#129](https://github.com/pulsemcp/air/issues/129): `@pulsemcp/air-adapter-claude` v0.4.0 silently dropped hooks whose `HOOK.json` declared Claude lifecycle events not in the internal `AIR_TO_CLAUDE_EVENT` lookup table.

Three fixes, all in `packages/extensions/adapter-claude/src/claude-adapter.ts`:

1. **Expanded `AIR_TO_CLAUDE_EVENT`** to cover all 9 Claude lifecycle events (`SessionStart`, `SessionEnd`, `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `SubagentStop`, `PreCompact`, `UserPromptSubmit`) via both snake_case AIR names and PascalCase Claude names (identity mappings). Hooks targeting `Stop` / `SubagentStop` / `PreCompact` / `UserPromptSubmit` are no longer silently dropped.

2. **Warn on unrecognized events** in `reconcileSettingsHooks` instead of silently continuing. The warning includes the hook id, the offending event name, and the list of supported events so the failure mode is visible to operators.

3. **Rewrite hook-relative `args` paths** to project-root-relative form when written into `.claude/settings.json`. Args like `"dist/capture.js"` now resolve to `".claude/hooks/<hook-id>/dist/capture.js"` so Claude Code can find the file from its project-root cwd. Rewriting only applies when the arg looks like a path (contains `/` or starts with `./`) AND the file exists in the hook directory — bare command names and flags (e.g., `--verbose`) pass through unchanged.

Patch version bump on every workspace package (lockstep monorepo): 0.4.0 → 0.4.1.

## Files changed

- `packages/extensions/adapter-claude/src/claude-adapter.ts` — expanded event map, added `console.warn`, added `rewriteHookArgPath()`, threaded `hookAbsDir` through `buildHookCommand`
- `packages/extensions/adapter-claude/tests/claude-adapter.test.ts` — 8 new tests (121 total in this package)
- `docs/hooks.md` — added 4 new events to the events table; documented PascalCase identity acceptance
- `docs/guides/hooks.md` — added 4 new events; documented PascalCase identity, args path rewriting, and updated Limitations
- `CHANGELOG.md` — new `## [0.4.1]` entry
- All 8 `package.json` files + `package-lock.json` — version bumps

## Verification

- [x] All 3 fixes implemented in `claude-adapter.ts` (expanded event map, warn on unknown, args path rewriting)
- [x] 8 new tests added covering: all 9 events via snake_case, PascalCase identity, Stop regression, warn on unrecognized event, args path rewriting (3 cases), and a regression test asserting bare command names are NOT rewritten even when a same-named file exists in the hook dir
- [x] `adapter-claude` tests pass locally: 121/121
- [x] Full monorepo tests pass locally: 883/883
- [x] Lockstep version bump applied across all 8 packages (0.4.0 → 0.4.1)
- [x] `package-lock.json` regenerated in sync
- [x] CHANGELOG entry added under `[0.4.1]` linking #129
- [x] Docs updated (`docs/hooks.md`, `docs/guides/hooks.md`)
- [x] Self-review pass done; independent subagent code review run with feedback addressed (added regression test for the bare-command collision case)
- [x] CI green on this PR (all 5 checks: e2e, test 18/20/22, validate-schemas)

Resolves #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)