### PR TITLE
fix(adapter-claude): anchor hook paths with $CLAUDE_PROJECT_DIR (v0.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-05-16
+
+### Fixed
+- **`@pulsemcp/air-adapter-claude` anchors hook command paths with `$CLAUDE_PROJECT_DIR` so hooks survive mid-session `cd` calls.** v0.4.1 rewrote hook-relative `args` and `./`-prefixed `command` paths to project-root form (e.g. `.claude/hooks/<id>/dist/capture.js`), which works only as long as the agent's current working directory at hook-firing time is still the project root. Once the agent `cd`s into a subdirectory (e.g. `.agent-containers/`), Claude Code invokes the hook with that cwd and Node errors out with `MODULE_NOT_FOUND` because the cwd-relative path now points one level too deep. The adapter now wraps rewritten paths as `"$CLAUDE_PROJECT_DIR/.claude/hooks/<id>/<file>"` — Claude Code sets `CLAUDE_PROJECT_DIR` in the hook environment, the double quotes keep paths with spaces safe, and the env var expands at invocation time so the absolute path is correct regardless of cwd. Applies uniformly to every Claude lifecycle event AIR emits (`SessionStart`, `Stop`, `PreToolUse`, etc.). Bare command names (`node`, `lint-staged`), flags, absolute paths, and home-relative paths still pass through unchanged.
+
 ## [0.4.1] - 2026-05-15
 
 ### Fixed

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -333,8 +333,10 @@ The adapter also accepts the PascalCase Claude event names (`SessionStart`, `Sto
 
 The `command` and `args` from `HOOK.json` are combined into a single command string. Path rewriting happens at two levels:
 
-- `command` rewrites if it starts with `./` (e.g. `./notify.sh` → `.claude/hooks/<id>/notify.sh`).
+- `command` rewrites if it starts with `./` (e.g. `./notify.sh` → `"$CLAUDE_PROJECT_DIR/.claude/hooks/<id>/notify.sh"`).
 - Each `args` entry rewrites when it looks like a path (contains a `/` separator, or starts with `./`) **and** points at a real file under the hook's installed directory. Bare command names like `lint-staged` and flags like `--quiet` pass through unchanged.
+
+Rewritten paths are anchored with Claude Code's `$CLAUDE_PROJECT_DIR` environment variable and wrapped in double quotes (e.g. `"$CLAUDE_PROJECT_DIR/.claude/hooks/<id>/dist/capture.js"`). This makes hooks resilient to mid-session `cd` calls — if the agent changes its working directory before a hook fires, a plain cwd-relative path would fail to resolve, but the `$CLAUDE_PROJECT_DIR`-anchored path always resolves to the project root regardless of cwd.
 
 The `matcher` and `timeout_seconds` fields are carried through when present.
 
@@ -364,6 +366,27 @@ Produces this entry in `.claude/settings.json`:
             "command": "npx lint-staged",
             "timeout": 30,
             "_airHookId": "lint-staged"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+A hook whose args reference a script inside its own directory (e.g. `args: ["dist/capture.js"]`) emits a path-rewritten command anchored to the project root:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-transcript-capture/dist/capture.js\"",
+            "_airHookId": "agent-transcript-capture"
           }
         ]
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -892,9 +892,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.4.1",
+        "@pulsemcp/air-sdk": "0.4.2",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -913,7 +913,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -930,9 +930,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.1"
+        "@pulsemcp/air-core": "0.4.2"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -945,9 +945,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.1"
+        "@pulsemcp/air-core": "0.4.2"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -960,9 +960,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.1",
+        "@pulsemcp/air-core": "0.4.2",
         "proper-lockfile": "^4.1.2"
       },
       "devDependencies": {
@@ -977,9 +977,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.1"
+        "@pulsemcp/air-core": "0.4.2"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -992,9 +992,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.1"
+        "@pulsemcp/air-core": "0.4.2"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1007,9 +1007,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.1"
+        "@pulsemcp/air-core": "0.4.2"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.4.1",
+    "@pulsemcp/air-sdk": "0.4.2",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.1"
+    "@pulsemcp/air-core": "0.4.2"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/adapter-claude/src/claude-adapter.ts
+++ b/packages/extensions/adapter-claude/src/claude-adapter.ts
@@ -995,18 +995,26 @@ export class ClaudeAdapter implements AgentAdapter {
   /**
    * Build a shell command string from HOOK.json's command and args fields.
    *
-   * Claude Code invokes hook commands from the project root, but hook authors
-   * naturally write paths relative to their own hook directory. This method
-   * rewrites those hook-relative paths to project-root-relative form:
+   * Hook authors write paths relative to their own hook directory. Claude
+   * Code invokes hooks with the agent's *current* cwd, which is often the
+   * project root but is NOT guaranteed — if the agent `cd`s into a
+   * subdirectory mid-session, a cwd-relative `.claude/hooks/<id>/...` path
+   * fails to resolve and Node throws MODULE_NOT_FOUND. To anchor the path
+   * regardless of cwd, hook-relative paths are rewritten to
+   * `"$CLAUDE_PROJECT_DIR/.claude/hooks/<id>/<path>"` — Claude Code sets
+   * `CLAUDE_PROJECT_DIR` in the hook environment, the double quotes keep
+   * the path safe for project directories with spaces, and the variable
+   * expands at hook-invocation time.
    *
-   *   - `command` rewrites if it starts with `./` (explicit hook-relative).
-   *   - Each `args` entry rewrites if it looks like a path AND the file exists
-   *     under the hook's installed directory. We require a path-like form
-   *     (a `/` separator or an explicit `./` prefix) so command names like
-   *     `lint-staged` are not accidentally rewritten when a same-named file
-   *     happens to live in the hook directory.
+   *   - `command` is anchored if it starts with `./` (explicit hook-relative).
+   *   - Each `args` entry is anchored if it looks like a path AND the file
+   *     exists under the hook's installed directory. We require a path-like
+   *     form (a `/` separator or an explicit `./` prefix) so command names
+   *     like `lint-staged` are not accidentally rewritten when a same-named
+   *     file happens to live in the hook directory.
    *
-   * Args containing shell metacharacters are single-quoted for safety.
+   * Args that are not rewritten and contain shell metacharacters are
+   * single-quoted for safety.
    */
   private buildHookCommand(
     hookRelDir: string,
@@ -1014,16 +1022,22 @@ export class ClaudeAdapter implements AgentAdapter {
     command: string,
     args?: string[]
   ): string {
-    let cmd = command;
-    if (cmd.startsWith("./")) {
-      cmd = join(hookRelDir, cmd.slice(2));
+    let cmd: string;
+    if (command.startsWith("./")) {
+      cmd = this.anchorHookPath(join(hookRelDir, command.slice(2)));
+    } else {
+      cmd = command;
     }
     if (args && args.length > 0) {
       const rewritten = args.map((a) =>
         this.rewriteHookArgPath(a, hookRelDir, hookAbsDir)
       );
-      const escaped = rewritten.map((a) =>
-        /[\s;&|`$"'\\]/.test(a) ? `'${a.replace(/'/g, "'\\''")}'` : a
+      const escaped = rewritten.map((r) =>
+        r.anchored
+          ? this.anchorHookPath(r.value)
+          : /[\s;&|`$"'\\]/.test(r.value)
+            ? `'${r.value.replace(/'/g, "'\\''")}'`
+            : r.value
       );
       cmd += " " + escaped.join(" ");
     }
@@ -1031,27 +1045,46 @@ export class ClaudeAdapter implements AgentAdapter {
   }
 
   /**
+   * Wrap a project-root-relative path in `"$CLAUDE_PROJECT_DIR/..."` so the
+   * resolved path is independent of the cwd at hook invocation. Double
+   * quotes are required so the env var expands; characters that are
+   * special inside double quotes (`$`, ``` ` ```, `"`, `\`) are escaped in
+   * the path component so an unusual hook ID or filename can't break out
+   * of the quoting.
+   */
+  private anchorHookPath(projectRelPath: string): string {
+    const safe = projectRelPath.replace(/[\\"$`]/g, "\\$&");
+    return `"$CLAUDE_PROJECT_DIR/${safe}"`;
+  }
+
+  /**
    * If `arg` is a hook-relative path that points at a real file under the
-   * hook's installed directory, rewrite it to a project-root-relative form
-   * (`.claude/hooks/<id>/<path>`). Otherwise return `arg` unchanged.
+   * hook's installed directory, return its project-root-relative form
+   * (`.claude/hooks/<id>/<path>`) flagged as anchored so the caller can
+   * wrap it in `$CLAUDE_PROJECT_DIR/`. Otherwise return `arg` unchanged
+   * with `anchored: false`.
    */
   private rewriteHookArgPath(
     arg: string,
     hookRelDir: string,
     hookAbsDir: string
-  ): string {
-    if (!arg) return arg;
+  ): { value: string; anchored: boolean } {
+    if (!arg) return { value: arg, anchored: false };
     // Flags, absolute paths, and home-relative paths are not hook-relative.
     if (arg.startsWith("-") || arg.startsWith("/") || arg.startsWith("~")) {
-      return arg;
+      return { value: arg, anchored: false };
     }
     // Require a path-like form so bare command/package names (e.g. "lint-staged")
     // are not accidentally rewritten when a same-named file exists in the hook dir.
     const hasExplicitPrefix = arg.startsWith("./");
     const candidate = hasExplicitPrefix ? arg.slice(2) : arg;
-    if (!hasExplicitPrefix && !candidate.includes("/")) return arg;
-    if (!existsSync(join(hookAbsDir, candidate))) return arg;
-    return join(hookRelDir, candidate);
+    if (!hasExplicitPrefix && !candidate.includes("/")) {
+      return { value: arg, anchored: false };
+    }
+    if (!existsSync(join(hookAbsDir, candidate))) {
+      return { value: arg, anchored: false };
+    }
+    return { value: join(hookRelDir, candidate), anchored: true };
   }
 
   /** Human-readable list of the supported AIR hook event names (snake_case only). */

--- a/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
+++ b/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
@@ -2304,6 +2304,62 @@ describe("ClaudeAdapter", () => {
         expect(command).toMatch(/\.js"/);
       });
 
+      it("escapes shell-special chars in anchored hook paths so they can't break out of the double quotes", async () => {
+        // Hook filenames inside the materialized hook directory shouldn't
+        // normally contain $, `, ", or \, but if they did, those characters
+        // are special inside double quotes and could allow command injection
+        // or path corruption. anchorHookPath() escapes them with a leading
+        // backslash. This test plants such a file and proves the emitted
+        // command stays inside the double quotes.
+        const dir = createTempDir();
+
+        const hookSrcDir = join(dir, "..", "hooks", "weird-paths");
+        // A filename containing $ and ` — characters that bash would
+        // otherwise interpret inside double quotes (variable expansion and
+        // command substitution).
+        const weirdFile = "weird$name`x.js";
+        mkdirSync(hookSrcDir, { recursive: true });
+        writeFileSync(
+          join(hookSrcDir, "HOOK.json"),
+          JSON.stringify({
+            event: "Stop",
+            command: "node",
+            args: [`./${weirdFile}`],
+          })
+        );
+        writeFileSync(join(hookSrcDir, weirdFile), "// noop");
+
+        const artifacts = emptyArtifacts();
+        artifacts.hooks["@local/weird-paths"] = {
+          description: "Weird paths",
+          path: resolve(hookSrcDir),
+        };
+
+        const root: RootEntry = {
+          description: "Test",
+          default_hooks: ["weird-paths"],
+        };
+
+        await adapter.prepareSession(artifacts, dir, { root });
+
+        const settings = JSON.parse(
+          readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
+        );
+        const command = settings.hooks.Stop[0].hooks[0].command as string;
+        // The $ and ` chars in the filename must be backslash-escaped so the
+        // shell treats them as literal characters, not as variable expansion
+        // or command substitution.
+        expect(command).toContain("\\$name");
+        expect(command).toContain("\\`x.js");
+        // $CLAUDE_PROJECT_DIR must still expand — i.e. its $ must NOT be
+        // escaped.
+        expect(command).toContain('"$CLAUDE_PROJECT_DIR/');
+        // The whole anchored path must remain wrapped in a single pair of
+        // double quotes (no stray quoting from injection).
+        const matches = command.match(/"/g) ?? [];
+        expect(matches.length).toBe(2);
+      });
+
       it("anchors a './'-prefixed command path with $CLAUDE_PROJECT_DIR", async () => {
         // The command field can also be a hook-relative path (e.g. "./run.sh")
         // and must be anchored the same way as args paths.

--- a/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
+++ b/packages/extensions/adapter-claude/tests/claude-adapter.test.ts
@@ -1680,7 +1680,7 @@ describe("ClaudeAdapter", () => {
         expect(settings.hooks.PreToolUse[0].hooks[0].command).toBe("npx lint-staged --quiet");
       });
 
-      it("resolves relative command paths to hook install directory", async () => {
+      it("resolves relative command paths to hook install directory anchored with $CLAUDE_PROJECT_DIR", async () => {
         const dir = createTempDir();
 
         const hookSrcDir = join(dir, "..", "hooks", "notify");
@@ -1703,7 +1703,7 @@ describe("ClaudeAdapter", () => {
 
         const settings = JSON.parse(readFileSync(join(dir, ".claude", "settings.json"), "utf-8"));
         expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(
-          join(".claude", "hooks", "notify", "notify.sh")
+          `"$CLAUDE_PROJECT_DIR/${join(".claude", "hooks", "notify", "notify.sh")}"`
         );
       });
 
@@ -2042,7 +2042,13 @@ describe("ClaudeAdapter", () => {
         expect(settings.hooks.Stop).toBeDefined();
         expect(settings.hooks.Stop).toHaveLength(1);
         expect(settings.hooks.Stop[0].hooks[0].command).toBe(
-          `node ${join(".claude", "hooks", "agent-transcript-capture", "dist", "capture.js")}`
+          `node "$CLAUDE_PROJECT_DIR/${join(
+            ".claude",
+            "hooks",
+            "agent-transcript-capture",
+            "dist",
+            "capture.js"
+          )}"`
         );
       });
 
@@ -2117,15 +2123,15 @@ describe("ClaudeAdapter", () => {
         const settings = JSON.parse(
           readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
         );
-        // dist/capture.js exists in the hook dir → rewritten.
+        // dist/capture.js exists in the hook dir → rewritten and anchored.
         // --mode and json don't match a file in the hook dir → unchanged.
-        const expected = `node ${join(
+        const expected = `node "$CLAUDE_PROJECT_DIR/${join(
           ".claude",
           "hooks",
           "capture",
           "dist",
           "capture.js"
-        )} --mode json`;
+        )}" --mode json`;
         expect(settings.hooks.Stop[0].hooks[0].command).toBe(expected);
       });
 
@@ -2160,7 +2166,12 @@ describe("ClaudeAdapter", () => {
         const settings = JSON.parse(
           readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
         );
-        const expected = `bash ${join(".claude", "hooks", "explicit-arg", "entry.sh")}`;
+        const expected = `bash "$CLAUDE_PROJECT_DIR/${join(
+          ".claude",
+          "hooks",
+          "explicit-arg",
+          "entry.sh"
+        )}"`;
         expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(expected);
       });
 
@@ -2243,6 +2254,97 @@ describe("ClaudeAdapter", () => {
         // through as a bare command name even though a file with the same
         // name happens to exist in the hook dir.
         expect(settings.hooks.PreToolUse[0].hooks[0].command).toBe("npx lint-staged");
+      });
+
+      it("anchors rewritten hook arg paths with $CLAUDE_PROJECT_DIR so cwd changes don't break Stop hooks", async () => {
+        // Regression: when the agent `cd`s into a subdirectory mid-session
+        // (e.g. .agent-containers/), Claude Code invokes the Stop hook with
+        // that cwd. A cwd-relative path like ".claude/hooks/<id>/dist/capture.js"
+        // resolves one level too deep and Node errors with MODULE_NOT_FOUND.
+        // Anchoring with $CLAUDE_PROJECT_DIR makes the path absolute at
+        // invocation time regardless of cwd.
+        const dir = createTempDir();
+
+        const hookSrcDir = join(dir, "..", "hooks", "agent-transcript-capture");
+        mkdirSync(join(hookSrcDir, "dist"), { recursive: true });
+        writeFileSync(
+          join(hookSrcDir, "HOOK.json"),
+          JSON.stringify({
+            event: "Stop",
+            command: "node",
+            args: ["dist/capture.js"],
+          })
+        );
+        writeFileSync(join(hookSrcDir, "dist", "capture.js"), "// noop");
+
+        const artifacts = emptyArtifacts();
+        artifacts.hooks["@local/agent-transcript-capture"] = {
+          description: "Transcript capture",
+          path: resolve(hookSrcDir),
+        };
+
+        const root: RootEntry = {
+          description: "Test",
+          default_hooks: ["agent-transcript-capture"],
+        };
+
+        await adapter.prepareSession(artifacts, dir, { root });
+
+        const settings = JSON.parse(
+          readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
+        );
+        const command = settings.hooks.Stop[0].hooks[0].command as string;
+        expect(command).toContain("$CLAUDE_PROJECT_DIR/");
+        expect(command).toContain(
+          join(".claude", "hooks", "agent-transcript-capture", "dist", "capture.js")
+        );
+        // The path expansion lives inside double quotes so paths containing
+        // spaces (e.g. on macOS "/Users/foo bar/...") still work.
+        expect(command).toMatch(/"\$CLAUDE_PROJECT_DIR\//);
+        expect(command).toMatch(/\.js"/);
+      });
+
+      it("anchors a './'-prefixed command path with $CLAUDE_PROJECT_DIR", async () => {
+        // The command field can also be a hook-relative path (e.g. "./run.sh")
+        // and must be anchored the same way as args paths.
+        const dir = createTempDir();
+
+        const hookSrcDir = join(dir, "..", "hooks", "explicit-cmd");
+        mkdirSync(hookSrcDir, { recursive: true });
+        writeFileSync(
+          join(hookSrcDir, "HOOK.json"),
+          JSON.stringify({
+            event: "session_start",
+            command: "./run.sh",
+          })
+        );
+        writeFileSync(join(hookSrcDir, "run.sh"), "#!/bin/bash\n");
+
+        const artifacts = emptyArtifacts();
+        artifacts.hooks["@local/explicit-cmd"] = {
+          description: "Explicit cmd",
+          path: resolve(hookSrcDir),
+        };
+
+        const root: RootEntry = {
+          description: "Test",
+          default_hooks: ["explicit-cmd"],
+        };
+
+        await adapter.prepareSession(artifacts, dir, { root });
+
+        const settings = JSON.parse(
+          readFileSync(join(dir, ".claude", "settings.json"), "utf-8")
+        );
+        const command = settings.hooks.SessionStart[0].hooks[0].command as string;
+        expect(command).toBe(
+          `"$CLAUDE_PROJECT_DIR/${join(
+            ".claude",
+            "hooks",
+            "explicit-cmd",
+            "run.sh"
+          )}"`
+        );
       });
     });
 

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.1"
+    "@pulsemcp/air-core": "0.4.2"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.1",
+    "@pulsemcp/air-core": "0.4.2",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.1"
+    "@pulsemcp/air-core": "0.4.2"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.1"
+    "@pulsemcp/air-core": "0.4.2"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.1"
+    "@pulsemcp/air-core": "0.4.2"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary

Fixes a recurring `MODULE_NOT_FOUND` failure when AIR-managed hooks fire while the agent's cwd is not the project root.

v0.4.1 (#130) rewrote hook-relative `args` (e.g. `dist/capture.js`) and `./`-prefixed `command` strings (e.g. `./run.sh`) to a project-root-relative form like `.claude/hooks/<id>/<file>`. That assumed Claude Code always invokes hooks from the project root. In practice it invokes them with the agent's *current* cwd — and once the agent `cd`s into a subdirectory mid-session, the cwd-relative path resolves one level too deep and Node crashes before the hook body runs:

```
Cannot find module '.../<root>/agents/agent-orchestrator/.agent-containers/.claude/hooks/agent-transcript-capture/dist/capture.js'
code: 'MODULE_NOT_FOUND'
```

(Real failure from AO session 6112 — the hook actually lives at `.../agent-orchestrator/.claude/hooks/...`, one level up from where Node looked.) A transcript scan turned up 22 such errors in one session and 1–5 errors each in eight other agent-orchestrator sessions. Only sessions that never `cd`'d out of the agent root succeeded in uploading transcripts.

### Fix

Wrap rewritten paths with Claude Code's `$CLAUDE_PROJECT_DIR` env var, double-quoted so paths with spaces stay safe and the variable still expands:

```
node "$CLAUDE_PROJECT_DIR/.claude/hooks/agent-transcript-capture/dist/capture.js"
```

`CLAUDE_PROJECT_DIR` is set by Claude Code in the hook environment regardless of cwd, so the absolute path is computed at invocation time. The fix applies uniformly to every Claude lifecycle event AIR emits (`Stop`, `SessionStart`, `PreToolUse`, etc.) — no special-case handling.

### Files changed

- `packages/extensions/adapter-claude/src/claude-adapter.ts` — `rewriteHookArgPath` now returns `{ value, anchored }`; new `anchorHookPath()` helper wraps anchored values in `"$CLAUDE_PROJECT_DIR/..."` with escaping for `$`, `` ` ``, `"`, `\` so an unusual hook ID/filename can't break out of the quoting; `buildHookCommand` anchors both the `./`-prefixed `command` and anchored args
- `packages/extensions/adapter-claude/tests/claude-adapter.test.ts` — 3 new tests + 4 existing tests updated for the new emitted form (124 total in this package)
- `docs/guides/hooks.md` — documents the anchoring + a materialized example
- `CHANGELOG.md` — new `## [0.4.2]` entry
- All 8 `package.json` files + `package-lock.json` — lockstep version bump 0.4.1 → 0.4.2

## Verification

- [x] **Identified the exact file/function in AIR that composes the hook command string** — `packages/extensions/adapter-claude/src/claude-adapter.ts`, specifically `buildHookCommand()` and `rewriteHookArgPath()` (called from `reconcileSettingsHooks()`).
- [x] **Before/after of the emitted command for a representative Stop hook.**
  - Before (v0.4.1):
    ```json
    { "command": "node .claude/hooks/agent-transcript-capture/dist/capture.js" }
    ```
  - After (this PR):
    ```json
    { "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-transcript-capture/dist/capture.js\"" }
    ```
  Verified end-to-end by running the adapter against a real `HOOK.json` and inspecting the generated `.claude/settings.json`:
    ```json
    {
      "hooks": {
        "Stop": [
          {
            "matcher": "",
            "hooks": [
              {
                "type": "command",
                "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-transcript-capture/dist/capture.js\"",
                "_airHookId": "agent-transcript-capture"
              }
            ]
          }
        ]
      }
    }
    ```
- [x] **Reproduced the original failure mode and confirmed the fix resolves it.** New regression test `anchors rewritten hook arg paths with $CLAUDE_PROJECT_DIR so cwd changes don't break Stop hooks` asserts the emitted command contains `$CLAUDE_PROJECT_DIR/` and ends inside double quotes. Also verified by hand: from a subdirectory, `cd subdir && node ".claude/hooks/.../capture.js"` fails with `MODULE_NOT_FOUND`; `CLAUDE_PROJECT_DIR=<root> eval 'node "$CLAUDE_PROJECT_DIR/.claude/hooks/.../capture.js"'` runs successfully. A dedicated shell-escape regression test (`escapes shell-special chars in anchored hook paths…`) locks in the quoting invariant by planting a filename containing `$` and `` ` ``. Full `adapter-claude` suite passes locally: **124 / 124 passing**.
- [x] **Patch version bump landed in the right manifest(s).** Lockstep bump from 0.4.1 → 0.4.2 in every `packages/**/package.json` and the lockfile. Quoted diff (every package matches the same shape):
  ```diff
  -  "version": "0.4.1",
  +  "version": "0.4.2",
  ```
  And every internal `@pulsemcp/air-*` dependency reference:
  ```diff
  -    "@pulsemcp/air-core": "0.4.1"
  +    "@pulsemcp/air-core": "0.4.2"
  ```
- [x] **CI green on this PR** — all checks pass (`e2e`, `test (18/20/22)`, `validate-schemas`).

## Constraints honored

- Applied uniformly to all hook events (not just `Stop`) — the anchoring logic lives in `buildHookCommand` / `rewriteHookArgPath`, which run for every `HOOK.json` regardless of `event`.
- Patch version bump only (0.4.1 → 0.4.2).

## Notes

- The Co-work plugin emitter (`packages/extensions/cowork/src/cowork-emitter.ts`) already uses the analogous `${CLAUDE_PLUGIN_ROOT}` anchor for its `./`-prefixed `command` paths; its `args` rewriting is a separate concern (different output format) and is out of scope for this bugfix.
- The CHANGELOG entry under [0.4.1] called out the project-root rewrite as a fix for the same root-cause issue; the [0.4.2] entry explicitly notes that this follow-up fully resolves the cwd-relative resolution problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)