### PR TITLE
fix(core): warn instead of error when an excluded artifact is still referenced (v0.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-05-17
+
+### Changed
+- **`@pulsemcp/air-core` no longer hard-fails resolution when a surviving artifact references an excluded one.** Previously, if `air.json#exclude` dropped an artifact that was still referenced from another artifact's body (a plugin's `mcp_servers`, a root's `default_mcp_servers`, a skill's `references`, etc.), `resolveArtifacts` threw with `Reference resolution failed: … which is removed by air.json#exclude … Drop the exclude entry or also remove every artifact that references it.` That made `exclude` impractical against catalogs whose plugins and default-loaded roots reference one another — adding a single exclude could fan out into rewriting every consumer. The resolver now emits a warning naming the consumer and the dropped reference, drops the reference from the consumer's resolved list, and continues. Downstream behavior follows: a root's `default_mcp_servers` simply omits the excluded server, so adapters like `@pulsemcp/air-adapter-claude` no longer write it into `.mcp.json`. Truly-missing references (not matched by any `exclude` entry of the same type) still hard-fail with the existing unknown-reference error.
+
 ## [0.4.2] - 2026-05-16
 
 ### Fixed

--- a/docs/guides/composition-and-overrides.md
+++ b/docs/guides/composition-and-overrides.md
@@ -129,6 +129,7 @@ Notes:
 - Each entry must be a qualified ID (`@scope/id`) or a wildcard pattern of the same shape — bare shortnames are rejected with a hard error.
 - An entry — exact or wildcard — that does not match any resolved artifact of its type emits a warning that names both the type and the offending pattern (typo guard, not an error).
 - `exclude` runs after composition, so a catalog you depend on cannot bypass it.
+- If a surviving artifact still references something you excluded (e.g. a plugin's `mcp_servers` or a root's `default_mcp_servers` points at the dropped MCP server), AIR emits a warning naming the consumer and the dropped reference, then resolves the consumer without it. Excluding an artifact never forces you to also rewrite every plugin or root that referenced it.
 - Omitting a key means "don't exclude anything of that type."
 
 There is no field-level patch, no "override this one field" knob. If you want a different behavior for a skill, ship a new skill under your own scope.
@@ -435,6 +436,7 @@ There is no "disabled" flag, no override-with-empty-entry trick. If you want a t
 | `exclude.<type>` matches a qualified ID | Artifact of that type removed from the resolved set; identically-named artifacts of other types untouched |
 | `exclude.<type>` matches a wildcard pattern | Every qualified ID of that type matching the pattern is removed |
 | `exclude.<type>` entry matches nothing | Per-type/per-pattern warning logged; resolution continues |
+| Surviving artifact references something `exclude` removed | Warning logged naming the consumer and dropped reference; the reference is dropped from the consumer and resolution continues |
 | `exclude.<type>` entry is not a qualified ID or wildcard | Hard-fail with the offending entry |
 | `exclude` is an array (legacy shape) | Hard-fail with a migration error pointing at the per-type object form |
 | `exclude` key is not a valid artifact type | Hard-fail naming the unknown key and listing valid keys |

--- a/package-lock.json
+++ b/package-lock.json
@@ -892,9 +892,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.4.2",
+        "@pulsemcp/air-sdk": "0.4.3",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -913,7 +913,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -930,9 +930,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.2"
+        "@pulsemcp/air-core": "0.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -945,9 +945,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.2"
+        "@pulsemcp/air-core": "0.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -960,9 +960,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.2",
+        "@pulsemcp/air-core": "0.4.3",
         "proper-lockfile": "^4.1.2"
       },
       "devDependencies": {
@@ -977,9 +977,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.2"
+        "@pulsemcp/air-core": "0.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -992,9 +992,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.2"
+        "@pulsemcp/air-core": "0.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1007,9 +1007,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
-        "@pulsemcp/air-core": "0.4.2"
+        "@pulsemcp/air-core": "0.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.4.2",
+    "@pulsemcp/air-sdk": "0.4.3",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -649,15 +649,13 @@ function canonicalizeReferences(
       } else if (res.status === "missing") {
         const matches = excludedMatches(ref, artifactType);
         if (matches.length > 0) {
-          // Demote to a warning and drop the reference: an artifact author
-          // and an exclude author may be different humans, and forcing the
-          // exclude author to also rewrite every consumer would make
-          // `exclude` unusable against catalogs that ship dense plugins or
-          // default-loaded roots.
+          // Warn instead of erroring: exclude and artifact authors are often
+          // different humans, and forcing every consumer to be rewritten
+          // makes `exclude` unusable against dense upstream catalogs.
           warnings.push(
             `${ownerLabel}.${field} references ${poolType} "${ref}", ` +
               `which is removed by air.json#exclude (${matches.join(", ")}). ` +
-              `Dropping the reference; ${ownerLabel} will resolve without it.`
+              `Dropping the reference.`
           );
         } else {
           errors.push(

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -586,7 +586,8 @@ async function expandAllCatalogs(
 function canonicalizeReferences(
   artifacts: ResolvedArtifacts,
   excluded: Map<ArtifactType, Set<QualifiedId>>,
-  errors: string[]
+  errors: string[],
+  warnings: string[]
 ): ResolvedArtifacts {
   type RefField =
     | { kind: "skill"; entry: SkillEntry }
@@ -648,11 +649,15 @@ function canonicalizeReferences(
       } else if (res.status === "missing") {
         const matches = excludedMatches(ref, artifactType);
         if (matches.length > 0) {
-          errors.push(
+          // Demote to a warning and drop the reference: an artifact author
+          // and an exclude author may be different humans, and forcing the
+          // exclude author to also rewrite every consumer would make
+          // `exclude` unusable against catalogs that ship dense plugins or
+          // default-loaded roots.
+          warnings.push(
             `${ownerLabel}.${field} references ${poolType} "${ref}", ` +
               `which is removed by air.json#exclude (${matches.join(", ")}). ` +
-              `Drop the exclude entry or also remove every artifact that ` +
-              `references it.`
+              `Dropping the reference; ${ownerLabel} will resolve without it.`
           );
         } else {
           errors.push(
@@ -1123,7 +1128,12 @@ export async function resolveArtifacts(
   warnCrossScopeShortnames(filtered, sourcesByType, warnings);
 
   const refErrors: string[] = [];
-  const canonical = canonicalizeReferences(filtered, excluded, refErrors);
+  const canonical = canonicalizeReferences(
+    filtered,
+    excluded,
+    refErrors,
+    warnings
+  );
   if (refErrors.length > 0) {
     throw new Error(
       `Reference resolution failed:\n  - ${refErrors.join("\n  - ")}`

--- a/packages/core/tests/composition.test.ts
+++ b/packages/core/tests/composition.test.ts
@@ -536,7 +536,8 @@ describe("composition", () => {
     );
   });
 
-  it("reference to an excluded artifact emits a tailored error", async () => {
+  it("reference to an excluded artifact warns and drops the reference", async () => {
+    const warnings: string[] = [];
     const { dir, cleanup: c } = createTempAirDir({
       "air.json": {
         name: "test",
@@ -545,17 +546,75 @@ describe("composition", () => {
         exclude: { references: ["@local/git-workflow"] },
       },
       "skills.json": {
-        deploy: exampleSkill("deploy", { references: ["git-workflow"] }),
+        deploy: exampleSkill("deploy", {
+          references: ["git-workflow", "code-style"],
+        }),
       },
       "refs.json": {
         "git-workflow": exampleReference("git-workflow"),
+        "code-style": exampleReference("code-style"),
       },
     });
     cleanup = c;
 
-    await expect(resolveArtifacts(join(dir, "air.json"))).rejects.toThrow(
-      /removed by air\.json#exclude.*@local\/git-workflow/s,
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      onWarning: (m) => warnings.push(m),
+    });
+
+    expect(artifacts.skills["@local/deploy"]).toBeDefined();
+    // Surviving reference is kept and canonicalized; excluded one is dropped.
+    expect(artifacts.skills["@local/deploy"].references).toEqual([
+      "@local/code-style",
+    ]);
+    expect(artifacts.references["@local/git-workflow"]).toBeUndefined();
+
+    const dropWarns = warnings.filter((w) =>
+      w.includes("removed by air.json#exclude"),
     );
+    expect(dropWarns).toHaveLength(1);
+    expect(dropWarns[0]).toMatch(
+      /@local\/deploy\.references references reference "git-workflow"/,
+    );
+    expect(dropWarns[0]).toMatch(/@local\/git-workflow/);
+    expect(dropWarns[0]).toMatch(/Dropping the reference/);
+  });
+
+  it("excluded MCP server referenced by a root's default_mcp_servers warns and is dropped", async () => {
+    const warnings: string[] = [];
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        mcp: ["./mcp.json"],
+        roots: ["./roots.json"],
+        exclude: { mcp: ["@local/github"] },
+      },
+      "mcp.json": {
+        github: exampleMcpStdio({ title: "GitHub MCP" }),
+        jira: exampleMcpStdio({ title: "Jira MCP" }),
+      },
+      "roots.json": {
+        web: exampleRoot("web", {
+          default_mcp_servers: ["github", "jira"],
+        }),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      onWarning: (m) => warnings.push(m),
+    });
+
+    expect(artifacts.roots["@local/web"].default_mcp_servers).toEqual([
+      "@local/jira",
+    ]);
+    expect(artifacts.mcp["@local/github"]).toBeUndefined();
+
+    const dropWarns = warnings.filter((w) =>
+      w.includes("removed by air.json#exclude"),
+    );
+    expect(dropWarns).toHaveLength(1);
+    expect(dropWarns[0]).toMatch(/default_mcp_servers/);
+    expect(dropWarns[0]).toMatch(/@local\/github/);
   });
 
   it("cross-scope shortname collision warns once when both scopes survive exclude", async () => {

--- a/packages/core/tests/composition.test.ts
+++ b/packages/core/tests/composition.test.ts
@@ -617,6 +617,90 @@ describe("composition", () => {
     expect(dropWarns[0]).toMatch(/@local\/github/);
   });
 
+  it("excluded child plugin referenced by another plugin's plugins[] warns and is dropped before expandPlugins runs", async () => {
+    const warnings: string[] = [];
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        skills: ["./skills.json"],
+        plugins: ["./plugins.json"],
+        exclude: { plugins: ["@local/child"] },
+      },
+      "skills.json": {
+        deploy: exampleSkill("deploy"),
+        lint: exampleSkill("lint"),
+      },
+      "plugins.json": {
+        child: {
+          description: "Child plugin (will be excluded)",
+          skills: ["lint"],
+        },
+        parent: {
+          description: "Parent plugin that references the excluded child",
+          plugins: ["child"],
+          skills: ["deploy"],
+        },
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      onWarning: (m) => warnings.push(m),
+    });
+
+    expect(artifacts.plugins["@local/child"]).toBeUndefined();
+    // expandPlugins must not have thrown — and parent's own skills survive,
+    // without the excluded child's `lint` contribution being merged in.
+    expect(artifacts.plugins["@local/parent"]).toBeDefined();
+    expect(artifacts.plugins["@local/parent"].plugins).toEqual([]);
+    expect(artifacts.plugins["@local/parent"].skills).toEqual(["@local/deploy"]);
+
+    const dropWarns = warnings.filter((w) =>
+      w.includes("removed by air.json#exclude"),
+    );
+    expect(dropWarns).toHaveLength(1);
+    expect(dropWarns[0]).toMatch(/@local\/parent\.plugins references plugin "child"/);
+    expect(dropWarns[0]).toMatch(/@local\/child/);
+  });
+
+  it("wildcard exclude that drops a whole scope still demotes consumer references to warnings", async () => {
+    const warnings: string[] = [];
+    const { dir, cleanup: c } = createTempAirDir({
+      "air.json": {
+        name: "test",
+        references: ["./refs.json"],
+        skills: ["./skills.json"],
+        exclude: { references: ["@local/*"] },
+      },
+      "refs.json": {
+        "git-workflow": exampleReference("git-workflow"),
+        "code-style": exampleReference("code-style"),
+      },
+      "skills.json": {
+        deploy: exampleSkill("deploy", {
+          references: ["git-workflow", "code-style"],
+        }),
+      },
+    });
+    cleanup = c;
+
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      onWarning: (m) => warnings.push(m),
+    });
+
+    // Both refs were dropped by the wildcard, so deploy's references list is empty.
+    expect(artifacts.references).toEqual({});
+    expect(artifacts.skills["@local/deploy"].references).toEqual([]);
+
+    const dropWarns = warnings.filter((w) =>
+      w.includes("removed by air.json#exclude"),
+    );
+    // One warning per dangling reference, naming the wildcard-expanded ID.
+    expect(dropWarns).toHaveLength(2);
+    expect(dropWarns.some((w) => w.includes("@local/git-workflow"))).toBe(true);
+    expect(dropWarns.some((w) => w.includes("@local/code-style"))).toBe(true);
+  });
+
   it("cross-scope shortname collision warns once when both scopes survive exclude", async () => {
     const warnings: string[] = [];
     const { dir, cleanup: c } = createTempAirDir({

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.2"
+    "@pulsemcp/air-core": "0.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.2"
+    "@pulsemcp/air-core": "0.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.2",
+    "@pulsemcp/air-core": "0.4.3",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.2"
+    "@pulsemcp/air-core": "0.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.2"
+    "@pulsemcp/air-core": "0.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.4.2"
+    "@pulsemcp/air-core": "0.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary

`air.json#exclude` was effectively unusable against any catalog whose plugins or roots cross-reference one another. Excluding a single MCP server fan-outed into a hard error of the form:

```
Reference resolution failed:
  - @reframe-systems/agentic-engineering/ai-artifact-catalog-management-for-non-engineers.mcp_servers references mcp "github", which is removed by air.json#exclude (@reframe-systems/agentic-engineering/github). Drop the exclude entry or also remove every artifact that references it.
```

The reporter's intent is clear: they want the MCP server gone — they do not want to also be forced to rewrite every plugin and root in the upstream catalog that happens to reference it.

## What changed

- `canonicalizeReferences` in `packages/core/src/config.ts` now treats "this reference points at something that was just excluded" as a **warning** rather than an error, and drops the reference from the consumer's resolved list. Truly-missing references (no match against any `exclude.<type>` entry) still hard-fail.
- The new warning carries the consumer label, the field, the excluded qualified ID, and "Dropping the reference; …" so it is greppable and self-explanatory.
- Applies uniformly to every reference field in the resolver: `skill.references`, `hook.references`, `plugin.{skills,mcp_servers,hooks,plugins}`, and `root.{default_skills,default_mcp_servers,default_plugins,default_hooks,default_subagent_roots}`. Downstream: a root's `default_mcp_servers` simply omits the excluded server, so `air-adapter-claude` never writes it into `.mcp.json`.
- `docs/guides/composition-and-overrides.md` — added a behavior-table row and a `Notes:` bullet under `exclude` documenting the new semantics.
- Version bumped to **v0.4.3** in lockstep across all packages, with a `CHANGELOG.md` entry.

## Verification

- [x] **Tests added** — `packages/core/tests/composition.test.ts` gains two cases:
  - `"reference to an excluded artifact warns and drops the reference"` — replaces the old hard-fail test; asserts the warning fires, the excluded reference is dropped from `skill.references`, and the surviving reference is preserved and canonicalized.
  - `"excluded MCP server referenced by a root's default_mcp_servers warns and is dropped"` — covers the user-reported `root.default_mcp_servers` path end-to-end.
- [x] **Tests pass locally** — full `@pulsemcp/air-core` suite green (242 / 242) and `@pulsemcp/air-cli` (144 / 144). Pre-existing macOS `/private/var` symlink-related SDK test failures reproduce identically on `origin/main` and are unrelated to this change.
- [x] **Docs updated** — `docs/guides/composition-and-overrides.md` behavior table + notes; ran the `air-update-docs` pre-PR review and confirmed no other guide describes the old hard-fail behavior.
- [x] **Version bump validated** — all eight `packages/**/package.json` files at 0.4.3, internal `@pulsemcp/air-*` deps updated, lockfile regenerated, `CHANGELOG.md` entry added under today's date, full repo grep for `"0.4.2"` outside `node_modules`/lockfile returns nothing.
- [x] **CI green** — confirmed via `wait-for-ci` after push (see CI checks on this PR).
- [x] **Self-review done** — re-read the diff after a separate review agent pass; addressed feedback before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)