### PR TITLE
fix(core): warn instead of error on references to unknown artifacts (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-05-28
+
+### Changed
+- **`@pulsemcp/air-core` no longer hard-fails resolution when an artifact references an unknown (truly-missing) artifact.** v0.4.3 made references to *excluded* artifacts warn-and-drop, but a reference to something that was never contributed at all — a typo, a not-yet-installed catalog, or an upstream rename — still threw `Reference resolution failed: … references unknown skill "create-pr". Available qualified IDs: …`, blocking resolution of the entire config. A single dangling reference (e.g. a root's `default_skills` pointing at a skill the catalog no longer ships) took down every otherwise-valid artifact. `canonicalizeReferences` in `packages/core/src/config.ts` now treats an unknown reference as a warning, drops the dangling reference from the consumer's resolved list, and continues. The warning names the consumer, the field, the missing reference, and the available qualified IDs, and ends with "Dropping the reference." Applies uniformly to every reference field in the resolver (`skill.references`, `hook.references`, `plugin.{skills,mcp_servers,hooks,plugins}`, `root.{default_skills,default_mcp_servers,default_plugins,default_hooks,default_subagent_roots}`). Ambiguous references (a short ID matching multiple scopes) still hard-fail, since those are resolvable by qualifying the reference rather than by dropping it.
+
 ## [0.5.0] - 2026-05-21
 
 ### Added

--- a/docs/guides/composition-and-overrides.md
+++ b/docs/guides/composition-and-overrides.md
@@ -164,6 +164,8 @@ Error: Reference "review" is ambiguous — candidates: @acme/air-org/review,
 @local/review. Use the qualified form to disambiguate.
 ```
 
+A reference to an artifact that does not exist in the resolved set at all — a typo, a not-yet-installed catalog, or an artifact an upstream catalog renamed or removed — does **not** fail resolution. AIR emits a warning naming the consumer, the field, the missing reference, and the available qualified IDs, then drops the dangling reference and continues. A single bad reference (for example a root's `default_skills` pointing at a skill the catalog no longer ships) never blocks the rest of an otherwise-valid config. Ambiguous references are the exception: because they are fixable by qualifying the reference rather than by dropping it, they still hard-fail as shown above.
+
 After resolution, root and plugin reference fields are stored in **canonical (qualified) form** so adapters and consumers do not need to re-resolve them.
 
 ### Single-scope universes: `air resolve --no-scope`
@@ -442,6 +444,7 @@ There is no "disabled" flag, no override-with-empty-entry trick. If you want a t
 | `exclude` key is not a valid artifact type | Hard-fail naming the unknown key and listing valid keys |
 | Short reference, unambiguous | Resolved to its qualified ID |
 | Short reference, ambiguous | Hard-fail with candidate list |
+| Reference to an artifact not in the resolved set | Warning logged naming the consumer and missing reference; the reference is dropped from the consumer and resolution continues |
 | Short reference inside a catalog index | Resolved to the catalog's own scope first |
 | Plugin references another plugin | Recursive expansion; references canonicalized |
 | Subagent root artifacts | Merged into parent session |

--- a/package-lock.json
+++ b/package-lock.json
@@ -908,9 +908,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.5.0",
+        "@pulsemcp/air-sdk": "0.5.1",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -929,7 +929,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -946,9 +946,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.5.0"
+        "@pulsemcp/air-core": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -961,9 +961,9 @@
     },
     "packages/extensions/adapter-codex": {
       "name": "@pulsemcp/air-adapter-codex",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.5.0",
+        "@pulsemcp/air-core": "0.5.1",
         "smol-toml": "^1.3.0"
       },
       "devDependencies": {
@@ -977,9 +977,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.5.0"
+        "@pulsemcp/air-core": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -992,9 +992,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.5.0",
+        "@pulsemcp/air-core": "0.5.1",
         "proper-lockfile": "^4.1.2"
       },
       "devDependencies": {
@@ -1009,9 +1009,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.5.0"
+        "@pulsemcp/air-core": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1024,9 +1024,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.5.0"
+        "@pulsemcp/air-core": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1039,9 +1039,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
-        "@pulsemcp/air-core": "0.5.0"
+        "@pulsemcp/air-core": "0.5.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.5.0",
+    "@pulsemcp/air-sdk": "0.5.1",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -658,9 +658,14 @@ function canonicalizeReferences(
               `Dropping the reference.`
           );
         } else {
-          errors.push(
+          // Warn instead of erroring: a reference to an artifact that was
+          // never contributed (typo, not-yet-installed catalog, upstream
+          // rename) should not block resolution of everything else. Drop the
+          // dangling reference and let the session proceed.
+          warnings.push(
             `${ownerLabel}.${field} references unknown ${poolType} "${ref}". ` +
-              `Available qualified IDs: ${listIds(pool)}.`
+              `Available qualified IDs: ${listIds(pool)}. ` +
+              `Dropping the reference.`
           );
         }
       } else {

--- a/packages/core/tests/composition.test.ts
+++ b/packages/core/tests/composition.test.ts
@@ -519,7 +519,8 @@ describe("composition", () => {
     expect(artifacts.references["@local/git-workflow"]).toBeDefined();
   });
 
-  it("reference to missing artifact hard-fails", async () => {
+  it("reference to missing artifact warns and drops the reference", async () => {
+    const warnings: string[] = [];
     const { dir, cleanup: c } = createTempAirDir({
       "air.json": {
         name: "test",
@@ -531,9 +532,19 @@ describe("composition", () => {
     });
     cleanup = c;
 
-    await expect(resolveArtifacts(join(dir, "air.json"))).rejects.toThrow(
-      /references unknown reference "missing-ref"/,
+    const artifacts = await resolveArtifacts(join(dir, "air.json"), {
+      onWarning: (m) => warnings.push(m),
+    });
+
+    // Resolution succeeds; the dangling reference is dropped, not fatal.
+    expect(artifacts.skills["@local/deploy"]).toBeDefined();
+    expect(artifacts.skills["@local/deploy"].references).toEqual([]);
+
+    const missingWarns = warnings.filter((w) =>
+      w.includes('references unknown reference "missing-ref"'),
     );
+    expect(missingWarns).toHaveLength(1);
+    expect(missingWarns[0]).toMatch(/Dropping the reference/);
   });
 
   it("reference to an excluded artifact warns and drops the reference", async () => {

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.5.0"
+    "@pulsemcp/air-core": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/adapter-codex/package.json
+++ b/packages/extensions/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-codex",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.5.0",
+    "@pulsemcp/air-core": "0.5.1",
     "smol-toml": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.5.0"
+    "@pulsemcp/air-core": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.5.0",
+    "@pulsemcp/air-core": "0.5.1",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.5.0"
+    "@pulsemcp/air-core": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.5.0"
+    "@pulsemcp/air-core": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.5.0"
+    "@pulsemcp/air-core": "0.5.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary

A reference to an artifact that was never contributed — a typo, a not-yet-installed catalog, or an artifact an upstream catalog renamed/removed — hard-failed the *entire* resolution:

```
AIR prepare failed (exit 1): Error: Reference resolution failed:
  - @reframe-systems/agentic-engineering/frameshape.default_skills references unknown skill "create-pr". Available qualified IDs: …
```

A single dangling reference (e.g. a root's `default_skills` pointing at a skill the catalog no longer ships) took down every otherwise-valid artifact in the config. This is the direct follow-up to #134, which made references to *excluded* artifacts warn-and-drop but left *truly-missing* references as a hard error.

## What changed

- `canonicalizeReferences` in `packages/core/src/config.ts` now treats an unknown reference as a **warning** rather than an error: it names the consumer, the field, the missing reference, and the available qualified IDs, drops the dangling reference from the consumer's resolved list, and continues.
- Applies uniformly to every reference field in the resolver: `skill.references`, `hook.references`, `plugin.{skills,mcp_servers,hooks,plugins}`, and `root.{default_skills,default_mcp_servers,default_plugins,default_hooks,default_subagent_roots}`.
- **Ambiguous** references (a short ID matching multiple scopes) still hard-fail — those are resolvable by qualifying the reference, not by dropping it.
- Version bumped to **v0.5.1** in lockstep across all nine packages, internal `@pulsemcp/air-*` deps updated, lockfile regenerated, `CHANGELOG.md` entry added.
- `docs/guides/composition-and-overrides.md` — new paragraph in the reference-resolution section and a row in the composition behavior table.

## Verification

- `@pulsemcp/air-core` suite green (244/244), including the updated `composition.test.ts` case `"reference to missing artifact warns and drops the reference"` (replaces the old hard-fail test).
- Full workspace suite: the only failures are the pre-existing macOS `/private/tmp` symlink path-normalization tests in `@pulsemcp/air-sdk` (`discover-indexes`, `auto-discovery`), identical on `main` and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)