### PR TITLE
fix(cowork): fail loud on unmapped hook events + map full event vocabulary (v0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-06-02
+
+### Fixed
+- **`@pulsemcp/air-cowork` — `air export cowork` no longer silently drops hooks whose event has no Co-work mapping, and command paths in `args` are now anchored to `${CLAUDE_PLUGIN_ROOT}`.** Previously the emitter only knew five AIR events (`session_start`, `session_end`, `pre_tool_call`, `post_tool_call`, `notification`); any other event — including the common `Stop` — was *silently skipped*. The export still wrote a `plugin.json`, never wrote `hooks/hooks.json` or copied the hook script, and yet reported `hookCount: 1` and exited `0`, producing a broken/empty plugin directory that looked successful. (This is what kept `agent-transcript-capture`, a `Stop`-event hook resolved via `github://pulsemcp/ai-artifacts`, from exporting.) Three changes fix this: (1) the event map now covers AIR's full lifecycle vocabulary — `stop`/`Stop`, `subagent_stop`/`SubagentStop`, `pre_compact`/`PreCompact`, `user_prompt_submit`/`UserPromptSubmit` in addition to the originals — accepting both snake_case AIR names and PascalCase Claude/Co-work names as identity mappings, mirroring the Claude adapter; (2) any hook that cannot be fully materialized (unknown artifact, missing/malformed `HOOK.json`, unmapped event, or missing `command`) now throws, so the export fails loud with a non-zero exit instead of shipping a broken plugin, and the reported `hookCount` reflects only what was actually written; (3) interpreter-style commands whose relative script path lives in `args` (e.g. `node dist/capture.js`) now anchor that path under `${CLAUDE_PLUGIN_ROOT}/scripts/<id>/` when the file exists in the hook directory — matching the Claude adapter — so the emitted command resolves regardless of cwd.
+
 ## [0.9.0] - 2026-05-31
 
 ### Fixed

--- a/docs/guides/extensions.md
+++ b/docs/guides/extensions.md
@@ -313,7 +313,7 @@ The `@pulsemcp/air-cowork` emitter translates AIR plugins into Claude Co-work pl
 - Writes `.claude-plugin/plugin.json` manifest from AIR plugin metadata
 - Copies skills into `skills/{skill-id}/SKILL.md` with reference documents
 - Translates AIR hooks into Co-work's inline `hooks/hooks.json` format (mapping AIR event names to Co-work event names like `SessionStart`, `PreToolUse`, etc.)
-- Copies hook scripts into `scripts/{hook-id}/` and rewrites paths to use `${CLAUDE_PLUGIN_ROOT}`
+- Copies hook scripts into `scripts/{hook-id}/` and rewrites hook-relative paths — whether in the `command` field or in a path-like `args` entry (e.g. `node dist/capture.js`) — to use `${CLAUDE_PLUGIN_ROOT}`
 - Translates MCP server configs into `.mcp.json` (same format as Claude Code)
 - Produces a `marketplace.json` index suitable for Co-work's GitHub marketplace sync
 
@@ -326,8 +326,14 @@ AIR events are mapped to Co-work events as follows:
 | `pre_tool_call` | `PreToolUse` |
 | `post_tool_call` | `PostToolUse` |
 | `notification` | `Notification` |
+| `stop` | `Stop` |
+| `subagent_stop` | `SubagentStop` |
+| `pre_compact` | `PreCompact` |
+| `user_prompt_submit` | `UserPromptSubmit` |
 
-AIR events without a Co-work equivalent are silently skipped.
+The emitter also accepts the PascalCase Claude/Co-work event names (`SessionStart`, `Stop`, `PreCompact`, …) directly in `HOOK.json`'s `event` field as identity mappings, so hook authors targeting the Claude runtime need not translate to snake_case.
+
+If a plugin references a hook the emitter cannot fully materialize — an unmapped `event`, a missing or malformed `HOOK.json`, or a missing `command` — `air export` **fails with a non-zero exit** rather than silently skipping the hook. This guarantees the emitter never produces a plugin directory that looks successful (a reported hook count) but is missing its `hooks/hooks.json` and script. To intentionally drop such a hook, exclude it via `air.json`'s `exclude` list.
 
 ## Extension loading order
 

--- a/docs/guides/running-sessions.md
+++ b/docs/guides/running-sessions.md
@@ -494,6 +494,8 @@ The structured JSON output to stdout describes what was built:
 }
 ```
 
+The reported `hookCount` reflects only what was actually written to disk. If a plugin references a hook the emitter cannot fully materialize (an unmapped `event`, a missing or malformed `HOOK.json`, or a missing `command`), `air export` **fails with a non-zero exit** instead of silently skipping the hook — so it never reports success for a plugin that is missing its `hooks/hooks.json` and script. To intentionally drop such a hook, exclude it via `air.json`'s `exclude` list.
+
 ## How roots, adapters, and providers interact
 
 Here's the full flow when you run a session:

--- a/package-lock.json
+++ b/package-lock.json
@@ -916,9 +916,9 @@
     },
     "packages/cli": {
       "name": "@pulsemcp/air-cli",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
-        "@pulsemcp/air-sdk": "0.9.0",
+        "@pulsemcp/air-sdk": "0.10.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -937,7 +937,7 @@
     },
     "packages/core": {
       "name": "@pulsemcp/air-core",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -954,9 +954,9 @@
     },
     "packages/extensions/adapter-claude": {
       "name": "@pulsemcp/air-adapter-claude",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.9.0"
+        "@pulsemcp/air-core": "0.10.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -969,9 +969,9 @@
     },
     "packages/extensions/adapter-codex": {
       "name": "@pulsemcp/air-adapter-codex",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.9.0",
+        "@pulsemcp/air-core": "0.10.0",
         "smol-toml": "^1.3.0"
       },
       "devDependencies": {
@@ -985,9 +985,9 @@
     },
     "packages/extensions/adapter-cursor": {
       "name": "@pulsemcp/air-adapter-cursor",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.9.0"
+        "@pulsemcp/air-core": "0.10.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1000,9 +1000,9 @@
     },
     "packages/extensions/adapter-pi": {
       "name": "@pulsemcp/air-adapter-pi",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.9.0"
+        "@pulsemcp/air-core": "0.10.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1015,9 +1015,9 @@
     },
     "packages/extensions/cowork": {
       "name": "@pulsemcp/air-cowork",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.9.0"
+        "@pulsemcp/air-core": "0.10.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1030,9 +1030,9 @@
     },
     "packages/extensions/provider-github": {
       "name": "@pulsemcp/air-provider-github",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.9.0",
+        "@pulsemcp/air-core": "0.10.0",
         "proper-lockfile": "^4.1.2"
       },
       "devDependencies": {
@@ -1047,9 +1047,9 @@
     },
     "packages/extensions/secrets-env": {
       "name": "@pulsemcp/air-secrets-env",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.9.0"
+        "@pulsemcp/air-core": "0.10.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1062,9 +1062,9 @@
     },
     "packages/extensions/secrets-file": {
       "name": "@pulsemcp/air-secrets-file",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.9.0"
+        "@pulsemcp/air-core": "0.10.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1077,9 +1077,9 @@
     },
     "packages/sdk": {
       "name": "@pulsemcp/air-sdk",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
-        "@pulsemcp/air-core": "0.9.0"
+        "@pulsemcp/air-core": "0.10.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cli",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-sdk": "0.9.0",
+    "@pulsemcp/air-sdk": "0.10.0",
     "commander": "^12.1.0",
     "chalk": "^5.3.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/adapter-claude/package.json
+++ b/packages/extensions/adapter-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-claude",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.9.0"
+    "@pulsemcp/air-core": "0.10.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/adapter-codex/package.json
+++ b/packages/extensions/adapter-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-codex",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.9.0",
+    "@pulsemcp/air-core": "0.10.0",
     "smol-toml": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/extensions/adapter-cursor/package.json
+++ b/packages/extensions/adapter-cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-cursor",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.9.0"
+    "@pulsemcp/air-core": "0.10.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/adapter-pi/package.json
+++ b/packages/extensions/adapter-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-adapter-pi",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.9.0"
+    "@pulsemcp/air-core": "0.10.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/package.json
+++ b/packages/extensions/cowork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-cowork",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.9.0"
+    "@pulsemcp/air-core": "0.10.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/cowork/src/cowork-emitter.ts
+++ b/packages/extensions/cowork/src/cowork-emitter.ts
@@ -113,19 +113,35 @@ export class CoworkEmitter implements PluginEmitter {
     plugin: PluginEntry,
     outputDir: string
   ): BuiltPlugin {
+    const manifest = this.buildManifest(shortId, plugin);
+
+    const skillActs = this.shortenChildIds(plugin.skills ?? []);
+    const hookActs = this.shortenChildIds(plugin.hooks ?? []);
+    const mcpActs = this.shortenChildIds(plugin.mcp_servers ?? []);
+
+    // Validate hooks BEFORE writing anything to disk. buildHooksConfig fails
+    // loud on any hook it can't fully materialize, so resolving it up front
+    // means a doomed plugin throws before a partial dir lands on disk —
+    // per-plugin emission is atomic and never leaves a broken-but-present dir
+    // (e.g. a plugin.json with no hooks/hooks.json) that looks successful.
+    const hooksConfig: { hooks: Record<string, unknown[]> } =
+      hookActs.length > 0
+        ? this.buildHooksConfig(artifacts, hookActs)
+        : { hooks: {} };
+    // Each materialized hook contributes exactly one matcher group.
+    const writtenHookCount = Object.values(hooksConfig.hooks).reduce(
+      (sum, groups) => sum + groups.length,
+      0
+    );
+
     mkdirSync(outputDir, { recursive: true });
 
-    const manifest = this.buildManifest(shortId, plugin);
     const manifestDir = join(outputDir, ".claude-plugin");
     mkdirSync(manifestDir, { recursive: true });
     writeFileSync(
       join(manifestDir, "plugin.json"),
       JSON.stringify(manifest, null, 2) + "\n"
     );
-
-    const skillActs = this.shortenChildIds(plugin.skills ?? []);
-    const hookActs = this.shortenChildIds(plugin.hooks ?? []);
-    const mcpActs = this.shortenChildIds(plugin.mcp_servers ?? []);
 
     // Emit skills under skills/<short>/
     for (const a of skillActs) {
@@ -140,26 +156,15 @@ export class CoworkEmitter implements PluginEmitter {
       }
     }
 
-    // Emit hooks. buildHooksConfig fails loud on any hook it can't fully
-    // materialize, so a non-zero hookActs length always yields a complete
-    // hooks.json + scripts (or the export throws) — never a broken plugin dir.
-    let writtenHookCount = 0;
-    if (hookActs.length > 0) {
-      const hooksConfig = this.buildHooksConfig(artifacts, hookActs);
-      // Each materialized hook contributes exactly one matcher group.
-      writtenHookCount = Object.values(hooksConfig.hooks).reduce(
-        (sum, groups) => sum + groups.length,
-        0
+    // Emit hooks (already validated above).
+    if (Object.keys(hooksConfig.hooks).length > 0) {
+      const hooksDir = join(outputDir, "hooks");
+      mkdirSync(hooksDir, { recursive: true });
+      writeFileSync(
+        join(hooksDir, "hooks.json"),
+        JSON.stringify(hooksConfig, null, 2) + "\n"
       );
-      if (Object.keys(hooksConfig.hooks).length > 0) {
-        const hooksDir = join(outputDir, "hooks");
-        mkdirSync(hooksDir, { recursive: true });
-        writeFileSync(
-          join(hooksDir, "hooks.json"),
-          JSON.stringify(hooksConfig, null, 2) + "\n"
-        );
-        this.copyHookScripts(artifacts, hookActs, outputDir);
-      }
+      this.copyHookScripts(artifacts, hookActs, outputDir);
     }
 
     // Emit MCP servers

--- a/packages/extensions/cowork/src/cowork-emitter.ts
+++ b/packages/extensions/cowork/src/cowork-emitter.ts
@@ -31,17 +31,45 @@ interface ChildActivation {
 }
 
 /**
- * AIR event names → Claude Co-work hook event names.
- * Co-work supports many more events than AIR currently models;
- * unmapped AIR events are silently skipped.
+ * AIR lifecycle event names → Claude Co-work hook event names.
+ *
+ * Accepts both snake_case AIR names and PascalCase Claude/Co-work lifecycle
+ * names as identity mappings, so hook authors targeting the Claude runtime can
+ * write Claude-native event names directly without translating to snake_case.
+ * This mirrors the Claude adapter's AIR_TO_CLAUDE_EVENT map — Co-work consumes
+ * the same `hooks/hooks.json` event vocabulary as Claude Code.
+ *
+ * An AIR event that is absent here cannot be materialized into a valid Co-work
+ * hook. Rather than silently dropping such a hook (which previously produced a
+ * broken/empty plugin dir while still reporting success), `buildHooksConfig`
+ * throws so the export fails loudly with a non-zero exit.
  */
 const AIR_TO_COWORK_EVENT: Record<string, string> = {
+  // snake_case AIR names
   session_start: "SessionStart",
   session_end: "SessionEnd",
   pre_tool_call: "PreToolUse",
   post_tool_call: "PostToolUse",
   notification: "Notification",
+  stop: "Stop",
+  subagent_stop: "SubagentStop",
+  pre_compact: "PreCompact",
+  user_prompt_submit: "UserPromptSubmit",
+  // PascalCase Claude/Co-work event names (identity — hook authors targeting
+  // the Claude runtime often write these directly).
+  SessionStart: "SessionStart",
+  SessionEnd: "SessionEnd",
+  PreToolUse: "PreToolUse",
+  PostToolUse: "PostToolUse",
+  Notification: "Notification",
+  Stop: "Stop",
+  SubagentStop: "SubagentStop",
+  PreCompact: "PreCompact",
+  UserPromptSubmit: "UserPromptSubmit",
 };
+
+/** Distinct Co-work event names supported by the mapping, for error messages. */
+const SUPPORTED_COWORK_EVENTS = [...new Set(Object.values(AIR_TO_COWORK_EVENT))];
 
 export class CoworkEmitter implements PluginEmitter {
   name = "cowork";
@@ -112,9 +140,17 @@ export class CoworkEmitter implements PluginEmitter {
       }
     }
 
-    // Emit hooks
+    // Emit hooks. buildHooksConfig fails loud on any hook it can't fully
+    // materialize, so a non-zero hookActs length always yields a complete
+    // hooks.json + scripts (or the export throws) — never a broken plugin dir.
+    let writtenHookCount = 0;
     if (hookActs.length > 0) {
       const hooksConfig = this.buildHooksConfig(artifacts, hookActs);
+      // Each materialized hook contributes exactly one matcher group.
+      writtenHookCount = Object.values(hooksConfig.hooks).reduce(
+        (sum, groups) => sum + groups.length,
+        0
+      );
       if (Object.keys(hooksConfig.hooks).length > 0) {
         const hooksDir = join(outputDir, "hooks");
         mkdirSync(hooksDir, { recursive: true });
@@ -141,7 +177,7 @@ export class CoworkEmitter implements PluginEmitter {
       id: shortId,
       path: outputDir,
       skillCount: skillActs.filter((a) => artifacts.skills[a.qualified]).length,
-      hookCount: hookActs.filter((a) => artifacts.hooks[a.qualified]).length,
+      hookCount: writtenHookCount,
       mcpServerCount: mcpActs.filter((a) => artifacts.mcp[a.qualified]).length,
     };
   }
@@ -167,6 +203,13 @@ export class CoworkEmitter implements PluginEmitter {
    * Build inline hooks.json in the Co-work format.
    * Each hook activation contributes one matcher group; commands are rewritten
    * to use ${CLAUDE_PLUGIN_ROOT}/scripts/<short>/ for relative paths.
+   *
+   * Fails loud: any hook that cannot be fully materialized into a valid Co-work
+   * entry (unknown artifact, missing/malformed HOOK.json, unmapped event, or
+   * missing command) throws rather than being silently skipped. A silently
+   * skipped hook would leave the plugin dir without its `hooks/hooks.json` and
+   * script while the export still reported a non-zero hook count — emitting a
+   * broken plugin that looks successful.
    */
   buildHooksConfig(
     artifacts: ResolvedArtifacts,
@@ -176,23 +219,52 @@ export class CoworkEmitter implements PluginEmitter {
 
     for (const a of hookActs) {
       const hook = artifacts.hooks[a.qualified];
-      if (!hook) continue;
+      if (!hook) {
+        throw new Error(
+          `Hook "${a.qualified}" is referenced by a plugin but is not present ` +
+            `in the resolved artifacts. Cannot export a plugin that references ` +
+            `a missing hook.`
+        );
+      }
 
       const hookJsonPath = join(hook.path, "HOOK.json");
-      if (!existsSync(hookJsonPath)) continue;
+      if (!existsSync(hookJsonPath)) {
+        throw new Error(
+          `Hook "${a.qualified}" has no HOOK.json at ${hookJsonPath}. ` +
+            `The hook directory must contain a HOOK.json to be exported.`
+        );
+      }
 
       let hookJson: Record<string, unknown>;
       try {
         hookJson = JSON.parse(readFileSync(hookJsonPath, "utf-8"));
-      } catch {
-        continue;
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Hook "${a.qualified}" has a malformed HOOK.json at ${hookJsonPath}: ${detail}`
+        );
       }
 
-      const coworkEvent = AIR_TO_COWORK_EVENT[hookJson.event as string];
-      if (!coworkEvent || !hookJson.command) continue;
+      const airEvent = hookJson.event as string | undefined;
+      const coworkEvent = airEvent ? AIR_TO_COWORK_EVENT[airEvent] : undefined;
+      if (!coworkEvent) {
+        throw new Error(
+          `Hook "${a.qualified}" declares event ${JSON.stringify(airEvent)}, ` +
+            `which has no Claude Co-work equivalent. Supported events: ` +
+            `${SUPPORTED_COWORK_EVENTS.join(", ")}. Add a mapping in the cowork ` +
+            `emitter or exclude this hook from the plugin via air.json#exclude.`
+        );
+      }
+      if (!hookJson.command) {
+        throw new Error(
+          `Hook "${a.qualified}" has no "command" field in HOOK.json. ` +
+            `A hook must define a command to be exported.`
+        );
+      }
 
       const command = this.buildHookCommand(
         a.short,
+        hook.path,
         hookJson.command as string,
         hookJson.args as string[] | undefined
       );
@@ -219,22 +291,73 @@ export class CoworkEmitter implements PluginEmitter {
     return { hooks };
   }
 
+  /**
+   * Build a shell command string from HOOK.json's command and args fields,
+   * anchoring hook-relative paths under ${CLAUDE_PLUGIN_ROOT}/scripts/<short>/.
+   *
+   * Hook authors write paths relative to their own hook directory, but Co-work
+   * copies those files into the plugin's scripts/<short>/ tree and invokes the
+   * command with an arbitrary cwd, so a bare relative path would not resolve.
+   * Mirroring the Claude adapter:
+   *   - `command` is anchored if it starts with `./` (explicit hook-relative).
+   *   - Each `args` entry is anchored if it is path-like (has a `/` separator
+   *     or an explicit `./` prefix) AND names a real file under the hook's
+   *     source directory. This is what makes interpreter-style invocations like
+   *     `node dist/capture.js` resolve. The path-like + exists requirement
+   *     keeps bare command/package names (e.g. `lint-staged`) from being
+   *     accidentally rewritten.
+   *
+   * Args that are neither anchored nor safe (contain shell metacharacters) are
+   * single-quoted.
+   */
   buildHookCommand(
     shortId: string,
+    hookDir: string,
     command: string,
     args?: string[]
   ): string {
     let cmd = command;
     if (cmd.startsWith("./")) {
-      cmd = `\${CLAUDE_PLUGIN_ROOT}/scripts/${shortId}/${cmd.slice(2)}`;
+      cmd = this.pluginScriptPath(shortId, cmd.slice(2));
     }
     if (args?.length) {
-      const escaped = args.map((a) =>
-        /[\s;&|`$"'\\]/.test(a) ? `'${a.replace(/'/g, "'\\''")}'` : a
-      );
+      const escaped = args.map((a) => {
+        const rel = this.hookRelativeArg(a, hookDir);
+        if (rel !== null) {
+          return this.pluginScriptPath(shortId, rel);
+        }
+        return /[\s;&|`$"'\\]/.test(a) ? `'${a.replace(/'/g, "'\\''")}'` : a;
+      });
       cmd += " " + escaped.join(" ");
     }
     return cmd;
+  }
+
+  /** Anchor a hook-relative path under the plugin's scripts/<short>/ tree. */
+  private pluginScriptPath(shortId: string, rel: string): string {
+    return `\${CLAUDE_PLUGIN_ROOT}/scripts/${shortId}/${rel}`;
+  }
+
+  /**
+   * If `arg` is a hook-relative path pointing at a real file under the hook's
+   * source directory, return its path relative to that directory (for anchoring
+   * under scripts/<short>/). Otherwise return null. Flags, absolute/home paths,
+   * and bare command/package names are never rewritten.
+   */
+  private hookRelativeArg(arg: string, hookDir: string): string | null {
+    if (!arg) return null;
+    if (arg.startsWith("-") || arg.startsWith("/") || arg.startsWith("~")) {
+      return null;
+    }
+    const hasExplicitPrefix = arg.startsWith("./");
+    const candidate = hasExplicitPrefix ? arg.slice(2) : arg;
+    if (!hasExplicitPrefix && !candidate.includes("/")) {
+      return null;
+    }
+    if (!existsSync(join(hookDir, candidate))) {
+      return null;
+    }
+    return candidate;
   }
 
   /**

--- a/packages/extensions/cowork/tests/cowork-emitter.test.ts
+++ b/packages/extensions/cowork/tests/cowork-emitter.test.ts
@@ -838,8 +838,14 @@ describe("CoworkEmitter", () => {
         )
       ).toThrow(/no Claude Co-work equivalent/);
 
-      // No partial/broken hook output should remain.
+      // Emission is atomic: a doomed plugin is validated before any disk write,
+      // so nothing is left behind — not the hooks.json, and not the manifest
+      // (which would otherwise be a broken-but-present plugin dir).
       expect(existsSync(join(pluginDir, "hooks", "hooks.json"))).toBe(false);
+      expect(existsSync(join(pluginDir, ".claude-plugin", "plugin.json"))).toBe(
+        false
+      );
+      expect(existsSync(pluginDir)).toBe(false);
     });
 
     it("writes .mcp.json with translated servers", () => {

--- a/packages/extensions/cowork/tests/cowork-emitter.test.ts
+++ b/packages/extensions/cowork/tests/cowork-emitter.test.ts
@@ -256,23 +256,55 @@ describe("CoworkEmitter", () => {
 
   describe("buildHookCommand", () => {
     it("rewrites relative paths to use CLAUDE_PLUGIN_ROOT", () => {
-      const cmd = emitter.buildHookCommand("my-hook", "./notify.sh");
+      const cmd = emitter.buildHookCommand("my-hook", "/nonexistent", "./notify.sh");
       expect(cmd).toBe("${CLAUDE_PLUGIN_ROOT}/scripts/my-hook/notify.sh");
     });
 
     it("leaves absolute/non-relative commands unchanged", () => {
-      const cmd = emitter.buildHookCommand("my-hook", "npx", [
+      const cmd = emitter.buildHookCommand("my-hook", "/nonexistent", "npx", [
         "lint-staged",
       ]);
       expect(cmd).toBe("npx lint-staged");
     });
 
     it("escapes shell metacharacters in args", () => {
-      const cmd = emitter.buildHookCommand("my-hook", "echo", [
+      const cmd = emitter.buildHookCommand("my-hook", "/nonexistent", "echo", [
         "hello world",
         "safe",
       ]);
       expect(cmd).toBe("echo 'hello world' safe");
+    });
+
+    it("anchors a path-like arg that resolves to a real file under the hook dir", () => {
+      // Mirrors agent-transcript-capture: command "node", args ["dist/capture.js"].
+      const hookDir = makeTempDir();
+      mkdirSync(join(hookDir, "dist"), { recursive: true });
+      writeFileSync(join(hookDir, "dist", "capture.js"), "console.log('x');");
+
+      const cmd = emitter.buildHookCommand("capture", hookDir, "node", [
+        "dist/capture.js",
+      ]);
+      expect(cmd).toBe(
+        "node ${CLAUDE_PLUGIN_ROOT}/scripts/capture/dist/capture.js"
+      );
+    });
+
+    it("does not anchor a path-like arg that has no matching file under the hook dir", () => {
+      const hookDir = makeTempDir();
+      const cmd = emitter.buildHookCommand("capture", hookDir, "node", [
+        "dist/missing.js",
+      ]);
+      // No such file → left as a bare arg (not rewritten).
+      expect(cmd).toBe("node dist/missing.js");
+    });
+
+    it("never anchors bare command/package names even if a same-named file exists", () => {
+      const hookDir = makeTempDir();
+      writeFileSync(join(hookDir, "lint-staged"), "");
+      const cmd = emitter.buildHookCommand("my-hook", hookDir, "npx", [
+        "lint-staged",
+      ]);
+      expect(cmd).toBe("npx lint-staged");
     });
   });
 
@@ -333,7 +365,85 @@ describe("CoworkEmitter", () => {
       expect(result.hooks).toHaveProperty("SessionEnd");
     });
 
-    it("skips hooks with unmapped AIR events", () => {
+    it("maps the Stop event (snake_case) to a Co-work Stop hook", () => {
+      const sourceDir = makeTempDir();
+      const hookDir = createHookOnDisk(sourceDir, "capture", {
+        event: "stop",
+        command: "./capture.js",
+      });
+
+      const artifacts = emptyArtifacts();
+      artifacts.hooks = {
+        "@local/capture": { description: "Transcript capture", path: hookDir },
+      };
+
+      const result = emitter.buildHooksConfig(artifacts, acts("capture"));
+
+      expect(result.hooks).toHaveProperty("Stop");
+      expect(result.hooks.Stop).toHaveLength(1);
+      const group = result.hooks.Stop[0] as any;
+      expect(group.hooks[0].command).toBe(
+        "${CLAUDE_PLUGIN_ROOT}/scripts/capture/capture.js"
+      );
+    });
+
+    it("accepts PascalCase Claude event names as identity mappings", () => {
+      const sourceDir = makeTempDir();
+      const hookDir = createHookOnDisk(sourceDir, "capture", {
+        // Hook authors targeting the Claude runtime sometimes write the
+        // PascalCase Claude event name directly instead of the snake_case form.
+        event: "Stop",
+        command: "./capture.js",
+      });
+
+      const artifacts = emptyArtifacts();
+      artifacts.hooks = {
+        "@local/capture": { description: "Transcript capture", path: hookDir },
+      };
+
+      const result = emitter.buildHooksConfig(artifacts, acts("capture"));
+
+      expect(result.hooks).toHaveProperty("Stop");
+      expect(result.hooks.Stop).toHaveLength(1);
+    });
+
+    it("maps every AIR lifecycle event to its Co-work equivalent", () => {
+      const sourceDir = makeTempDir();
+      const cases: Array<[string, string, string]> = [
+        ["start", "session_start", "SessionStart"],
+        ["end", "session_end", "SessionEnd"],
+        ["pre-tool", "pre_tool_call", "PreToolUse"],
+        ["post-tool", "post_tool_call", "PostToolUse"],
+        ["notify", "notification", "Notification"],
+        ["stop", "stop", "Stop"],
+        ["subagent", "subagent_stop", "SubagentStop"],
+        ["compact", "pre_compact", "PreCompact"],
+        ["prompt", "user_prompt_submit", "UserPromptSubmit"],
+      ];
+
+      const artifacts = emptyArtifacts();
+      const ids: string[] = [];
+      for (const [id, airEvent] of cases) {
+        const hookDir = createHookOnDisk(sourceDir, id, {
+          event: airEvent,
+          command: "echo",
+          args: [id],
+        });
+        artifacts.hooks[`@local/${id}`] = {
+          description: `${id} hook`,
+          path: hookDir,
+        };
+        ids.push(id);
+      }
+
+      const result = emitter.buildHooksConfig(artifacts, acts(...ids));
+
+      for (const [, , coworkEvent] of cases) {
+        expect(result.hooks).toHaveProperty(coworkEvent);
+      }
+    });
+
+    it("throws (fail loud) on hooks with unmapped AIR events", () => {
       const sourceDir = makeTempDir();
       const hookDir = createHookOnDisk(sourceDir, "pre-commit", {
         event: "pre_commit",
@@ -346,13 +456,12 @@ describe("CoworkEmitter", () => {
         "@local/pre-commit": { description: "Pre-commit", path: hookDir },
       };
 
-      const pluginDir = makeTempDir();
-      const result = emitter.buildHooksConfig(artifacts, acts("pre-commit"));
-
-      expect(Object.keys(result.hooks)).toHaveLength(0);
+      expect(() =>
+        emitter.buildHooksConfig(artifacts, acts("pre-commit"))
+      ).toThrow(/no Claude Co-work equivalent/);
     });
 
-    it("skips hooks with malformed HOOK.json", () => {
+    it("throws (fail loud) on malformed HOOK.json", () => {
       const sourceDir = makeTempDir();
       const hookDir = join(sourceDir, "broken");
       mkdirSync(hookDir, { recursive: true });
@@ -363,10 +472,40 @@ describe("CoworkEmitter", () => {
         "@local/broken": { description: "Broken hook", path: hookDir },
       };
 
-      const pluginDir = makeTempDir();
-      const result = emitter.buildHooksConfig(artifacts, acts("broken"));
+      expect(() =>
+        emitter.buildHooksConfig(artifacts, acts("broken"))
+      ).toThrow(/malformed HOOK\.json/);
+    });
 
-      expect(Object.keys(result.hooks)).toHaveLength(0);
+    it("throws (fail loud) when the hook directory has no HOOK.json", () => {
+      const sourceDir = makeTempDir();
+      const hookDir = join(sourceDir, "no-json");
+      mkdirSync(hookDir, { recursive: true });
+
+      const artifacts = emptyArtifacts();
+      artifacts.hooks = {
+        "@local/no-json": { description: "No HOOK.json", path: hookDir },
+      };
+
+      expect(() =>
+        emitter.buildHooksConfig(artifacts, acts("no-json"))
+      ).toThrow(/no HOOK\.json/);
+    });
+
+    it("throws (fail loud) when a hook is missing its command", () => {
+      const sourceDir = makeTempDir();
+      const hookDir = createHookOnDisk(sourceDir, "no-cmd", {
+        event: "session_start",
+      });
+
+      const artifacts = emptyArtifacts();
+      artifacts.hooks = {
+        "@local/no-cmd": { description: "No command", path: hookDir },
+      };
+
+      expect(() =>
+        emitter.buildHooksConfig(artifacts, acts("no-cmd"))
+      ).toThrow(/no "command" field/);
     });
   });
 
@@ -590,6 +729,117 @@ describe("CoworkEmitter", () => {
       const scriptsDir = join(pluginDir, "scripts", "my-hook");
       expect(existsSync(join(scriptsDir, "run.sh"))).toBe(true);
       expect(existsSync(join(scriptsDir, "HOOK.json"))).toBe(false);
+    });
+
+    it("fully materializes a Stop-event hook (hooks.json + script + count)", () => {
+      // Regression: a github://-resolved hook declaring event "Stop" — the exact
+      // shape of agent-transcript-capture — must produce a self-contained plugin
+      // dir, not silently vanish. Mirrors the real HOOK.json (event + dist script).
+      const sourceDir = makeTempDir();
+      const hookDir = join(sourceDir, "agent-transcript-capture");
+      mkdirSync(join(hookDir, "dist"), { recursive: true });
+      writeFileSync(
+        join(hookDir, "HOOK.json"),
+        JSON.stringify({
+          event: "Stop",
+          command: "node",
+          args: ["dist/capture.js"],
+          timeout_seconds: 120,
+        })
+      );
+      writeFileSync(
+        join(hookDir, "dist", "capture.js"),
+        "#!/usr/bin/env node\nconsole.log('capture');"
+      );
+
+      const outputDir = makeTempDir();
+      const pluginDir = join(outputDir, "agent-transcript-capture");
+
+      const artifacts = emptyArtifacts();
+      artifacts.hooks = {
+        "@local/agent-transcript-capture": {
+          description: "Transcript capture",
+          path: hookDir,
+        },
+      };
+      artifacts.plugins = {
+        "@local/agent-transcript-capture": {
+          description: "Captures agent transcripts on stop",
+          hooks: ["@local/agent-transcript-capture"],
+        },
+      };
+
+      const result = emitter.buildPlugin(
+        artifacts,
+        "@local/agent-transcript-capture",
+        "agent-transcript-capture",
+        artifacts.plugins["@local/agent-transcript-capture"],
+        pluginDir
+      );
+
+      // hooks/hooks.json materialized with a Stop entry
+      const hooksJsonPath = join(pluginDir, "hooks", "hooks.json");
+      expect(existsSync(hooksJsonPath)).toBe(true);
+      const hooksConfig = JSON.parse(readFileSync(hooksJsonPath, "utf-8"));
+      expect(hooksConfig.hooks.Stop[0].hooks[0].command).toBe(
+        "node ${CLAUDE_PLUGIN_ROOT}/scripts/agent-transcript-capture/dist/capture.js"
+      );
+      expect(hooksConfig.hooks.Stop[0].hooks[0].timeout).toBe(120);
+
+      // The dist script was copied into scripts/
+      expect(
+        existsSync(
+          join(
+            pluginDir,
+            "scripts",
+            "agent-transcript-capture",
+            "dist",
+            "capture.js"
+          )
+        )
+      ).toBe(true);
+
+      // Reported count reflects what was actually written
+      expect(result.hookCount).toBe(1);
+    });
+
+    it("throws (fail loud) on an unmapped event instead of emitting a broken plugin with a false count", () => {
+      // Before the fix the emitter silently skipped the unmapped hook, wrote no
+      // hooks.json/script, yet still reported hookCount: 1 and exited 0. Now it
+      // must throw — and must not leave a half-written plugin dir behind.
+      const sourceDir = makeTempDir();
+      const hookDir = createHookOnDisk(sourceDir, "pre-commit", {
+        event: "pre_commit",
+        command: "npx",
+        args: ["lint-staged"],
+      });
+
+      const outputDir = makeTempDir();
+      const pluginDir = join(outputDir, "linter");
+
+      const artifacts = emptyArtifacts();
+      artifacts.hooks = {
+        "@local/pre-commit": { description: "Pre-commit", path: hookDir },
+      };
+      artifacts.plugins = {
+        "@local/linter": {
+          description: "Linter plugin",
+          hooks: ["@local/pre-commit"],
+        },
+      };
+
+      expect(() =>
+        emitter.buildPlugin(
+          artifacts,
+          "@local/linter",
+          "linter",
+          artifacts.plugins["@local/linter"],
+          pluginDir
+        )
+      ).toThrow(/no Claude Co-work equivalent/);
+
+      // No partial/broken hook output should remain.
+      expect(existsSync(join(pluginDir, "hooks", "hooks.json"))).toBe(false);
     });
 
     it("writes .mcp.json with translated servers", () => {

--- a/packages/extensions/provider-github/package.json
+++ b/packages/extensions/provider-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-provider-github",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.9.0",
+    "@pulsemcp/air-core": "0.10.0",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/extensions/secrets-env/package.json
+++ b/packages/extensions/secrets-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-env",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.9.0"
+    "@pulsemcp/air-core": "0.10.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/extensions/secrets-file/package.json
+++ b/packages/extensions/secrets-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-secrets-file",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.9.0"
+    "@pulsemcp/air-core": "0.10.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/air-sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@pulsemcp/air-core": "0.9.0"
+    "@pulsemcp/air-core": "0.10.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary

`air export cowork` **silently dropped** any AIR hook whose event was not in the cowork emitter's 5-entry `AIR_TO_COWORK_EVENT` map (`session_start`, `session_end`, `pre_tool_call`, `post_tool_call`, `notification`). Any other event — including the common `Stop` — was skipped: the export wrote `plugin.json`, never wrote `hooks/hooks.json`, never copied the hook script, yet still reported `hookCount: 1` and exited `0`. The result was a broken/empty plugin directory that looked successful.

This blocked exporting the `agent-transcript-capture` plugin, whose hook (resolved remotely via `github://pulsemcp/ai-artifacts@main/hooks/agent-transcript-capture`) declares `"event": "Stop"`.

### Diagnosis confirmation

I confirmed the diagnosis is in the **`@pulsemcp/air-cowork` emitter**, not core/provider resolution. `github://` resolution works fine — the cached `HOOK.json` + `dist/capture.js` are present and other artifacts copy correctly. The defect was entirely the unmapped-event silent skip (`cowork-emitter.ts` `continue` on unmapped event) plus a `hookCount` derived from *resolved* hooks rather than *written* hooks.

## What changed (`packages/extensions/cowork/src/cowork-emitter.ts`)

1. **Full event vocabulary.** `AIR_TO_COWORK_EVENT` now covers AIR's complete lifecycle vocabulary — adds `stop`, `subagent_stop`, `pre_compact`, `user_prompt_submit` alongside the originals — and accepts both snake_case AIR names and PascalCase Claude/Co-work names as identity mappings, mirroring the Claude adapter's `AIR_TO_CLAUDE_EVENT`. These 9 events are exactly the Claude Code / Co-work plugin `hooks/hooks.json` event set ([Claude Code plugins reference](https://code.claude.com/docs/en/plugins-reference)) — no invented mappings.

2. **Fail loud.** Any hook that cannot be fully materialized — unknown artifact, missing `HOOK.json`, malformed `HOOK.json`, unmapped `event`, or missing `command` — now **throws**, so `air export` exits non-zero instead of shipping a broken plugin. The reported `hookCount` is now computed from the matcher groups actually written to disk, so it can never overstate what was emitted.

3. **Anchor relative paths in `args`.** The real `agent-transcript-capture` `HOOK.json` uses `"command": "node", "args": ["dist/capture.js"]`. Previously only `./`-prefixed *commands* were rewritten, so the emitted command was the broken `node dist/capture.js` (unresolvable at runtime). The emitter now also anchors a path-like `args` entry that names a real file under the hook dir to `${CLAUDE_PLUGIN_ROOT}/scripts/<id>/...`, matching the Claude adapter's `rewriteHookArgPath`. Bare command/package names (e.g. `lint-staged`) are never rewritten.

4. **Atomic per-plugin emission.** `buildPlugin` now validates hooks (the only step that can throw) **before** writing anything to disk, so a doomed plugin aborts cleanly instead of leaving a partial dir (a `plugin.json` with no `hooks/hooks.json`). This addresses fresh-eyes review feedback and is what the downstream auto-sync CI relies on — a failed export leaves no broken-but-present plugin dir.

## Why this matters / downstream

- Unblocks the **claude-plugins backfill** (AO session https://ao.pulsemcp.com/sessions/7099, PR https://github.com/pulsemcp/claude-plugins/pull/2), which ships only 8/9 plugins because it couldn't export `agent-transcript-capture`.
- A planned **auto-sync CI** (AIR `plugins.json` → claude-plugins) relies on this export **failing loud** rather than silently shipping a broken plugin.

## Release

Lockstep version bump **0.9.0 → 0.10.0** across all packages (via the `air-version-bump` skill), CHANGELOG updated. Publishing is automatic via `publish.yml` on merge to `main` — this PR only sets up the bump. **Expected published version: `@pulsemcp/air-cowork@0.10.0`.** Not published from this branch.

## Verification

- [x] **Full test suite green locally** — `npx vitest run`: **1040 passed, 2 skipped** across 55 files (including the cowork suite, now 40 tests).
- [x] **Regression tests added** covering both required cases:
  - a `Stop`-event hook (snake_case `stop` and PascalCase `Stop`) materializes correctly — `hooks/hooks.json` + script + accurate `hookCount`;
  - an unmapped event causes a **hard throw** (not a silent skip with a false `hookCount`), and leaves **no partial plugin dir** behind (asserts the whole dir — `plugin.json`, `hooks/hooks.json`, and the dir itself — is absent). Plus tests for missing/malformed `HOOK.json`, missing `command`, the full 9-event mapping, and `args` path anchoring (including the negative cases).
- [x] **Build green** — `npm run build` across all packages after the bump.
- [x] **Version bump verified** — every `packages/*` `package.json` and internal `@pulsemcp/air-*` dep at `0.10.0`; zero `0.9.0` hits outside `node_modules`/`package-lock.json`; CHANGELOG entry dated 2026-06-02; lockfile regenerated.
- [x] **Docs updated** (`air-update-docs`) — `docs/guides/extensions.md` event table now lists all 9 events + documents fail-loud; `docs/guides/running-sessions.md` notes `hookCount` truthfulness + fail-loud.
- [x] **Self-review** of the full diff completed.
- [x] **Fresh-eyes subagent review** completed; feedback addressed — the reviewer's "partial dir on failure" NIT is fixed by the atomic-emission commit, and the regression test now asserts full dir absence.

### Proof — real `github://` export of `agent-transcript-capture`

Ran the actual CLI (`air export cowork`) against an `air.json` that resolves the hook via `github://pulsemcp/ai-artifacts@main/hooks/agent-transcript-capture` — the exact downstream scenario.

**Before any conceptual change**, this hook produced a `plugin.json`-only dir while reporting `hookCount: 1`. **After the fix**, the export is self-contained:

Structured output (exit 0):
```json
{ "plugins": [ { "id": "agent-transcript-capture", "skillCount": 0, "hookCount": 1, "mcpServerCount": 0 } ] }
```

Materialized dir (self-contained — `plugin.json` + `hooks/hooks.json` + script under `scripts/`):
```
agent-transcript-capture/.claude-plugin/plugin.json
agent-transcript-capture/hooks/hooks.json
agent-transcript-capture/scripts/agent-transcript-capture/dist/capture.js
agent-transcript-capture/scripts/agent-transcript-capture/dist/...   (full dist/ tree)
```

`hooks/hooks.json` — `Stop` event, command anchored to `${CLAUDE_PLUGIN_ROOT}`:
```json
{
  "hooks": {
    "Stop": [
      {
        "matcher": "",
        "hooks": [
          {
            "type": "command",
            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/agent-transcript-capture/dist/capture.js",
            "timeout": 120
          }
        ]
      }
    ]
  }
}
```

### Proof — fail-loud + atomic abort on an unmapped event

Ran `air export cowork` against a local hook declaring `"event": "pre_commit"`:
```
Error: Hook "@local/bad-event-hook" declares event "pre_commit", which has no Claude Co-work equivalent. Supported events: SessionStart, SessionEnd, PreToolUse, PostToolUse, Notification, Stop, SubagentStop, PreCompact, UserPromptSubmit. Add a mapping in the cowork emitter or exclude this hook from the plugin via air.json#exclude.
EXIT CODE: 1
```
The export aborts before writing anything — the output dir is empty (`bad-event-plugin dir exists: NO`), so no broken-but-successful-looking dir is left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
