### PR TITLE
docs(readme): document default_runtime in roots example

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Roots are self-contained agent workspaces — a git repo (or subdirectory) with 
 }
 ```
 
-`default_runtime` is optional and selects the agent runtime for sessions (and subagents) spawned under the root. When omitted, it resolves to `claude_code`. It is an open string field — common values are `claude_code`, `codex`, `pi`, `opencode`, `amp`, `gemini`, and `github_copilot`, but any runtime identifier a downstream consumer recognizes is accepted, so new agents don't require a schema change. See the [roots guide](docs/guides/roots.md) for the full field reference.
+`default_runtime` is optional and selects the agent runtime for sessions and subagents spawned under the root (default: `claude_code`). It is an open string field — common values are `claude_code`, `codex`, `pi`, `opencode`, `amp`, `gemini`, and `github_copilot`, but any identifier a downstream consumer recognizes is accepted, so new agents don't require a schema change. See the [roots guide](docs/guides/roots.md) for the full field reference.
 
 ### Hooks
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Roots are self-contained agent workspaces — a git repo (or subdirectory) with 
     "url": "https://github.com/acme/web-app.git",
     "default_mcp_servers": ["github", "postgres-prod"],
     "default_skills": ["deploy-staging", "pr-review"],
-    "default_runtime": "codex",
+    "default_runtime": "claude_code",
     "user_invocable": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ A plugin entry in `plugins.json` declares which AIR artifacts it bundles by refe
 
 ### Roots
 
-Roots are self-contained agent workspaces — a git repo (or subdirectory) with a file hierarchy (including AGENTS.md files) an agent needs for a specific project. Each root declares its default MCP servers, skills, plugins, and hooks:
+Roots are self-contained agent workspaces — a git repo (or subdirectory) with a file hierarchy (including AGENTS.md files) an agent needs for a specific project. Each root declares its default MCP servers, skills, plugins, hooks, and the agent runtime it runs on:
 
 ```json
 {
@@ -309,10 +309,13 @@ Roots are self-contained agent workspaces — a git repo (or subdirectory) with 
     "url": "https://github.com/acme/web-app.git",
     "default_mcp_servers": ["github", "postgres-prod"],
     "default_skills": ["deploy-staging", "pr-review"],
+    "default_runtime": "codex",
     "user_invocable": true
   }
 }
 ```
+
+`default_runtime` is optional and selects the agent runtime for sessions (and subagents) spawned under the root. When omitted, it resolves to `claude_code`. It is an open string field — common values are `claude_code`, `codex`, `pi`, `opencode`, `amp`, `gemini`, and `github_copilot`, but any runtime identifier a downstream consumer recognizes is accepted, so new agents don't require a schema change. See the [roots guide](docs/guides/roots.md) for the full field reference.
 
 ### Hooks
 


### PR DESCRIPTION
## Summary

The optional `default_runtime` field on a root (added to the schema in #146) selects which agent runtime a root's sessions and subagents run on. It was already covered by the JSON schema (`schemas/roots.schema.json`), the example index (`examples/roots/roots.json`), validator tests, and both roots guides (`docs/roots.md`, `docs/guides/roots.md`) — but the **main README's example `roots.json` omitted it**, so newcomers never saw the field in context.

This PR closes that gap:

- Adds `"default_runtime": "claude_code"` to the README's example `roots.json` so it appears in context.
- Updates the intro sentence to mention the agent runtime alongside MCP servers, skills, plugins, and hooks.
- Adds a short explanatory note (optional; defaults to `claude_code`; open string field; common values; link to the roots guide) matching the README's existing style of a brief paragraph after each artifact example.

Docs-only change — no published package contents touched, so no version bump is required (per the `air-version-bump` skill's SKIP rules: README/docs don't ship to npm).

## Field semantics (verified against the implementation)

I confirmed the behavior against the source rather than the task's provided context, and found two differences worth flagging:

- **Open string field, not a `claude_code | codex` enum.** `schemas/roots.schema.json` defines `default_runtime` as `type: "string"` with `examples` only (`claude_code`, `codex`, `pi`, `opencode`, `amp`, `gemini`, `github_copilot`). Validator tests (`packages/core/tests/validator.test.ts`) explicitly assert that an out-of-list value like `"some-future-agent"` validates, and that a non-string is rejected. So any runtime identifier a downstream consumer recognizes is accepted; new agents don't require a schema change.
- **No enforced cross-runtime subagent constraint in this repo.** There's no runtime-resolution / subagent-inheritance code here. The schema's own wording — "Agent runtime to use for sessions and subagents spawned under this root" — is the authority: subagents spawned under a root run on that root's runtime. The "Claude-parent-can't-spawn-Codex-subagent" rule from the task context is a downstream-consumer concern, not something AIR enforces, so I did **not** document it as an AIR constraint.

Optionality and the `claude_code` default match the provided context.

## Related (not fixed here)

While verifying, I confirmed the `RootEntry` TypeScript interface in `packages/core/src/types.ts` is missing `default_runtime` (schema/type drift). This is already tracked by #147 and is a code change out of scope for this docs PR, so it's intentionally left untouched.

## Verification

- [x] Read the implementation as the source of truth: schema (`schemas/roots.schema.json`), validator tests (`packages/core/tests/validator.test.ts`), example index (`examples/roots/roots.json`), and confirmed no subagent-runtime enforcement exists in `packages/`.
- [x] Drove the change via the `air-update-docs` skill; confirmed the two roots guides already document the field accurately, so only the README needed updating.
- [x] Docs are internally consistent — the README note, both guide field tables, and the schema description all describe `default_runtime` as optional, defaulting to `claude_code`, an open string with the same common-values list.
- [x] Self-reviewed the diff; confirmed the example JSON is valid and the prose matches the schema.
- [x] Subagent fresh-eyes review performed; feedback addressed.
- [x] CI confirmed green via the `wait-for-ci` skill.

### Proof: rendered README diff

```diff
-Each root declares its default MCP servers, skills, plugins, and hooks:
+Each root declares its default MCP servers, skills, plugins, hooks, and the agent runtime it runs on:
   ...
     "default_skills": ["deploy-staging", "pr-review"],
+    "default_runtime": "claude_code",
     "user_invocable": true
   ...
+`default_runtime` is optional and selects the agent runtime for sessions (and
+subagents) spawned under the root. When omitted, it resolves to `claude_code`.
+It is an open string field — common values are `claude_code`, `codex`, `pi`,
+`opencode`, `amp`, `gemini`, and `github_copilot` ...
```

### Proof: example JSON snippet validates as a roots index

The README snippet (sans the illustrative `name` key) was saved to a file and validated with the AIR CLI against the roots schema:

```
$ npx tsx packages/cli/src/index.ts validate /tmp/readme-root.json --schema roots
✓ /tmp/readme-root.json is valid (schema: roots)
```

This is a docs change with no runtime logic to e2e-test beyond confirming the example snippet is a valid roots index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

